### PR TITLE
Add thread-locked voice conversations

### DIFF
--- a/app/Package.resolved
+++ b/app/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "de86578c859ed5e4cb23f2c28395243714d42a32076b7d47fa1347ff87dcd486",
   "pins" : [
     {
       "identity" : "hudsonkit-xcframework",
@@ -8,7 +9,15 @@
         "revision" : "913a62e8b6be2f457ba14a12685824b5b9d2aa3e",
         "version" : "0.3.3"
       }
+    },
+    {
+      "identity" : "vox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/arach/vox.git",
+      "state" : {
+        "revision" : "19be9f1d30b2fd7a79c5f88feffcb44091854761"
+      }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -11,7 +11,13 @@ let package = Package(
         .macOS(.v14)
     ],
     dependencies: [
-        .package(url: "https://github.com/arach/hudsonkit-xcframework.git", exact: "0.3.3")
+        .package(url: "https://github.com/arach/hudsonkit-xcframework.git", exact: "0.3.3"),
+        // 0.4.5's root SwiftPM manifest points at a resource absent from that
+        // tag. Pin the first known-good repository package revision instead.
+        .package(
+            url: "https://github.com/arach/vox.git",
+            revision: "19be9f1d30b2fd7a79c5f88feffcb44091854761"
+        )
     ],
     targets: [
         .executableTarget(
@@ -19,8 +25,13 @@ let package = Package(
             dependencies: [
                 .product(name: "HudsonUI", package: "hudsonkit-xcframework"),
                 .product(name: "HudsonShell", package: "hudsonkit-xcframework"),
+                .product(name: "VoxCore", package: "vox"),
+                .product(name: "VoxEngine", package: "vox"),
             ],
-            path: "Sources/SpeakEasy"
+            path: "Sources/SpeakEasy",
+            resources: [
+                .copy("Resources/codex-desktop-bridge.cjs")
+            ]
         ),
         .testTarget(
             name: "SpeakEasyTests",

--- a/app/Resources/Info.plist
+++ b/app/Resources/Info.plist
@@ -30,6 +30,8 @@
     <true/>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>SpeakEasy uses the microphone only while you explicitly record an utterance for a locked Codex task.</string>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
     <key>LSApplicationCategoryType</key>

--- a/app/Sources/SpeakEasy/CodexThreadRouter.swift
+++ b/app/Sources/SpeakEasy/CodexThreadRouter.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+struct CodexTaskSummary: Identifiable, Codable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let preview: String
+    let cwd: String
+    let updatedAt: Date
+}
+
+enum CodexThreadRouterError: LocalizedError {
+    case runtimeUnavailable
+    case bridgeUnavailable
+    case malformedResponse
+    case requestFailed(String)
+    case turnAlreadyActive
+
+    var errorDescription: String? {
+        switch self {
+        case .runtimeUnavailable:
+            return "SpeakEasy needs Bun or Node.js to connect to Codex Desktop."
+        case .bridgeUnavailable:
+            return "The SpeakEasy Codex Desktop bridge is missing. Reinstall the app."
+        case .malformedResponse:
+            return "Codex Desktop returned an unreadable bridge response."
+        case .requestFailed(let message):
+            return message
+        case .turnAlreadyActive:
+            return "SpeakEasy is already waiting for this task."
+        }
+    }
+}
+
+/// A fail-closed conduit into the task owned by Codex Desktop.
+///
+/// This process never launches `codex app-server`. The bundled runtime joins
+/// Desktop's user-private follower IPC, asks the window that owns the exact
+/// task to start the turn, and observes that task's own rollout for completion.
+actor CodexThreadRouter {
+    private struct BridgeEnvelope: Decodable {
+        let ok: Bool
+        let tasks: [TaskPayload]?
+        let task: TaskPayload?
+        let response: String?
+        let error: String?
+        let code: String?
+    }
+
+    private struct TaskPayload: Decodable {
+        let id: String
+        let title: String
+        let preview: String?
+        let cwd: String
+        let updatedAt: Double?
+    }
+
+    private var activeProcess: Process?
+
+    func listRecentTasks(limit: Int = 16) async throws -> [CodexTaskSummary] {
+        let envelope = try await invoke(arguments: ["list", String(max(1, min(limit, 100)))])
+        guard envelope.ok, let tasks = envelope.tasks else {
+            throw bridgeError(envelope)
+        }
+        return tasks.map(Self.summary)
+    }
+
+    func validateTask(_ threadID: String) async throws -> CodexTaskSummary {
+        let envelope = try await invoke(arguments: ["validate", threadID])
+        guard envelope.ok, let task = envelope.task, task.id == threadID else {
+            throw bridgeError(envelope)
+        }
+        return Self.summary(task)
+    }
+
+    func submit(_ text: String, to threadID: String) async throws -> String {
+        guard activeProcess == nil else { throw CodexThreadRouterError.turnAlreadyActive }
+        let envelope = try await invoke(
+            arguments: ["submit", threadID],
+            standardInput: text.data(using: .utf8)
+        )
+        guard envelope.ok,
+              let response = envelope.response?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !response.isEmpty
+        else { throw bridgeError(envelope) }
+        return response
+    }
+
+    func shutdown() {
+        activeProcess?.terminate()
+        activeProcess = nil
+    }
+
+    private func invoke(arguments: [String], standardInput: Data? = nil) async throws -> BridgeEnvelope {
+        guard let runtime = Self.resolveJavaScriptRuntime() else {
+            throw CodexThreadRouterError.runtimeUnavailable
+        }
+        guard let bridge = Self.resolveBridgeScript() else {
+            throw CodexThreadRouterError.bridgeUnavailable
+        }
+
+        let process = Process()
+        let output = Pipe()
+        let error = Pipe()
+        let input = Pipe()
+        process.executableURL = runtime
+        process.arguments = [bridge.path] + arguments
+        process.standardOutput = output
+        process.standardError = error
+        process.standardInput = input
+        activeProcess = process
+
+        do {
+            try process.run()
+            if let standardInput {
+                try input.fileHandleForWriting.write(contentsOf: standardInput)
+            }
+            try input.fileHandleForWriting.close()
+        } catch {
+            activeProcess = nil
+            throw CodexThreadRouterError.requestFailed(error.localizedDescription)
+        }
+
+        await withCheckedContinuation { continuation in
+            process.terminationHandler = { _ in continuation.resume() }
+        }
+        activeProcess = nil
+
+        let outputData = try output.fileHandleForReading.readToEnd() ?? Data()
+        let errorData = try error.fileHandleForReading.readToEnd() ?? Data()
+        guard let envelope = try? JSONDecoder().decode(BridgeEnvelope.self, from: outputData) else {
+            let detail = String(data: errorData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw CodexThreadRouterError.requestFailed(
+                detail?.isEmpty == false ? detail! : "Codex Desktop bridge exited unexpectedly."
+            )
+        }
+        return envelope
+    }
+
+    private func bridgeError(_ envelope: BridgeEnvelope) -> Error {
+        CodexThreadRouterError.requestFailed(
+            envelope.error ?? "Codex Desktop bridge failed (\(envelope.code ?? "unknown"))."
+        )
+    }
+
+    private static func summary(_ payload: TaskPayload) -> CodexTaskSummary {
+        CodexTaskSummary(
+            id: payload.id,
+            title: payload.title.trimmingCharacters(in: .whitespacesAndNewlines),
+            preview: payload.preview?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+            cwd: payload.cwd,
+            updatedAt: Date(timeIntervalSince1970: payload.updatedAt ?? 0)
+        )
+    }
+
+    private static func resolveBridgeScript() -> URL? {
+        let environment = ProcessInfo.processInfo.environment
+        if let override = environment["SPEAKEASY_CODEX_BRIDGE_PATH"],
+           FileManager.default.isReadableFile(atPath: override) {
+            return URL(fileURLWithPath: override)
+        }
+        return Bundle.module.url(forResource: "codex-desktop-bridge", withExtension: "cjs")
+    }
+
+    private static func resolveJavaScriptRuntime() -> URL? {
+        let environment = ProcessInfo.processInfo.environment
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidates = [
+            environment["SPEAKEASY_JS_RUNTIME"],
+            "\(home)/.bun/bin/bun",
+            "/opt/homebrew/bin/bun",
+            "/usr/local/bin/bun",
+            "/opt/homebrew/bin/node",
+            "/usr/local/bin/node",
+            "/usr/bin/node",
+        ].compactMap { $0 }
+        if let path = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return URL(fileURLWithPath: path)
+        }
+
+        let shell = Process()
+        let pipe = Pipe()
+        shell.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        shell.arguments = ["-lc", "command -v bun || command -v node"]
+        shell.standardOutput = pipe
+        shell.standardError = FileHandle.nullDevice
+        guard (try? shell.run()) != nil else { return nil }
+        shell.waitUntilExit()
+        guard shell.terminationStatus == 0 else { return nil }
+        let data = (try? pipe.fileHandleForReading.readToEnd()) ?? nil
+        guard let data,
+              let value = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty,
+              FileManager.default.isExecutableFile(atPath: value)
+        else { return nil }
+        return URL(fileURLWithPath: value)
+    }
+}

--- a/app/Sources/SpeakEasy/CodexThreadRouter.swift
+++ b/app/Sources/SpeakEasy/CodexThreadRouter.swift
@@ -8,6 +8,23 @@ struct CodexTaskSummary: Identifiable, Codable, Equatable, Sendable {
     let updatedAt: Date
 }
 
+enum CodexTurnDelivery: String, Codable, Equatable, Sendable {
+    case startedTurn = "started-turn"
+    case steeredActiveTurn = "steered-active-turn"
+
+    var label: String {
+        switch self {
+        case .startedTurn: "Started a new turn in the exact task"
+        case .steeredActiveTurn: "Steered the active turn in the exact task"
+        }
+    }
+}
+
+struct CodexTurnResult: Equatable, Sendable {
+    let response: String
+    let delivery: CodexTurnDelivery
+}
+
 enum CodexThreadRouterError: LocalizedError {
     case runtimeUnavailable
     case bridgeUnavailable
@@ -42,6 +59,7 @@ actor CodexThreadRouter {
         let tasks: [TaskPayload]?
         let task: TaskPayload?
         let response: String?
+        let delivery: String?
         let error: String?
         let code: String?
     }
@@ -72,7 +90,7 @@ actor CodexThreadRouter {
         return Self.summary(task)
     }
 
-    func submit(_ text: String, to threadID: String) async throws -> String {
+    func submit(_ text: String, to threadID: String) async throws -> CodexTurnResult {
         guard activeProcess == nil else { throw CodexThreadRouterError.turnAlreadyActive }
         let envelope = try await invoke(
             arguments: ["submit", threadID],
@@ -80,9 +98,11 @@ actor CodexThreadRouter {
         )
         guard envelope.ok,
               let response = envelope.response?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !response.isEmpty
+              !response.isEmpty,
+              let deliveryValue = envelope.delivery,
+              let delivery = CodexTurnDelivery(rawValue: deliveryValue)
         else { throw bridgeError(envelope) }
-        return response
+        return CodexTurnResult(response: response, delivery: delivery)
     }
 
     func shutdown() {

--- a/app/Sources/SpeakEasy/ConfigModel.swift
+++ b/app/Sources/SpeakEasy/ConfigModel.swift
@@ -232,6 +232,10 @@ class ConfigManager: ObservableObject {
         }
     }
 
+    var openaiModel: String {
+        config.providers?.openai?.model ?? "tts-1"
+    }
+
     var openaiInstructions: String {
         get { config.providers?.openai?.instructions ?? "" }
         set {
@@ -263,6 +267,10 @@ class ConfigManager: ObservableObject {
         }
     }
 
+    var elevenlabsModelId: String {
+        config.providers?.elevenlabs?.modelId ?? "eleven_multilingual_v2"
+    }
+
     // Groq
     var groqApiKey: String {
         get { config.providers?.groq?.apiKey ?? "" }
@@ -272,6 +280,14 @@ class ConfigManager: ObservableObject {
             config.providers?.groq?.apiKey = newValue.isEmpty ? nil : newValue
             markUnsaved()
         }
+    }
+
+    var groqVoice: String {
+        config.providers?.groq?.voice ?? "tara"
+    }
+
+    var groqModel: String {
+        config.providers?.groq?.model ?? "canopylabs/orpheus-v1-english"
     }
 
     // Gemini

--- a/app/Sources/SpeakEasy/GlobalListeningShortcut.swift
+++ b/app/Sources/SpeakEasy/GlobalListeningShortcut.swift
@@ -1,15 +1,27 @@
 import Carbon.HIToolbox
 import Foundation
 
+private let speakEasyHotKeySignature: OSType = 0x53_50_4B_59 // SPKY
+
+enum ListeningShortcutAction: Equatable, Sendable {
+    case toggleCurrentLane
+    case selectLane(Int)
+}
+
 @MainActor
 final class GlobalListeningShortcut {
     static let title = "⌃⌥Space"
+    static let laneRange = 1...9
 
-    private var hotKey: EventHotKeyRef?
+    private static let currentLaneID: UInt32 = 1
+    private static let firstLaneID: UInt32 = 101
+
+    private var hotKeys: [UInt32: EventHotKeyRef] = [:]
+    private var actions: [UInt32: ListeningShortcutAction] = [:]
     private var eventHandler: EventHandlerRef?
-    private let action: @MainActor @Sendable () -> Void
+    private let action: @MainActor @Sendable (ListeningShortcutAction) -> Void
 
-    init(action: @escaping @MainActor @Sendable () -> Void) {
+    init(action: @escaping @MainActor @Sendable (ListeningShortcutAction) -> Void) {
         self.action = action
 
         var eventType = EventTypeSpec(
@@ -18,12 +30,24 @@ final class GlobalListeningShortcut {
         )
         InstallEventHandler(
             GetApplicationEventTarget(),
-            { _, _, userData in
-                guard let userData else { return noErr }
+            { _, event, userData in
+                guard let event, let userData else { return OSStatus(eventNotHandledErr) }
+                var identifier = EventHotKeyID()
+                let status = GetEventParameter(
+                    event,
+                    EventParamName(kEventParamDirectObject),
+                    EventParamType(typeEventHotKeyID),
+                    nil,
+                    MemoryLayout<EventHotKeyID>.size,
+                    nil,
+                    &identifier
+                )
+                guard status == noErr, identifier.signature == speakEasyHotKeySignature else { return status }
                 let shortcut = Unmanaged<GlobalListeningShortcut>
                     .fromOpaque(userData)
                     .takeUnretainedValue()
-                Task { @MainActor in shortcut.action() }
+                let id = identifier.id
+                Task { @MainActor in shortcut.handle(id: id) }
                 return noErr
             },
             1,
@@ -34,41 +58,100 @@ final class GlobalListeningShortcut {
     }
 
     deinit {
-        if let hotKey { UnregisterEventHotKey(hotKey) }
+        for reference in hotKeys.values { UnregisterEventHotKey(reference) }
         if let eventHandler { RemoveEventHandler(eventHandler) }
     }
 
     @discardableResult
-    func register() -> Bool {
-        unregister()
+    func registerCurrentLane() -> Bool {
+        register(
+            id: Self.currentLaneID,
+            keyCode: UInt32(kVK_Space),
+            modifiers: UInt32(controlKey | optionKey),
+            action: .toggleCurrentLane
+        )
+    }
+
+    func registerLanes() -> [Int: Bool] {
+        Dictionary(uniqueKeysWithValues: Self.laneRange.map { lane in
+            let available = register(
+                id: Self.id(forLane: lane),
+                keyCode: Self.keyCode(forLane: lane),
+                modifiers: UInt32(cmdKey | optionKey),
+                action: .selectLane(lane)
+            )
+            return (lane, available)
+        })
+    }
+
+    func unregisterAll() {
+        for reference in hotKeys.values { UnregisterEventHotKey(reference) }
+        hotKeys.removeAll()
+        actions.removeAll()
+    }
+
+    /// Exercises a registered action without synthetic keystrokes or macOS
+    /// Accessibility permission. Used only by signed launch validation.
+    func triggerForTesting() {
+        guard ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_HOTKEY_ON_LAUNCH"] == "1" else {
+            return
+        }
+        action(.toggleCurrentLane)
+    }
+
+    func triggerLaneForTesting(_ lane: Int) {
+        guard ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_LANE_ON_LAUNCH"] == String(lane),
+              Self.laneRange.contains(lane)
+        else { return }
+        action(.selectLane(lane))
+    }
+
+    nonisolated static func title(forLane lane: Int) -> String { "⌘⌥\(lane)" }
+
+    static func keyCode(forLane lane: Int) -> UInt32 {
+        let codes = [
+            UInt32(kVK_ANSI_1), UInt32(kVK_ANSI_2), UInt32(kVK_ANSI_3),
+            UInt32(kVK_ANSI_4), UInt32(kVK_ANSI_5), UInt32(kVK_ANSI_6),
+            UInt32(kVK_ANSI_7), UInt32(kVK_ANSI_8), UInt32(kVK_ANSI_9),
+        ]
+        guard Self.laneRange.contains(lane) else { return UInt32(kVK_ANSI_1) }
+        return codes[lane - 1]
+    }
+
+    private static func id(forLane lane: Int) -> UInt32 {
+        firstLaneID + UInt32(lane - 1)
+    }
+
+    @discardableResult
+    private func register(
+        id: UInt32,
+        keyCode: UInt32,
+        modifiers: UInt32,
+        action: ListeningShortcutAction
+    ) -> Bool {
+        if let existing = hotKeys.removeValue(forKey: id) {
+            UnregisterEventHotKey(existing)
+        }
+        actions.removeValue(forKey: id)
+
         var reference: EventHotKeyRef?
-        let identifier = EventHotKeyID(signature: 0x53_50_4B_59, id: 1) // SPKY
+        let identifier = EventHotKeyID(signature: speakEasyHotKeySignature, id: id)
         let status = RegisterEventHotKey(
-            UInt32(kVK_Space),
-            UInt32(controlKey | optionKey),
+            keyCode,
+            modifiers,
             identifier,
             GetApplicationEventTarget(),
             0,
             &reference
         )
-        guard status == noErr else { return false }
-        hotKey = reference
+        guard status == noErr, let reference else { return false }
+        hotKeys[id] = reference
+        actions[id] = action
         return true
     }
 
-    func unregister() {
-        if let hotKey {
-            UnregisterEventHotKey(hotKey)
-            self.hotKey = nil
-        }
-    }
-
-    /// Exercises the registered hotkey action without requiring test runners
-    /// to obtain macOS Accessibility permission for synthetic keystrokes.
-    func triggerForTesting() {
-        guard ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_HOTKEY_ON_LAUNCH"] == "1" else {
-            return
-        }
-        action()
+    private func handle(id: UInt32) {
+        guard let shortcutAction = actions[id] else { return }
+        action(shortcutAction)
     }
 }

--- a/app/Sources/SpeakEasy/GlobalListeningShortcut.swift
+++ b/app/Sources/SpeakEasy/GlobalListeningShortcut.swift
@@ -1,0 +1,74 @@
+import Carbon.HIToolbox
+import Foundation
+
+@MainActor
+final class GlobalListeningShortcut {
+    static let title = "⌃⌥Space"
+
+    private var hotKey: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
+    private let action: @MainActor @Sendable () -> Void
+
+    init(action: @escaping @MainActor @Sendable () -> Void) {
+        self.action = action
+
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            { _, _, userData in
+                guard let userData else { return noErr }
+                let shortcut = Unmanaged<GlobalListeningShortcut>
+                    .fromOpaque(userData)
+                    .takeUnretainedValue()
+                Task { @MainActor in shortcut.action() }
+                return noErr
+            },
+            1,
+            &eventType,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &eventHandler
+        )
+    }
+
+    deinit {
+        if let hotKey { UnregisterEventHotKey(hotKey) }
+        if let eventHandler { RemoveEventHandler(eventHandler) }
+    }
+
+    @discardableResult
+    func register() -> Bool {
+        unregister()
+        var reference: EventHotKeyRef?
+        let identifier = EventHotKeyID(signature: 0x53_50_4B_59, id: 1) // SPKY
+        let status = RegisterEventHotKey(
+            UInt32(kVK_Space),
+            UInt32(controlKey | optionKey),
+            identifier,
+            GetApplicationEventTarget(),
+            0,
+            &reference
+        )
+        guard status == noErr else { return false }
+        hotKey = reference
+        return true
+    }
+
+    func unregister() {
+        if let hotKey {
+            UnregisterEventHotKey(hotKey)
+            self.hotKey = nil
+        }
+    }
+
+    /// Exercises the registered hotkey action without requiring test runners
+    /// to obtain macOS Accessibility permission for synthetic keystrokes.
+    func triggerForTesting() {
+        guard ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_HOTKEY_ON_LAUNCH"] == "1" else {
+            return
+        }
+        action()
+    }
+}

--- a/app/Sources/SpeakEasy/GlobalListeningShortcut.swift
+++ b/app/Sources/SpeakEasy/GlobalListeningShortcut.swift
@@ -6,14 +6,17 @@ private let speakEasyHotKeySignature: OSType = 0x53_50_4B_59 // SPKY
 enum ListeningShortcutAction: Equatable, Sendable {
     case toggleCurrentLane
     case selectLane(Int)
+    case announceActiveLane
 }
 
 @MainActor
 final class GlobalListeningShortcut {
     static let title = "⌃⌥Space"
+    static let confirmationTitle = "⌘⌥X"
     static let laneRange = 1...9
 
     private static let currentLaneID: UInt32 = 1
+    private static let confirmationID: UInt32 = 2
     private static let firstLaneID: UInt32 = 101
 
     private var hotKeys: [UInt32: EventHotKeyRef] = [:]
@@ -84,6 +87,16 @@ final class GlobalListeningShortcut {
         })
     }
 
+    @discardableResult
+    func registerLaneConfirmation() -> Bool {
+        register(
+            id: Self.confirmationID,
+            keyCode: UInt32(kVK_ANSI_X),
+            modifiers: UInt32(cmdKey | optionKey),
+            action: .announceActiveLane
+        )
+    }
+
     func unregisterAll() {
         for reference in hotKeys.values { UnregisterEventHotKey(reference) }
         hotKeys.removeAll()
@@ -104,6 +117,13 @@ final class GlobalListeningShortcut {
               Self.laneRange.contains(lane)
         else { return }
         action(.selectLane(lane))
+    }
+
+    func triggerConfirmationForTesting() {
+        guard ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_LANE_CONFIRMATION_ON_LAUNCH"] == "1" else {
+            return
+        }
+        action(.announceActiveLane)
     }
 
     nonisolated static func title(forLane lane: Int) -> String { "⌘⌥\(lane)" }

--- a/app/Sources/SpeakEasy/HUDSnapshot.swift
+++ b/app/Sources/SpeakEasy/HUDSnapshot.swift
@@ -11,6 +11,9 @@ enum HUDSnapshot {
         }
 
         let outputPath = CommandLine.arguments[argumentIndex + 1]
+        let requestedState = CommandLine.arguments.firstIndex(of: "--snapshot-hud-state")
+            .flatMap { CommandLine.arguments.indices.contains($0 + 1) ? CommandLine.arguments[$0 + 1] : nil }
+            .flatMap(ListeningPhase.init(rawValue:))
         let message = HUDMessage(
             text: "The permanent player now keeps every spoken word in view, follows the live narration, and can take you straight back to the Codex task that created it.",
             provider: "elevenlabs",
@@ -19,15 +22,39 @@ enum HUDSnapshot {
             audioLevel: 0.46,
             sourceThreadId: "019f9573-3e55-7701-8968-09c12d4fafe5"
         )
-        let rootView = HUDContent(
-            message: message,
-            theme: .dark,
-            audioLevel: 0.46,
-            playbackProgress: 0.78
-        )
-        .environment(\.theme, .dark)
-        .preferredColorScheme(.dark)
-        .padding(12)
+        let presentation = requestedState.map {
+            HUDConversationPresentation(
+                phase: $0,
+                taskTitle: "Prototype SpeakEasy listening mode",
+                taskID: "019f99a4-7867-7c23-ac29-0c0eca7da603",
+                transcript: "Can you make the voice loop feel more alive?",
+                error: $0 == .failed ? "Codex Desktop is unavailable." : nil,
+                inputDeviceName: "MacBook Air Microphone"
+            )
+        }
+        let content: AnyView
+        if let presentation, presentation.phase == .speaking {
+            content = AnyView(HUDContent(
+                message: message,
+                theme: .dark,
+                audioLevel: 0.46,
+                playbackProgress: 0.78,
+                conversation: presentation
+            ))
+        } else if let presentation {
+            content = AnyView(ConversationHUDContent(presentation: presentation))
+        } else {
+            content = AnyView(HUDContent(
+                message: message,
+                theme: .dark,
+                audioLevel: 0.46,
+                playbackProgress: 0.78
+            ))
+        }
+        let rootView = content
+            .environment(\.theme, .dark)
+            .preferredColorScheme(.dark)
+            .padding(12)
 
         let hostingView = NSHostingView(rootView: rootView)
         hostingView.frame = NSRect(x: 0, y: 0, width: 504, height: 204)

--- a/app/Sources/SpeakEasy/HUDSnapshot.swift
+++ b/app/Sources/SpeakEasy/HUDSnapshot.swift
@@ -27,6 +27,7 @@ enum HUDSnapshot {
                 phase: $0,
                 taskTitle: "Prototype SpeakEasy listening mode",
                 taskID: "019f99a4-7867-7c23-ac29-0c0eca7da603",
+                laneNumber: 2,
                 transcript: "Can you make the voice loop feel more alive?",
                 error: $0 == .failed ? "Codex Desktop is unavailable." : nil,
                 inputDeviceName: "MacBook Air Microphone"

--- a/app/Sources/SpeakEasy/HUDSnapshot.swift
+++ b/app/Sources/SpeakEasy/HUDSnapshot.swift
@@ -58,7 +58,12 @@ enum HUDSnapshot {
             .padding(12)
 
         let hostingView = NSHostingView(rootView: rootView)
-        hostingView.frame = NSRect(x: 0, y: 0, width: 504, height: 204)
+        hostingView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: HUDLayout.width + 24,
+            height: HUDLayout.height + 24
+        )
         hostingView.layoutSubtreeIfNeeded()
 
         guard let representation = hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds) else {

--- a/app/Sources/SpeakEasy/HUDView.swift
+++ b/app/Sources/SpeakEasy/HUDView.swift
@@ -27,15 +27,16 @@ struct HUDConversationPresentation: Equatable {
     let error: String?
     let inputDeviceName: String?
 
+    /// Restrained phase accents keep state distinct against the near-black shell.
     var accent: Color {
         switch phase {
-        case .recording: Color(red: 0.28, green: 0.94, blue: 0.68)
-        case .cueing: Color(red: 1, green: 0.72, blue: 0.32)
-        case .warmingUp, .transcribing: Color(red: 0.58, green: 0.72, blue: 1)
-        case .submitting: Color(red: 0.37, green: 0.82, blue: 1)
-        case .preparingSpeech, .speaking: Color(red: 0.76, green: 0.56, blue: 1)
-        case .failed: Color(red: 1, green: 0.53, blue: 0.36)
-        default: Color(red: 0.36, green: 0.87, blue: 0.66)
+        case .recording: Color(red: 0.46, green: 0.78, blue: 0.64)       // jade
+        case .cueing: Color(red: 0.88, green: 0.70, blue: 0.42)           // warm gold
+        case .warmingUp, .transcribing: Color(red: 0.62, green: 0.70, blue: 0.88) // periwinkle
+        case .submitting: Color(red: 0.52, green: 0.70, blue: 0.84)       // steel sky
+        case .preparingSpeech, .speaking: Color(red: 0.70, green: 0.62, blue: 0.86) // soft lavender
+        case .failed: Color(red: 0.90, green: 0.56, blue: 0.48)           // muted coral
+        default: Color(red: 0.52, green: 0.74, blue: 0.64)                // sage
         }
     }
 
@@ -59,7 +60,8 @@ struct HUDConversationPresentation: Equatable {
         if phase == .failed, let error, !error.isEmpty { return error }
         switch phase {
         case .validatingLock: return "Verifying the exact Codex task"
-        case .cueing: return taskTitle
+        // Header already shows the exact task; body explains the status check.
+        case .cueing: return "Status check · microphone is off"
         case .ready:
             if let laneNumber { return "Press ⌘⌥\(laneNumber) for this lane or ⌃⌥Space" }
             return "Press ⌃⌥Space and speak"
@@ -440,7 +442,7 @@ struct HUDOverlayView: View {
                 ))
             }
         }
-        .frame(width: 480, height: 180)
+        .frame(width: HUDLayout.width, height: HUDLayout.height)
     }
 
     private var entryEdge: Edge {
@@ -461,6 +463,41 @@ enum HUDPosition: String, CaseIterable {
     case bottomRight = "bottom-right"
 }
 
+/// Shared geometry for the floating conversation and playback HUD.
+enum HUDLayout {
+    static let width: CGFloat = 404
+    static let height: CGFloat = 132
+    static let cornerRadius: CGFloat = 14
+    static let contentPadding: CGFloat = 12
+    static let sectionSpacing: CGFloat = 10
+    static let iconSize: CGFloat = 34
+    static let iconSymbolSize: CGFloat = 14
+    static let titleSize: CGFloat = 14
+    static let detailSize: CGFloat = 10
+    static let headerStatusSize: CGFloat = 8
+    static let headerMetaSize: CGFloat = 9
+    static let energyHeight: CGFloat = 14
+    static let energyBarCount = 28
+    static let energyBarSpacing: CGFloat = 2
+    static let dismissSize: CGFloat = 18
+    static let dismissPadding: CGFloat = 6
+}
+
+/// Shared phase-surface treatment so conversation phases and speaking stay one family.
+enum HUDPhaseChrome {
+    static let fillOpacity: Double = 0.9
+    static let glowOpacity: Double = 0.09
+    static let borderOpacity: Double = 0.20
+    static let shadowOpacity: Double = 0.07
+    static let shadowRadius: CGFloat = 14
+    static let shadowY: CGFloat = 7
+    static let glowEndRadius: CGFloat = 260
+    static let statusDotShadowOpacity: Double = 0.42
+    static let statusDotShadowRadius: CGFloat = 2.5
+    static let iconFillOpacity: Double = 0.10
+    static let iconStrokeOpacity: Double = 0.26
+}
+
 // MARK: - Combined Style HUD Content (matches preview)
 
 struct HUDContent: View {
@@ -472,6 +509,10 @@ struct HUDContent: View {
     @ObservedObject private var config = ConfigManager.shared
 
     private var waveformColor: Color {
+        // Locked narration shares the same phase system as the conversation HUD.
+        if let conversation {
+            return conversation.accent
+        }
         switch config.hudWaveformColor.lowercased() {
         case "blue": return .blue
         case "purple": return .purple
@@ -513,46 +554,46 @@ struct HUDContent: View {
             VStack(spacing: 0) {
                 if let conversation {
                     HUDTaskLockHeader(presentation: conversation)
-                        .padding(.horizontal, 16)
-                        .padding(.top, 12)
+                        .padding(.horizontal, HUDLayout.contentPadding)
+                        .padding(.top, 10)
                 }
 
                 // Text section at top
                 HUDTextSection(
                     text: message.text ?? "",
                     cached: message.cached ?? false,
-                    fontSize: fontSize,
+                    fontSize: min(fontSize, 13),
                     fontDesign: fontDesign,
                     playbackProgress: playbackProgress
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-                HStack(spacing: 12) {
+                HStack(spacing: 10) {
                     HUDWaveformSection(
                         barCount: config.hudWaveformBarCount,
                         amplitudeMultiplier: config.hudWaveformAmplitude,
                         color: waveformColor,
                         audioLevel: audioLevel
                     )
-                    .frame(height: 30)
+                    .frame(height: 22)
 
                     if let url = CodexTaskLink.url(threadId: message.sourceThreadId) {
                         Button {
                             NSWorkspace.shared.open(url)
                         } label: {
                             Label("Back to Codex", systemImage: "arrow.turn.up.left")
-                                .font(.system(size: 11, weight: .semibold))
+                                .font(.system(size: 10, weight: .semibold))
                                 .foregroundColor(.white.opacity(0.82))
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 7)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 5)
                                 .background(Color.white.opacity(0.1), in: Capsule())
                         }
                         .buttonStyle(.plain)
                         .help("Open the Codex task that created this narration")
                     }
                 }
-                .padding(.horizontal, 16)
-                .padding(.bottom, 14)
+                .padding(.horizontal, HUDLayout.contentPadding)
+                .padding(.bottom, 10)
             }
 
             // Dismiss button
@@ -560,28 +601,58 @@ struct HUDContent: View {
                 HUDWindowManager.shared.dismiss()
             }) {
                 Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.white.opacity(0.4))
-                    .frame(width: 20, height: 20)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.42))
+                    .frame(width: HUDLayout.dismissSize, height: HUDLayout.dismissSize)
                     .background(Color.white.opacity(0.1))
                     .clipShape(Circle())
             }
             .buttonStyle(.plain)
-            .padding(8)
+            .padding(HUDLayout.dismissPadding)
+            .accessibilityLabel("Dismiss SpeakEasy conversation HUD")
         }
-        .frame(width: 480, height: 180)
-        .background(
-            ZStack {
-                // Super dark black background
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(Color.black.opacity(0.85))
-
-                // Subtle border for definition
-                RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.white.opacity(0.1), lineWidth: 0.5)
-            }
-        )
+        .frame(width: HUDLayout.width, height: HUDLayout.height)
+        .background(hudSurfaceBackground)
     }
+
+    @ViewBuilder
+    private var hudSurfaceBackground: some View {
+        if let conversation {
+            phaseSurface(accent: conversation.accent)
+        } else {
+            RoundedRectangle(cornerRadius: HUDLayout.cornerRadius, style: .continuous)
+                .fill(Color.black.opacity(0.85))
+                .overlay {
+                    RoundedRectangle(cornerRadius: HUDLayout.cornerRadius, style: .continuous)
+                        .stroke(Color.white.opacity(0.1), lineWidth: 0.5)
+                }
+        }
+    }
+}
+
+/// Shared surface: near-black fill, soft phase glow, thin accent border, quiet shadow.
+@ViewBuilder
+func phaseSurface(accent: Color) -> some View {
+    RoundedRectangle(cornerRadius: HUDLayout.cornerRadius, style: .continuous)
+        .fill(Color.black.opacity(HUDPhaseChrome.fillOpacity))
+        .overlay {
+            RadialGradient(
+                colors: [accent.opacity(HUDPhaseChrome.glowOpacity), .clear],
+                center: .topLeading,
+                startRadius: 0,
+                endRadius: HUDPhaseChrome.glowEndRadius
+            )
+            .clipShape(RoundedRectangle(cornerRadius: HUDLayout.cornerRadius, style: .continuous))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: HUDLayout.cornerRadius, style: .continuous)
+                .stroke(accent.opacity(HUDPhaseChrome.borderOpacity), lineWidth: 0.75)
+        }
+        .shadow(
+            color: accent.opacity(HUDPhaseChrome.shadowOpacity),
+            radius: HUDPhaseChrome.shadowRadius,
+            y: HUDPhaseChrome.shadowY
+        )
 }
 
 // MARK: - Thread-locked conversation HUD
@@ -594,34 +665,38 @@ struct ConversationHUDContent: View {
         TimelineView(.animation(minimumInterval: reduceMotion ? 1 : 1.0 / 24.0)) { timeline in
             let time = timeline.date.timeIntervalSinceReferenceDate
             ZStack(alignment: .topTrailing) {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: HUDLayout.sectionSpacing) {
                     HUDTaskLockHeader(presentation: presentation)
 
-                    HStack(spacing: 14) {
+                    HStack(spacing: 10) {
                         ZStack {
                             Circle()
-                                .fill(presentation.accent.opacity(0.12))
-                                .frame(width: 54, height: 54)
+                                .fill(presentation.accent.opacity(HUDPhaseChrome.iconFillOpacity))
+                                .frame(width: HUDLayout.iconSize, height: HUDLayout.iconSize)
                             Circle()
-                                .stroke(presentation.accent.opacity(0.34), lineWidth: 1)
-                                .frame(width: 54, height: 54)
+                                .stroke(presentation.accent.opacity(HUDPhaseChrome.iconStrokeOpacity), lineWidth: 1)
+                                .frame(width: HUDLayout.iconSize, height: HUDLayout.iconSize)
                                 .scaleEffect(pulseScale(time))
                                 .opacity(pulseOpacity(time))
                             Image(systemName: presentation.symbol)
-                                .font(.system(size: 21, weight: .semibold))
+                                .font(.system(size: HUDLayout.iconSymbolSize, weight: .semibold))
                                 .foregroundStyle(presentation.accent)
+                                .symbolRenderingMode(.hierarchical)
                         }
+                        .accessibilityHidden(true)
 
-                        VStack(alignment: .leading, spacing: 5) {
+                        VStack(alignment: .leading, spacing: 2) {
                             Text(presentation.title)
-                                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                                .font(.system(size: HUDLayout.titleSize, weight: .semibold, design: .rounded))
                                 .foregroundStyle(.white)
+                                .lineLimit(1)
                             Text(presentation.detail)
-                                .font(.system(size: 11, weight: .medium, design: .rounded))
-                                .foregroundStyle(.white.opacity(0.58))
+                                .font(.system(size: HUDLayout.detailSize, weight: .medium, design: .rounded))
+                                .foregroundStyle(.white.opacity(0.56))
                                 .lineLimit(2)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
-                        Spacer(minLength: 8)
+                        Spacer(minLength: 4)
                     }
 
                     ConversationEnergyField(
@@ -629,22 +704,22 @@ struct ConversationHUDContent: View {
                         accent: presentation.accent,
                         time: reduceMotion ? 0 : time
                     )
-                    .frame(height: 24)
+                    .frame(height: HUDLayout.energyHeight)
                 }
-                .padding(16)
+                .padding(HUDLayout.contentPadding)
 
                 Button { HUDWindowManager.shared.dismiss() } label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.42))
-                        .frame(width: 22, height: 22)
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.45))
+                        .frame(width: HUDLayout.dismissSize, height: HUDLayout.dismissSize)
                         .background(.white.opacity(0.08), in: Circle())
                 }
                 .buttonStyle(.plain)
-                .padding(9)
+                .padding(HUDLayout.dismissPadding)
                 .accessibilityLabel("Dismiss SpeakEasy conversation HUD")
             }
-            .frame(width: 480, height: 180)
+            .frame(width: HUDLayout.width, height: HUDLayout.height)
             .background(conversationBackground)
             .accessibilityElement(children: .combine)
             .accessibilityLabel("SpeakEasy \(presentation.title). Locked to \(presentation.taskTitle). \(presentation.detail)")
@@ -658,31 +733,16 @@ struct ConversationHUDContent: View {
 
     private func pulseScale(_ time: TimeInterval) -> CGFloat {
         guard isEnergetic, !reduceMotion else { return 1 }
-        return 1 + CGFloat((sin(time * 4.2) + 1) * 0.045)
+        return 1 + CGFloat((sin(time * 4.2) + 1) * 0.04)
     }
 
     private func pulseOpacity(_ time: TimeInterval) -> Double {
         guard isEnergetic, !reduceMotion else { return 1 }
-        return 0.42 + (sin(time * 4.2) + 1) * 0.18
+        return 0.4 + (sin(time * 4.2) + 1) * 0.16
     }
 
     private var conversationBackground: some View {
-        RoundedRectangle(cornerRadius: 18, style: .continuous)
-            .fill(Color.black.opacity(0.9))
-            .overlay {
-                RadialGradient(
-                    colors: [presentation.accent.opacity(0.19), .clear],
-                    center: .topLeading,
-                    startRadius: 0,
-                    endRadius: 360
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(presentation.accent.opacity(0.32), lineWidth: 0.75)
-            }
-            .shadow(color: presentation.accent.opacity(0.14), radius: 24, y: 10)
+        phaseSurface(accent: presentation.accent)
     }
 }
 
@@ -690,33 +750,50 @@ struct HUDTaskLockHeader: View {
     let presentation: HUDConversationPresentation
 
     var body: some View {
-        HStack(spacing: 7) {
+        HStack(spacing: 6) {
             Circle()
                 .fill(presentation.accent)
-                .frame(width: 6, height: 6)
-                .shadow(color: presentation.accent.opacity(0.8), radius: 4)
+                .frame(width: 5, height: 5)
+                .shadow(
+                    color: presentation.accent.opacity(HUDPhaseChrome.statusDotShadowOpacity),
+                    radius: HUDPhaseChrome.statusDotShadowRadius
+                )
                 .accessibilityHidden(true)
             Text(statusLabel)
-                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .font(.system(size: HUDLayout.headerStatusSize, weight: .bold, design: .monospaced))
                 .foregroundStyle(presentation.accent)
-            Spacer()
+                .lineLimit(1)
+                .layoutPriority(1)
+            Spacer(minLength: 6)
             Image(systemName: "lock.fill")
-                .font(.system(size: 8, weight: .bold))
+                .font(.system(size: 7, weight: .bold))
+                .foregroundStyle(.white.opacity(0.55))
             Text(presentation.taskTitle)
                 .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(2)
             Text(String(presentation.taskID.prefix(8)))
-                .fontDesign(.monospaced)
-                .foregroundStyle(.white.opacity(0.34))
+                .font(.system(size: HUDLayout.headerMetaSize, weight: .medium, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.32))
+                .layoutPriority(0)
         }
-        .font(.system(size: 10, weight: .semibold, design: .rounded))
-        .foregroundStyle(.white.opacity(0.68))
-        .padding(.trailing, 28)
+        .font(.system(size: HUDLayout.headerMetaSize, weight: .semibold, design: .rounded))
+        .foregroundStyle(.white.opacity(0.66))
+        .padding(.trailing, HUDLayout.dismissSize + HUDLayout.dismissPadding)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(presentation.phase.label). Locked to \(presentation.taskTitle)")
     }
 
     private var statusLabel: String {
-        let status = presentation.phase == .recording ? "LIVE" : presentation.phase.label.uppercased()
+        // Prefer short phase chips so the locked task title keeps horizontal room.
+        let status: String
+        switch presentation.phase {
+        case .recording: status = "LIVE"
+        case .cueing: status = "CONFIRMING"
+        case .submitting: status = "SUBMITTING"
+        case .preparingSpeech: status = "PREPARING"
+        default: status = presentation.phase.label.uppercased()
+        }
         guard let lane = presentation.laneNumber else { return status }
         return "LANE \(lane) · \(status)"
     }
@@ -727,16 +804,16 @@ struct ConversationEnergyField: View {
     let accent: Color
     let time: TimeInterval
 
-    private let count = 34
+    private let count = HUDLayout.energyBarCount
 
     var body: some View {
         GeometryReader { geometry in
-            HStack(alignment: .center, spacing: 3) {
+            HStack(alignment: .center, spacing: HUDLayout.energyBarSpacing) {
                 ForEach(0..<count, id: \.self) { index in
                     Capsule()
                         .fill(accent.opacity(opacity(for: index)))
                         .frame(
-                            width: max(2, (geometry.size.width - CGFloat(count - 1) * 3) / CGFloat(count)),
+                            width: max(1.5, (geometry.size.width - CGFloat(count - 1) * HUDLayout.energyBarSpacing) / CGFloat(count)),
                             height: height(for: index)
                         )
                 }
@@ -747,15 +824,16 @@ struct ConversationEnergyField: View {
     }
 
     private func height(for index: Int) -> CGFloat {
-        guard phase != .ready && phase != .failed else { return index.isMultiple(of: 5) ? 4 : 2 }
+        guard phase != .ready && phase != .failed else { return index.isMultiple(of: 5) ? 3 : 1.5 }
         let phaseOffset = Double(index) * 0.52
         let primary = (sin(time * 5.2 + phaseOffset) + 1) * 0.5
         let secondary = (sin(time * 2.3 - phaseOffset * 0.7) + 1) * 0.5
-        return 3 + CGFloat(primary * 13 + secondary * 5)
+        // Fit energetic bars inside the compact energy strip.
+        return 2 + CGFloat(primary * 8 + secondary * 3)
     }
 
     private func opacity(for index: Int) -> Double {
-        0.34 + (sin(time * 2.1 + Double(index) * 0.31) + 1) * 0.24
+        0.28 + (sin(time * 2.1 + Double(index) * 0.31) + 1) * 0.18
     }
 }
 

--- a/app/Sources/SpeakEasy/HUDView.swift
+++ b/app/Sources/SpeakEasy/HUDView.swift
@@ -22,6 +22,7 @@ struct HUDConversationPresentation: Equatable {
     let phase: ListeningPhase
     let taskTitle: String
     let taskID: String
+    let laneNumber: Int?
     let transcript: String
     let error: String?
     let inputDeviceName: String?
@@ -29,6 +30,7 @@ struct HUDConversationPresentation: Equatable {
     var accent: Color {
         switch phase {
         case .recording: Color(red: 0.28, green: 0.94, blue: 0.68)
+        case .cueing: Color(red: 1, green: 0.72, blue: 0.32)
         case .warmingUp, .transcribing: Color(red: 0.58, green: 0.72, blue: 1)
         case .submitting: Color(red: 0.37, green: 0.82, blue: 1)
         case .preparingSpeech, .speaking: Color(red: 0.76, green: 0.56, blue: 1)
@@ -40,6 +42,7 @@ struct HUDConversationPresentation: Equatable {
     var title: String {
         switch phase {
         case .validatingLock: "Locking onto task"
+        case .cueing: laneNumber.map { "Lane \($0) selected" } ?? "Lane selected"
         case .ready: "Ready when you are"
         case .warmingUp: "Warming up Vox"
         case .recording: "Listening to you"
@@ -56,8 +59,11 @@ struct HUDConversationPresentation: Equatable {
         if phase == .failed, let error, !error.isEmpty { return error }
         switch phase {
         case .validatingLock: return "Verifying the exact Codex task"
-        case .ready: return "Press ⌃⌥Space and speak"
-        case .warmingUp: return "Loading local speech recognition"
+        case .cueing: return "Opening the microphone after this cue"
+        case .ready:
+            if let laneNumber { return "Press ⌘⌥\(laneNumber) for this lane or ⌃⌥Space" }
+            return "Press ⌃⌥Space and speak"
+        case .warmingUp: return "Opening the microphone before Vox warmup"
         case .recording:
             if let inputDeviceName { return "⌃⌥Space to send · \(inputDeviceName)" }
             return "⌃⌥Space to stop and send"
@@ -74,6 +80,7 @@ struct HUDConversationPresentation: Equatable {
     var symbol: String {
         switch phase {
         case .validatingLock: "scope"
+        case .cueing: "speaker.wave.2.fill"
         case .ready: "waveform.badge.mic"
         case .warmingUp: "brain.head.profile"
         case .recording: "mic.fill"
@@ -132,17 +139,22 @@ class HUDWindowManager: ObservableObject {
 
     func bindListening(_ controller: ListeningSessionController) {
         guard listeningObservation == nil else { return }
-        listeningObservation = Publishers.CombineLatest4(
-            controller.$phase,
-            controller.$lockedTask,
-            controller.$lastTranscript,
-            controller.$lastError
+        listeningObservation = Publishers.CombineLatest(
+            Publishers.CombineLatest4(
+                controller.$phase,
+                controller.$lockedTask,
+                controller.$lastTranscript,
+                controller.$lastError
+            ),
+            controller.$activeLaneNumber
         )
         .receive(on: RunLoop.main)
-        .sink { [weak self, weak controller] phase, lock, transcript, error in
+        .sink { [weak self, weak controller] values, laneNumber in
+            let (phase, lock, transcript, error) = values
             self?.updateListening(
                 phase: phase,
                 lock: lock,
+                laneNumber: laneNumber,
                 transcript: transcript,
                 error: error,
                 inputDeviceName: controller?.inputDeviceName
@@ -186,6 +198,7 @@ class HUDWindowManager: ObservableObject {
     private func updateListening(
         phase: ListeningPhase,
         lock: ListeningTaskLock?,
+        laneNumber: Int?,
         transcript: String,
         error: String?,
         inputDeviceName: String?
@@ -201,6 +214,7 @@ class HUDWindowManager: ObservableObject {
             phase: phase,
             taskTitle: lock.title,
             taskID: lock.id,
+            laneNumber: laneNumber,
             transcript: transcript,
             error: error,
             inputDeviceName: inputDeviceName
@@ -638,7 +652,7 @@ struct ConversationHUDContent: View {
     }
 
     private var isEnergetic: Bool {
-        [.warmingUp, .recording, .transcribing, .submitting, .preparingSpeech, .speaking]
+        [.cueing, .warmingUp, .recording, .transcribing, .submitting, .preparingSpeech, .speaking]
             .contains(presentation.phase)
     }
 
@@ -682,7 +696,7 @@ struct HUDTaskLockHeader: View {
                 .frame(width: 6, height: 6)
                 .shadow(color: presentation.accent.opacity(0.8), radius: 4)
                 .accessibilityHidden(true)
-            Text(presentation.phase == .recording ? "LIVE" : presentation.phase.label.uppercased())
+            Text(statusLabel)
                 .font(.system(size: 9, weight: .bold, design: .monospaced))
                 .foregroundStyle(presentation.accent)
             Spacer()
@@ -699,6 +713,12 @@ struct HUDTaskLockHeader: View {
         .padding(.trailing, 28)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(presentation.phase.label). Locked to \(presentation.taskTitle)")
+    }
+
+    private var statusLabel: String {
+        let status = presentation.phase == .recording ? "LIVE" : presentation.phase.label.uppercased()
+        guard let lane = presentation.laneNumber else { return status }
+        return "LANE \(lane) · \(status)"
     }
 }
 

--- a/app/Sources/SpeakEasy/HUDView.swift
+++ b/app/Sources/SpeakEasy/HUDView.swift
@@ -42,7 +42,7 @@ struct HUDConversationPresentation: Equatable {
     var title: String {
         switch phase {
         case .validatingLock: "Locking onto task"
-        case .cueing: laneNumber.map { "Lane \($0) selected" } ?? "Lane selected"
+        case .cueing: laneNumber.map { "Lane \($0) confirmed" } ?? "Lane confirmed"
         case .ready: "Ready when you are"
         case .warmingUp: "Warming up Vox"
         case .recording: "Listening to you"
@@ -59,7 +59,7 @@ struct HUDConversationPresentation: Equatable {
         if phase == .failed, let error, !error.isEmpty { return error }
         switch phase {
         case .validatingLock: return "Verifying the exact Codex task"
-        case .cueing: return "Opening the microphone after this cue"
+        case .cueing: return taskTitle
         case .ready:
             if let laneNumber { return "Press ⌘⌥\(laneNumber) for this lane or ⌃⌥Space" }
             return "Press ⌃⌥Space and speak"

--- a/app/Sources/SpeakEasy/HUDView.swift
+++ b/app/Sources/SpeakEasy/HUDView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Foundation
 import AppKit
+import Combine
 
 // MARK: - HUD Message Model
 
@@ -17,8 +18,78 @@ struct HUDMessage: Codable {
     }
 }
 
+struct HUDConversationPresentation: Equatable {
+    let phase: ListeningPhase
+    let taskTitle: String
+    let taskID: String
+    let transcript: String
+    let error: String?
+    let inputDeviceName: String?
+
+    var accent: Color {
+        switch phase {
+        case .recording: Color(red: 0.28, green: 0.94, blue: 0.68)
+        case .warmingUp, .transcribing: Color(red: 0.58, green: 0.72, blue: 1)
+        case .submitting: Color(red: 0.37, green: 0.82, blue: 1)
+        case .preparingSpeech, .speaking: Color(red: 0.76, green: 0.56, blue: 1)
+        case .failed: Color(red: 1, green: 0.53, blue: 0.36)
+        default: Color(red: 0.36, green: 0.87, blue: 0.66)
+        }
+    }
+
+    var title: String {
+        switch phase {
+        case .validatingLock: "Locking onto task"
+        case .ready: "Ready when you are"
+        case .warmingUp: "Warming up Vox"
+        case .recording: "Listening to you"
+        case .transcribing: "Understanding that"
+        case .submitting: "Talking to this task"
+        case .preparingSpeech: "Preparing its voice"
+        case .speaking: "Speaking back"
+        case .failed: "Voice loop needs attention"
+        case .unlocked: "Choose a task"
+        }
+    }
+
+    var detail: String {
+        if phase == .failed, let error, !error.isEmpty { return error }
+        switch phase {
+        case .validatingLock: return "Verifying the exact Codex task"
+        case .ready: return "Press ⌃⌥Space and speak"
+        case .warmingUp: return "Loading local speech recognition"
+        case .recording:
+            if let inputDeviceName { return "⌃⌥Space to send · \(inputDeviceName)" }
+            return "⌃⌥Space to stop and send"
+        case .transcribing: return "Turning this utterance into text"
+        case .submitting:
+            return transcript.isEmpty ? "Routing through Codex Desktop" : transcript
+        case .preparingSpeech: return "Using your configured SpeakEasy voice"
+        case .speaking: return "⌃⌥Space interrupts and listens again"
+        case .failed: return "Open SpeakEasy for details"
+        case .unlocked: return "Lock SpeakEasy before listening"
+        }
+    }
+
+    var symbol: String {
+        switch phase {
+        case .validatingLock: "scope"
+        case .ready: "waveform.badge.mic"
+        case .warmingUp: "brain.head.profile"
+        case .recording: "mic.fill"
+        case .transcribing: "text.bubble.fill"
+        case .submitting: "arrow.up.forward"
+        case .preparingSpeech: "sparkles"
+        case .speaking: "speaker.wave.2.fill"
+        case .failed: "exclamationmark.triangle.fill"
+        case .unlocked: "lock.open.fill"
+        }
+    }
+}
+
 // MARK: - HUD Window Manager (Singleton)
 
+@MainActor
 class HUDWindowManager: ObservableObject {
     static let shared = HUDWindowManager()
 
@@ -26,11 +97,14 @@ class HUDWindowManager: ObservableObject {
     @Published var isVisible = false
     @Published var audioLevel: Float = 0.0  // Current audio level for waveform
     @Published var playbackProgress: Double?
+    @Published var conversation: HUDConversationPresentation?
 
     private var hideTimer: Timer?
     private var hudDuration: TimeInterval = 3.0
     private var isStarted = false
     private var visibilityHandler: ((Bool) -> Void)?
+    private var listeningObservation: AnyCancellable?
+    private var lastListeningPhase: ListeningPhase = .unlocked
 
     private init() {}
 
@@ -53,6 +127,27 @@ class HUDWindowManager: ObservableObject {
         // Don't actually stop - keep pipe reader running as singleton
         hideTimer?.invalidate()
         hideTimer = nil
+        listeningObservation = nil
+    }
+
+    func bindListening(_ controller: ListeningSessionController) {
+        guard listeningObservation == nil else { return }
+        listeningObservation = Publishers.CombineLatest4(
+            controller.$phase,
+            controller.$lockedTask,
+            controller.$lastTranscript,
+            controller.$lastError
+        )
+        .receive(on: RunLoop.main)
+        .sink { [weak self, weak controller] phase, lock, transcript, error in
+            self?.updateListening(
+                phase: phase,
+                lock: lock,
+                transcript: transcript,
+                error: error,
+                inputDeviceName: controller?.inputDeviceName
+            )
+        }
     }
 
     func setVisibilityHandler(_ handler: @escaping (Bool) -> Void) {
@@ -88,6 +183,44 @@ class HUDWindowManager: ObservableObject {
         scheduleHide()
     }
 
+    private func updateListening(
+        phase: ListeningPhase,
+        lock: ListeningTaskLock?,
+        transcript: String,
+        error: String?,
+        inputDeviceName: String?
+    ) {
+        defer { lastListeningPhase = phase }
+        guard let lock, phase != .unlocked else {
+            conversation = nil
+            if playbackProgress == nil { hideMessage() }
+            return
+        }
+
+        conversation = HUDConversationPresentation(
+            phase: phase,
+            taskTitle: lock.title,
+            taskID: lock.id,
+            transcript: transcript,
+            error: error,
+            inputDeviceName: inputDeviceName
+        )
+
+        hideTimer?.invalidate()
+        hideTimer = nil
+        showWindow()
+        switch phase {
+        case .ready:
+            if lastListeningPhase != .ready { scheduleHide(after: 2.8) }
+        case .failed:
+            scheduleHide(after: 8)
+        case .speaking:
+            break // Playback completion owns dismissal.
+        default:
+            break // Keep active work visible until the phase changes.
+        }
+    }
+
     private func handleMessage(_ message: HUDMessage) {
         if message.isLevelUpdate {
             // Just update audio level, don't reset timer
@@ -113,10 +246,10 @@ class HUDWindowManager: ObservableObject {
         visibilityHandler?(true)
     }
 
-    private func scheduleHide() {
+    private func scheduleHide(after duration: TimeInterval? = nil) {
         hideTimer?.invalidate()
-        hideTimer = Timer.scheduledTimer(withTimeInterval: hudDuration, repeats: false) { [weak self] _ in
-            self?.hideMessage()
+        hideTimer = Timer.scheduledTimer(withTimeInterval: duration ?? hudDuration, repeats: false) { [weak self] _ in
+            Task { @MainActor in self?.hideMessage() }
         }
     }
 
@@ -264,13 +397,28 @@ struct HUDOverlayView: View {
 
     var body: some View {
         Group {
-            if manager.isVisible, let message = manager.currentMessage {
-                HUDContent(
-                    message: message,
-                    theme: theme,
-                    audioLevel: manager.audioLevel,
-                    playbackProgress: manager.playbackProgress
-                )
+            if manager.isVisible {
+                Group {
+                    if let message = manager.currentMessage,
+                       manager.playbackProgress != nil {
+                        HUDContent(
+                            message: message,
+                            theme: theme,
+                            audioLevel: manager.audioLevel,
+                            playbackProgress: manager.playbackProgress,
+                            conversation: manager.conversation
+                        )
+                    } else if let conversation = manager.conversation {
+                        ConversationHUDContent(presentation: conversation)
+                    } else if let message = manager.currentMessage {
+                        HUDContent(
+                            message: message,
+                            theme: theme,
+                            audioLevel: manager.audioLevel,
+                            playbackProgress: manager.playbackProgress
+                        )
+                    }
+                }
                 .opacity(opacity)
                 .transition(.asymmetric(
                     insertion: .move(edge: entryEdge).combined(with: .opacity),
@@ -306,6 +454,7 @@ struct HUDContent: View {
     let theme: Theme
     let audioLevel: Float
     let playbackProgress: Double?
+    var conversation: HUDConversationPresentation? = nil
     @ObservedObject private var config = ConfigManager.shared
 
     private var waveformColor: Color {
@@ -348,6 +497,12 @@ struct HUDContent: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             VStack(spacing: 0) {
+                if let conversation {
+                    HUDTaskLockHeader(presentation: conversation)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 12)
+                }
+
                 // Text section at top
                 HUDTextSection(
                     text: message.text ?? "",
@@ -412,6 +567,175 @@ struct HUDContent: View {
                     .stroke(Color.white.opacity(0.1), lineWidth: 0.5)
             }
         )
+    }
+}
+
+// MARK: - Thread-locked conversation HUD
+
+struct ConversationHUDContent: View {
+    let presentation: HUDConversationPresentation
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: reduceMotion ? 1 : 1.0 / 24.0)) { timeline in
+            let time = timeline.date.timeIntervalSinceReferenceDate
+            ZStack(alignment: .topTrailing) {
+                VStack(alignment: .leading, spacing: 16) {
+                    HUDTaskLockHeader(presentation: presentation)
+
+                    HStack(spacing: 14) {
+                        ZStack {
+                            Circle()
+                                .fill(presentation.accent.opacity(0.12))
+                                .frame(width: 54, height: 54)
+                            Circle()
+                                .stroke(presentation.accent.opacity(0.34), lineWidth: 1)
+                                .frame(width: 54, height: 54)
+                                .scaleEffect(pulseScale(time))
+                                .opacity(pulseOpacity(time))
+                            Image(systemName: presentation.symbol)
+                                .font(.system(size: 21, weight: .semibold))
+                                .foregroundStyle(presentation.accent)
+                        }
+
+                        VStack(alignment: .leading, spacing: 5) {
+                            Text(presentation.title)
+                                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                                .foregroundStyle(.white)
+                            Text(presentation.detail)
+                                .font(.system(size: 11, weight: .medium, design: .rounded))
+                                .foregroundStyle(.white.opacity(0.58))
+                                .lineLimit(2)
+                        }
+                        Spacer(minLength: 8)
+                    }
+
+                    ConversationEnergyField(
+                        phase: presentation.phase,
+                        accent: presentation.accent,
+                        time: reduceMotion ? 0 : time
+                    )
+                    .frame(height: 24)
+                }
+                .padding(16)
+
+                Button { HUDWindowManager.shared.dismiss() } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.42))
+                        .frame(width: 22, height: 22)
+                        .background(.white.opacity(0.08), in: Circle())
+                }
+                .buttonStyle(.plain)
+                .padding(9)
+                .accessibilityLabel("Dismiss SpeakEasy conversation HUD")
+            }
+            .frame(width: 480, height: 180)
+            .background(conversationBackground)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("SpeakEasy \(presentation.title). Locked to \(presentation.taskTitle). \(presentation.detail)")
+        }
+    }
+
+    private var isEnergetic: Bool {
+        [.warmingUp, .recording, .transcribing, .submitting, .preparingSpeech, .speaking]
+            .contains(presentation.phase)
+    }
+
+    private func pulseScale(_ time: TimeInterval) -> CGFloat {
+        guard isEnergetic, !reduceMotion else { return 1 }
+        return 1 + CGFloat((sin(time * 4.2) + 1) * 0.045)
+    }
+
+    private func pulseOpacity(_ time: TimeInterval) -> Double {
+        guard isEnergetic, !reduceMotion else { return 1 }
+        return 0.42 + (sin(time * 4.2) + 1) * 0.18
+    }
+
+    private var conversationBackground: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(Color.black.opacity(0.9))
+            .overlay {
+                RadialGradient(
+                    colors: [presentation.accent.opacity(0.19), .clear],
+                    center: .topLeading,
+                    startRadius: 0,
+                    endRadius: 360
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(presentation.accent.opacity(0.32), lineWidth: 0.75)
+            }
+            .shadow(color: presentation.accent.opacity(0.14), radius: 24, y: 10)
+    }
+}
+
+struct HUDTaskLockHeader: View {
+    let presentation: HUDConversationPresentation
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(presentation.accent)
+                .frame(width: 6, height: 6)
+                .shadow(color: presentation.accent.opacity(0.8), radius: 4)
+                .accessibilityHidden(true)
+            Text(presentation.phase == .recording ? "LIVE" : presentation.phase.label.uppercased())
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundStyle(presentation.accent)
+            Spacer()
+            Image(systemName: "lock.fill")
+                .font(.system(size: 8, weight: .bold))
+            Text(presentation.taskTitle)
+                .lineLimit(1)
+            Text(String(presentation.taskID.prefix(8)))
+                .fontDesign(.monospaced)
+                .foregroundStyle(.white.opacity(0.34))
+        }
+        .font(.system(size: 10, weight: .semibold, design: .rounded))
+        .foregroundStyle(.white.opacity(0.68))
+        .padding(.trailing, 28)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(presentation.phase.label). Locked to \(presentation.taskTitle)")
+    }
+}
+
+struct ConversationEnergyField: View {
+    let phase: ListeningPhase
+    let accent: Color
+    let time: TimeInterval
+
+    private let count = 34
+
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(alignment: .center, spacing: 3) {
+                ForEach(0..<count, id: \.self) { index in
+                    Capsule()
+                        .fill(accent.opacity(opacity(for: index)))
+                        .frame(
+                            width: max(2, (geometry.size.width - CGFloat(count - 1) * 3) / CGFloat(count)),
+                            height: height(for: index)
+                        )
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func height(for index: Int) -> CGFloat {
+        guard phase != .ready && phase != .failed else { return index.isMultiple(of: 5) ? 4 : 2 }
+        let phaseOffset = Double(index) * 0.52
+        let primary = (sin(time * 5.2 + phaseOffset) + 1) * 0.5
+        let secondary = (sin(time * 2.3 - phaseOffset * 0.7) + 1) * 0.5
+        return 3 + CGFloat(primary * 13 + secondary * 5)
+    }
+
+    private func opacity(for index: Int) -> Double {
+        0.34 + (sin(time * 2.1 + Double(index) * 0.31) + 1) * 0.24
     }
 }
 

--- a/app/Sources/SpeakEasy/LaneCueStore.swift
+++ b/app/Sources/SpeakEasy/LaneCueStore.swift
@@ -87,12 +87,13 @@ actor LaneCueStore {
         configuration: SpeechNarrationConfiguration
     ) -> String {
         let identity = [
-            "cue-v3",
+            "cue-v4",
             lane.task.id,
             lane.task.title,
             configuration.provider,
             configuration.voice,
             configuration.model ?? "",
+            configuration.instructions ?? "",
             String(configuration.rate),
         ].joined(separator: "\u{1f}")
         let digest = SHA256.hash(data: Data(identity.utf8))

--- a/app/Sources/SpeakEasy/LaneCueStore.swift
+++ b/app/Sources/SpeakEasy/LaneCueStore.swift
@@ -1,0 +1,116 @@
+import CryptoKit
+import Foundation
+
+actor LaneCueStore {
+    private let narrator = ConfiguredResponseNarrator()
+    private let directory: URL
+
+    init(fileManager: FileManager = .default) {
+        let base = (try? fileManager.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fileManager.temporaryDirectory
+        directory = base.appendingPathComponent("SpeakEasy/LaneCues", isDirectory: true)
+    }
+
+    func cachedCue(
+        for lane: VoiceLane,
+        configuration: SpeechNarrationConfiguration
+    ) -> URL? {
+        let prefix = cachePrefix(for: lane, configuration: configuration)
+        return try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ).first { $0.lastPathComponent.hasPrefix(prefix + ".") }
+    }
+
+    @discardableResult
+    func prepare(
+        for lane: VoiceLane,
+        configuration: SpeechNarrationConfiguration
+    ) async throws -> URL {
+        if let cached = cachedCue(for: lane, configuration: configuration) { return cached }
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+
+        // The HUD already names the lane. Speaking only the compact task title
+        // keeps the select-to-microphone interval short and useful.
+        let cue = "\(lane.spokenTitle)."
+        let temporary = try await narrator.render(text: cue, configuration: configuration)
+        defer { try? FileManager.default.removeItem(at: temporary) }
+
+        let destination = directory
+            .appendingPathComponent(cachePrefix(for: lane, configuration: configuration))
+            .appendingPathExtension(temporary.pathExtension.isEmpty ? "audio" : temporary.pathExtension)
+        if !FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.copyItem(at: temporary, to: destination)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: destination.path
+            )
+        }
+        return destination
+    }
+
+    func play(_ url: URL, volume: Double) async throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/afplay")
+        process.arguments = [
+            "-v", String(max(0, min(volume, 1))),
+            "-r", "1.12",
+            "-q", "1",
+            url.path,
+        ]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw LaneCueError.playbackFailed(process.terminationStatus)
+        }
+    }
+
+    func removeCue(for lane: VoiceLane) {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        let lanePrefix = "lane-\(lane.number)-"
+        for file in files where file.lastPathComponent.hasPrefix(lanePrefix) {
+            try? FileManager.default.removeItem(at: file)
+        }
+    }
+
+    private func cachePrefix(
+        for lane: VoiceLane,
+        configuration: SpeechNarrationConfiguration
+    ) -> String {
+        let identity = [
+            "cue-v2",
+            lane.task.id,
+            lane.task.title,
+            configuration.provider,
+            configuration.voice,
+            configuration.model ?? "",
+            String(configuration.rate),
+        ].joined(separator: "\u{1f}")
+        let digest = SHA256.hash(data: Data(identity.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "lane-\(lane.number)-\(digest.prefix(16))"
+    }
+}
+
+enum LaneCueError: LocalizedError {
+    case playbackFailed(Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .playbackFailed(let status):
+            return "The lane announcement could not play (status \(status))."
+        }
+    }
+}

--- a/app/Sources/SpeakEasy/LaneCueStore.swift
+++ b/app/Sources/SpeakEasy/LaneCueStore.swift
@@ -38,9 +38,7 @@ actor LaneCueStore {
             attributes: [.posixPermissions: 0o700]
         )
 
-        // The HUD already names the lane. Speaking only the compact task title
-        // keeps the select-to-microphone interval short and useful.
-        let cue = "\(lane.spokenTitle)."
+        let cue = "Lane \(lane.number). \(lane.spokenTitle)."
         let temporary = try await narrator.render(text: cue, configuration: configuration)
         defer { try? FileManager.default.removeItem(at: temporary) }
 
@@ -89,7 +87,7 @@ actor LaneCueStore {
         configuration: SpeechNarrationConfiguration
     ) -> String {
         let identity = [
-            "cue-v2",
+            "cue-v3",
             lane.task.id,
             lane.task.title,
             configuration.provider,

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+struct ListeningPopoverSection: View {
+    @ObservedObject private var listening = ListeningSessionController.shared
+    @Environment(\.theme) private var theme
+
+    private let accent = Color(red: 0.36, green: 0.87, blue: 0.66)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label("Conversation", systemImage: listening.phase == .recording ? "mic.fill" : "mic")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(listening.phase == .recording ? .red : theme.text)
+                Spacer()
+                Text(listening.phase.label)
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+                    .foregroundColor(stateColor)
+            }
+
+            if let lock = listening.lockedTask {
+                lockedTask(lock)
+            } else {
+                taskPicker
+            }
+
+            if let error = listening.lastError {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityLabel("Listening error: \(error)")
+            } else if !listening.lastTranscript.isEmpty {
+                Text("“\(listening.lastTranscript)”")
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.textTertiary)
+                    .lineLimit(2)
+                    .accessibilityLabel("Last transcript: \(listening.lastTranscript)")
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(theme.text.opacity(0.04))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(listening.phase == .recording ? Color.red.opacity(0.55) : theme.text.opacity(0.09), lineWidth: 1)
+                )
+        )
+        .padding(.horizontal, 14)
+        .padding(.bottom, 10)
+    }
+
+    private func lockedTask(_ lock: ListeningTaskLock) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 7) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(accent)
+                Text(lock.title)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.textSecondary)
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                Button("Unlock") { listening.unlock() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.textTertiary)
+                    .disabled(isBusy)
+            }
+
+            Button(action: listening.toggleListening) {
+                HStack(spacing: 7) {
+                    Image(systemName: listening.phase == .recording ? "stop.fill" : "mic.fill")
+                    Text(buttonLabel)
+                    Spacer()
+                    Text(ListeningSessionController.shortcutTitle)
+                        .font(.system(size: 10, design: .rounded))
+                        .opacity(0.75)
+                }
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(listening.phase == .recording ? .white : .black.opacity(0.78))
+                .padding(.horizontal, 10)
+                .frame(height: 30)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(listening.phase == .recording ? Color.red : accent)
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(!listening.phase.acceptsHotkey)
+            .opacity(listening.phase.acceptsHotkey ? 1 : 0.55)
+            .accessibilityLabel(buttonLabel)
+            .accessibilityHint("Global shortcut \(ListeningSessionController.shortcutTitle)")
+
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(listening.shortcutAvailable ? Color.green : Color.orange)
+                    .frame(width: 5, height: 5)
+                    .accessibilityHidden(true)
+                Text(listening.shortcutAvailable ? "Global shortcut active" : "Shortcut unavailable")
+                if let device = listening.inputDeviceName, listening.phase == .recording {
+                    Text("· \(device)")
+                }
+            }
+            .font(.system(size: 9))
+            .foregroundColor(theme.textTertiary)
+            .accessibilityElement(children: .combine)
+        }
+    }
+
+    private var taskPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Codex task", selection: $listening.selectedTaskID) {
+                if listening.tasks.isEmpty {
+                    Text("No recent tasks found").tag("")
+                }
+                ForEach(listening.tasks) { task in
+                    Text(task.title).tag(task.id)
+                }
+            }
+            .labelsHidden()
+            .frame(maxWidth: .infinity)
+
+            HStack {
+                Button("Refresh") { listening.refreshTasks() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.textTertiary)
+                Spacer()
+                Button("Lock task") { listening.lockSelectedTask() }
+                    .disabled(listening.selectedTaskID.isEmpty)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Choose a Codex task to lock for voice conversation")
+    }
+
+    private var isBusy: Bool {
+        switch listening.phase {
+        case .validatingLock, .warmingUp, .transcribing, .submitting, .preparingSpeech, .speaking: true
+        default: false
+        }
+    }
+
+    private var buttonLabel: String {
+        switch listening.phase {
+        case .recording: "Stop and send"
+        case .ready, .failed: "Start listening"
+        case .speaking: "Interrupt and listen"
+        default: listening.phase.label
+        }
+    }
+
+    private var stateColor: Color {
+        switch listening.phase {
+        case .recording: .red
+        case .failed: .orange
+        case .unlocked: theme.textTertiary
+        default: accent
+        }
+    }
+}

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -69,6 +69,11 @@ struct ListeningPopoverSection: View {
                     .disabled(isBusy)
             }
 
+            Text("Voice stays routed to this task—even when you change apps or Codex windows.")
+                .font(.system(size: 9))
+                .foregroundStyle(theme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
             Button(action: listening.toggleListening) {
                 HStack(spacing: 7) {
                     Image(systemName: listening.phase == .recording ? "stop.fill" : "mic.fill")
@@ -111,6 +116,11 @@ struct ListeningPopoverSection: View {
 
     private var taskPicker: some View {
         VStack(alignment: .leading, spacing: 8) {
+            Text("Choose a task. SpeakEasy opens it in Codex and verifies the exact lock before listening.")
+                .font(.system(size: 9))
+                .foregroundStyle(theme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
             Picker("Codex task", selection: $listening.selectedTaskID) {
                 if listening.tasks.isEmpty {
                     Text("No recent tasks found").tag("")

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -129,6 +129,22 @@ struct ListeningPopoverSection: View {
             }
 
             HStack(spacing: 5) {
+                Circle()
+                    .fill(listening.confirmationShortcutAvailable ? Color.green : Color.orange)
+                    .frame(width: 5, height: 5)
+                    .accessibilityHidden(true)
+                Text("⌘⌥X says the active lane on demand")
+                    .font(.system(size: 8, design: .rounded))
+                    .foregroundColor(theme.textTertiary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                listening.confirmationShortcutAvailable
+                    ? "Command Option X announces the active lane"
+                    : "Command Option X confirmation shortcut unavailable"
+            )
+
+            HStack(spacing: 5) {
                 ForEach(ListeningSessionController.laneRange, id: \.self) { number in
                     let assignment = listening.lane(number)
                     let isCurrent = assignment?.task.id == currentTask.id

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct ListeningPopoverSection: View {
     @ObservedObject private var listening = ListeningSessionController.shared
+    @ObservedObject private var config = ConfigManager.shared
     @Environment(\.theme) private var theme
+    @State private var laneVoiceDraft = ""
 
     private let accent = Color(red: 0.36, green: 0.87, blue: 0.66)
 
@@ -199,6 +201,7 @@ struct ListeningPopoverSection: View {
                     .font(.system(size: 9, weight: .medium))
                     .foregroundColor(theme.textTertiary)
                     .lineLimit(1)
+                laneVoiceEditor(for: assignment)
             } else {
                 Text("Tap an empty lane to assign this exact task.")
                     .font(.system(size: 9))
@@ -207,6 +210,99 @@ struct ListeningPopoverSection: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Exact task voice lanes")
+        .onAppear(perform: synchronizeVoiceDraft)
+        .onChange(of: listening.activeLaneNumber) { synchronizeVoiceDraft() }
+        .onChange(of: config.defaultProvider) { synchronizeVoiceDraft() }
+    }
+
+    private func laneVoiceEditor(for assignment: VoiceLane) -> some View {
+        HStack(spacing: 5) {
+            Text(config.defaultProvider.uppercased())
+                .font(.system(size: 7, weight: .bold, design: .monospaced))
+                .foregroundColor(theme.textTertiary)
+
+            TextField("Inherit \(globalVoiceID)", text: $laneVoiceDraft)
+                .textFieldStyle(.plain)
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundColor(theme.textSecondary)
+                .padding(.horizontal, 6)
+                .frame(height: 22)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(theme.text.opacity(0.045))
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .stroke(theme.text.opacity(0.09), lineWidth: 0.75)
+                }
+                .onSubmit { saveVoiceDraft(for: assignment.number) }
+                .accessibilityLabel("Voice ID for lane \(assignment.number)")
+                .accessibilityHint("Leave empty to inherit \(globalVoiceID) from the global \(config.defaultProvider) provider")
+
+            Button {
+                saveVoiceDraft(for: assignment.number)
+            } label: {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(accent)
+            .disabled(isBusy)
+            .help("Save voice for lane \(assignment.number)")
+            .accessibilityLabel("Save lane voice")
+
+            if assignment.voiceOverride != nil {
+                Button {
+                    laneVoiceDraft = ""
+                    listening.setVoiceOverride(
+                        provider: config.defaultProvider,
+                        voiceID: "",
+                        forLane: assignment.number
+                    )
+                } label: {
+                    Image(systemName: "arrow.uturn.backward")
+                        .font(.system(size: 8, weight: .semibold))
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(theme.textTertiary)
+                .disabled(isBusy)
+                .help("Inherit the global \(config.defaultProvider) voice")
+                .accessibilityLabel("Reset lane voice to the global provider default")
+            }
+        }
+    }
+
+    private var globalVoiceID: String {
+        switch config.defaultProvider {
+        case "openai": config.openaiVoice
+        case "elevenlabs": config.elevenlabsVoiceId
+        case "groq": config.groqVoice
+        case "gemini": "Puck"
+        case "system": config.systemVoice
+        default: "provider default"
+        }
+    }
+
+    private func synchronizeVoiceDraft() {
+        guard let active = listening.activeLaneNumber,
+              let assignment = listening.lane(active),
+              assignment.voiceOverride?.provider == config.defaultProvider.lowercased()
+        else {
+            laneVoiceDraft = ""
+            return
+        }
+        laneVoiceDraft = assignment.voiceOverride?.voiceID ?? ""
+    }
+
+    private func saveVoiceDraft(for laneNumber: Int) {
+        listening.setVoiceOverride(
+            provider: config.defaultProvider,
+            voiceID: laneVoiceDraft,
+            forLane: laneNumber
+        )
+        synchronizeVoiceDraft()
     }
 
     private func laneHelp(

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -5,6 +5,7 @@ struct ListeningPopoverSection: View {
     @ObservedObject private var config = ConfigManager.shared
     @Environment(\.theme) private var theme
     @State private var laneVoiceDraft = ""
+    @State private var laneCueDraft = ""
 
     private let accent = Color(red: 0.36, green: 0.87, blue: 0.66)
 
@@ -33,11 +34,19 @@ struct ListeningPopoverSection: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityLabel("Listening error: \(error)")
             } else if !listening.lastTranscript.isEmpty {
-                Text("“\(listening.lastTranscript)”")
-                    .font(.system(size: 10))
-                    .foregroundColor(theme.textTertiary)
-                    .lineLimit(2)
-                    .accessibilityLabel("Last transcript: \(listening.lastTranscript)")
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("“\(listening.lastTranscript)”")
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.textTertiary)
+                        .lineLimit(2)
+                        .accessibilityLabel("Last transcript: \(listening.lastTranscript)")
+                    if let delivery = listening.lastDelivery {
+                        Label(delivery.label, systemImage: delivery == .steeredActiveTurn ? "arrow.triangle.turn.up.right.diamond.fill" : "plus.bubble.fill")
+                            .font(.system(size: 8, weight: .medium))
+                            .foregroundColor(accent.opacity(0.82))
+                            .accessibilityLabel(delivery.label)
+                    }
+                }
             }
         }
         .padding(12)
@@ -138,6 +147,18 @@ struct ListeningPopoverSection: View {
                 Text("⌘⌥X says the active lane on demand")
                     .font(.system(size: 8, design: .rounded))
                     .foregroundColor(theme.textTertiary)
+                Spacer()
+                Button {
+                    listening.confirmActiveLane()
+                } label: {
+                    Image(systemName: "speaker.wave.2.fill")
+                        .font(.system(size: 8, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(accent)
+                .disabled(isBusy || listening.activeLaneNumber == nil)
+                .help("Play the active lane cue")
+                .accessibilityLabel("Play active lane cue")
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel(
@@ -202,6 +223,7 @@ struct ListeningPopoverSection: View {
                     .foregroundColor(theme.textTertiary)
                     .lineLimit(1)
                 laneVoiceEditor(for: assignment)
+                laneNarrationCueEditor(for: assignment)
             } else {
                 Text("Tap an empty lane to assign this exact task.")
                     .font(.system(size: 9))
@@ -274,6 +296,66 @@ struct ListeningPopoverSection: View {
         }
     }
 
+    private func laneNarrationCueEditor(for assignment: VoiceLane) -> some View {
+        HStack(spacing: 5) {
+            Text("CUE")
+                .font(.system(size: 7, weight: .bold, design: .monospaced))
+                .foregroundColor(theme.textTertiary)
+                .frame(width: 31, alignment: .leading)
+
+            TextField(
+                providerSupportsNarrationCue ? "Warm, concise, energized…" : "OpenAI voices only",
+                text: $laneCueDraft
+            )
+            .textFieldStyle(.plain)
+            .font(.system(size: 9))
+            .foregroundColor(theme.textSecondary)
+            .padding(.horizontal, 6)
+            .frame(height: 22)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(theme.text.opacity(0.045))
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .stroke(theme.text.opacity(0.09), lineWidth: 0.75)
+            }
+            .disabled(!providerSupportsNarrationCue || isBusy)
+            .onSubmit { saveNarrationCue(for: assignment.number) }
+            .accessibilityLabel("Narration cue for lane \(assignment.number)")
+            .accessibilityHint("A short speaking-style instruction for OpenAI narration")
+
+            Button {
+                saveNarrationCue(for: assignment.number)
+            } label: {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(accent)
+            .disabled(!providerSupportsNarrationCue || isBusy)
+            .help("Save narration cue for lane \(assignment.number)")
+            .accessibilityLabel("Save lane narration cue")
+
+            if assignment.narrationCue != nil {
+                Button {
+                    laneCueDraft = ""
+                    listening.setNarrationCue("", forLane: assignment.number)
+                } label: {
+                    Image(systemName: "arrow.uturn.backward")
+                        .font(.system(size: 8, weight: .semibold))
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(theme.textTertiary)
+                .disabled(isBusy)
+                .help("Clear the lane narration cue")
+                .accessibilityLabel("Clear lane narration cue")
+            }
+        }
+    }
+
     private var globalVoiceID: String {
         switch config.defaultProvider {
         case "openai": config.openaiVoice
@@ -285,15 +367,22 @@ struct ListeningPopoverSection: View {
         }
     }
 
+    private var providerSupportsNarrationCue: Bool {
+        config.defaultProvider == "openai"
+    }
+
     private func synchronizeVoiceDraft() {
         guard let active = listening.activeLaneNumber,
               let assignment = listening.lane(active),
               assignment.voiceOverride?.provider == config.defaultProvider.lowercased()
         else {
             laneVoiceDraft = ""
+            laneCueDraft = listening.activeLaneNumber
+                .flatMap { listening.lane($0)?.narrationCue } ?? ""
             return
         }
         laneVoiceDraft = assignment.voiceOverride?.voiceID ?? ""
+        laneCueDraft = assignment.narrationCue ?? ""
     }
 
     private func saveVoiceDraft(for laneNumber: Int) {
@@ -302,6 +391,11 @@ struct ListeningPopoverSection: View {
             voiceID: laneVoiceDraft,
             forLane: laneNumber
         )
+        synchronizeVoiceDraft()
+    }
+
+    private func saveNarrationCue(for laneNumber: Int) {
+        listening.setNarrationCue(laneCueDraft, forLane: laneNumber)
         synchronizeVoiceDraft()
     }
 

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -74,6 +74,8 @@ struct ListeningPopoverSection: View {
                 .foregroundStyle(theme.textTertiary)
                 .fixedSize(horizontal: false, vertical: true)
 
+            laneStrip(currentTask: lock)
+
             Button(action: listening.toggleListening) {
                 HStack(spacing: 7) {
                     Image(systemName: listening.phase == .recording ? "stop.fill" : "mic.fill")
@@ -114,6 +116,96 @@ struct ListeningPopoverSection: View {
         }
     }
 
+    private func laneStrip(currentTask: ListeningTaskLock) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("VOICE LANES")
+                    .font(.system(size: 8, weight: .bold, design: .monospaced))
+                    .foregroundColor(theme.textTertiary)
+                Spacer()
+                Text("⌘⌥1–9 selects + listens")
+                    .font(.system(size: 8, design: .rounded))
+                    .foregroundColor(theme.textTertiary)
+            }
+
+            HStack(spacing: 5) {
+                ForEach(ListeningSessionController.laneRange, id: \.self) { number in
+                    let assignment = listening.lane(number)
+                    let isCurrent = assignment?.task.id == currentTask.id
+                    Button {
+                        if assignment == nil {
+                            listening.assignLockedTask(toLane: number)
+                        } else {
+                            listening.activateLane(number)
+                        }
+                    } label: {
+                        ZStack(alignment: .topTrailing) {
+                            Text("\(number)")
+                                .font(.system(size: 10, weight: .bold, design: .rounded))
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            Circle()
+                                .fill(listening.laneShortcutAvailable(number) ? Color.green : Color.orange)
+                                .frame(width: 4, height: 4)
+                                .padding(3)
+                                .accessibilityHidden(true)
+                        }
+                        .frame(width: 25, height: 25)
+                        .foregroundStyle(
+                            isCurrent ? Color.black.opacity(0.78) : (assignment == nil ? theme.textSecondary : accent)
+                        )
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(isCurrent ? accent : (assignment == nil ? theme.text.opacity(0.035) : accent.opacity(0.14)))
+                        )
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .stroke(
+                                    listening.activeLaneNumber == number ? accent : theme.text.opacity(0.08),
+                                    lineWidth: listening.activeLaneNumber == number ? 1.5 : 0.75
+                                )
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isBusy)
+                    .help(laneHelp(number: number, assignment: assignment, currentTask: currentTask))
+                    .contextMenu {
+                        Button("Assign current task") { listening.assignLockedTask(toLane: number) }
+                        if assignment != nil {
+                            Button("Clear lane") { listening.removeLane(number) }
+                        }
+                    }
+                    .accessibilityLabel(laneHelp(number: number, assignment: assignment, currentTask: currentTask))
+                }
+            }
+
+            if let active = listening.activeLaneNumber, let assignment = listening.lane(active) {
+                Text("Lane \(active): \(assignment.task.title)")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundColor(theme.textTertiary)
+                    .lineLimit(1)
+            } else {
+                Text("Tap an empty lane to assign this exact task.")
+                    .font(.system(size: 9))
+                    .foregroundColor(theme.textTertiary)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Exact task voice lanes")
+    }
+
+    private func laneHelp(
+        number: Int,
+        assignment: VoiceLane?,
+        currentTask: ListeningTaskLock
+    ) -> String {
+        let shortcut = GlobalListeningShortcut.title(forLane: number)
+        let availability = listening.laneShortcutAvailable(number) ? "shortcut active" : "shortcut unavailable"
+        guard let assignment else {
+            return "Lane \(number), unassigned. Tap to assign \(currentTask.title). \(shortcut), \(availability)."
+        }
+        return "Lane \(number), \(assignment.task.title). \(shortcut), \(availability)."
+    }
+
     private var taskPicker: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Choose a task. SpeakEasy opens it in Codex and verifies the exact lock before listening.")
@@ -148,7 +240,7 @@ struct ListeningPopoverSection: View {
 
     private var isBusy: Bool {
         switch listening.phase {
-        case .validatingLock, .warmingUp, .transcribing, .submitting, .preparingSpeech, .speaking: true
+        case .validatingLock, .cueing, .warmingUp, .transcribing, .submitting, .preparingSpeech, .speaking: true
         default: false
         }
     }

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -6,6 +6,7 @@ import VoxCore
 enum ListeningPhase: String, Sendable {
     case unlocked
     case validatingLock
+    case cueing
     case ready
     case warmingUp
     case recording
@@ -19,8 +20,9 @@ enum ListeningPhase: String, Sendable {
         switch self {
         case .unlocked: "Choose a task"
         case .validatingLock: "Checking task"
+        case .cueing: "Announcing lane"
         case .ready: "Ready"
-        case .warmingUp: "Preparing speech recognition"
+        case .warmingUp: "Opening microphone"
         case .recording: "Listening"
         case .transcribing: "Transcribing"
         case .submitting: "Waiting for Codex"
@@ -45,12 +47,16 @@ struct ListeningTaskLock: Codable, Equatable, Sendable {
 final class ListeningSessionController: ObservableObject {
     static let shared = ListeningSessionController()
     static let shortcutTitle = GlobalListeningShortcut.title
+    static let laneRange = GlobalListeningShortcut.laneRange
 
     @Published private(set) var phase: ListeningPhase = .unlocked
     @Published private(set) var tasks: [CodexTaskSummary] = []
     @Published var selectedTaskID = ""
     @Published private(set) var lockedTask: ListeningTaskLock?
+    @Published private(set) var lanes: [VoiceLane] = []
+    @Published private(set) var activeLaneNumber: Int?
     @Published private(set) var shortcutAvailable = false
+    @Published private(set) var laneShortcutAvailability: [Int: Bool] = [:]
     @Published private(set) var inputDeviceName: String?
     @Published private(set) var lastTranscript = ""
     @Published private(set) var lastResponse = ""
@@ -59,17 +65,24 @@ final class ListeningSessionController: ObservableObject {
     private let vox = VoxListeningService()
     private let router = CodexThreadRouter()
     private let narrator = ConfiguredResponseNarrator()
+    private let laneCueStore = LaneCueStore()
     private let lockDefaultsKey = "speakeasy.listening.task-lock.v1"
+    private let lanesDefaultsKey = "speakeasy.listening.voice-lanes.v1"
+    private let activeLaneDefaultsKey = "speakeasy.listening.active-lane.v1"
     private var shortcut: GlobalListeningShortcut?
     private var maxRecordingTimer: Timer?
     private var playbackObservation: AnyCancellable?
     private var fixtureHasRun = false
+    private var launchHotkeyHasRun = false
+    private var launchLaneHasRun = false
     private var restoredLockCandidate: ListeningTaskLock?
     private var pendingNarrationItemID: UUID?
     private var narrationDidStart = false
+    private var validationID: UUID?
+    private var recordingStartID: UUID?
 
     private init() {
-        restoreLock()
+        restoreState()
         playbackObservation = PlaybackEngine.shared.$state
             .receive(on: RunLoop.main)
             .sink { [weak self] state in
@@ -89,12 +102,17 @@ final class ListeningSessionController: ObservableObject {
     func start() {
         diagnostic("starting listening controller")
         if shortcut == nil {
-            let shortcut = GlobalListeningShortcut { [weak self] in self?.toggleListening() }
+            let shortcut = GlobalListeningShortcut { [weak self] action in
+                self?.handleShortcut(action)
+            }
             self.shortcut = shortcut
-            shortcutAvailable = shortcut.register()
+            shortcutAvailable = shortcut.registerCurrentLane()
+            laneShortcutAvailability = shortcut.registerLanes()
             diagnostic(shortcutAvailable
                 ? "global shortcut \(Self.shortcutTitle) registered"
                 : "global shortcut \(Self.shortcutTitle) unavailable")
+            let registered = laneShortcutAvailability.filter(\.value).keys.sorted()
+            diagnostic("lane shortcuts registered: \(registered.map(String.init).joined(separator: ","))")
         }
         refreshTasks()
     }
@@ -102,9 +120,12 @@ final class ListeningSessionController: ObservableObject {
     func stop() {
         maxRecordingTimer?.invalidate()
         maxRecordingTimer = nil
-        shortcut?.unregister()
+        recordingStartID = nil
+        validationID = nil
+        shortcut?.unregisterAll()
         shortcut = nil
         shortcutAvailable = false
+        laneShortcutAvailability = [:]
         Task {
             await vox.cancelRecording()
             await router.shutdown()
@@ -126,6 +147,7 @@ final class ListeningSessionController: ObservableObject {
                 }
                 runLaunchFixtureIfPresent()
                 runLaunchHotkeyTestIfPresent()
+                runLaunchLaneTestIfPresent()
             } catch {
                 recordFailure(error)
             }
@@ -138,35 +160,69 @@ final class ListeningSessionController: ObservableObject {
     }
 
     func lock(_ task: CodexTaskSummary) {
-        if lockedTask?.id != task.id {
-            lockedTask = nil
-            UserDefaults.standard.removeObject(forKey: lockDefaultsKey)
+        validateAndLock(taskID: task.id, expectedLane: nil, beginAfterLock: false)
+    }
+
+    func assignLockedTask(toLane number: Int) {
+        guard Self.laneRange.contains(number), let lock = lockedTask else { return }
+        if let previous = lane(number) {
+            Task { await laneCueStore.removeCue(for: previous) }
         }
-        selectedTaskID = task.id
-        phase = .validatingLock
-        lastError = nil
-        openCodexTask(task.id)
-        Task {
-            do {
-                let validated = try await router.validateTask(task.id)
-                guard selectedTaskID == task.id else { return }
-                let lock = ListeningTaskLock(
-                    id: validated.id,
-                    title: validated.title,
-                    cwd: validated.cwd
-                )
-                lockedTask = lock
-                phase = .ready
-                if let data = try? JSONEncoder().encode(lock) {
-                    UserDefaults.standard.set(data, forKey: lockDefaultsKey)
-                }
-                diagnostic("locked to Desktop-owned Codex task \(task.id)")
-                runLaunchFixtureIfPresent()
-                runLaunchHotkeyTestIfPresent()
-            } catch {
-                recordFailure(error)
+        let assignment = VoiceLane(number: number, task: lock)
+        lanes.removeAll { $0.number == number }
+        lanes.append(assignment)
+        lanes.sort { $0.number < $1.number }
+        activeLaneNumber = number
+        UserDefaults.standard.set(number, forKey: activeLaneDefaultsKey)
+        persistLanes()
+        diagnostic("lane \(number) assigned to task \(lock.id)")
+        prepareCue(for: assignment)
+    }
+
+    func removeLane(_ number: Int) {
+        guard let assignment = lane(number) else { return }
+        lanes.removeAll { $0.number == number }
+        if activeLaneNumber == number {
+            activeLaneNumber = nil
+            UserDefaults.standard.removeObject(forKey: activeLaneDefaultsKey)
+        }
+        persistLanes()
+        Task { await laneCueStore.removeCue(for: assignment) }
+        diagnostic("lane \(number) removed")
+    }
+
+    func activateLane(_ number: Int, beginListening: Bool = false) {
+        guard let assignment = lane(number) else {
+            lastError = "Lane \(number) is not assigned yet. Lock a task, then assign it from SpeakEasy."
+            if lockedTask != nil { phase = .failed }
+            NSSound.beep()
+            return
+        }
+        guard !isRoutingTurn else {
+            lastError = "Finish the current voice turn before switching lanes."
+            NSSound.beep()
+            return
+        }
+        if phase == .recording {
+            if activeLaneNumber == number { finishRecording() }
+            else {
+                lastError = "Finish or cancel this utterance before switching lanes."
+                NSSound.beep()
             }
+            return
         }
+        if phase == .speaking { PlaybackEngine.shared.stop() }
+        activeLaneNumber = number
+        UserDefaults.standard.set(number, forKey: activeLaneDefaultsKey)
+        // Keep the destination visible in the HUD while its exact Desktop
+        // ownership is revalidated. No recording or submission is permitted
+        // during this phase.
+        lockedTask = assignment.task
+        validateAndLock(
+            taskID: assignment.task.id,
+            expectedLane: number,
+            beginAfterLock: beginListening
+        )
     }
 
     func unlock() {
@@ -174,9 +230,12 @@ final class ListeningSessionController: ObservableObject {
             cancelRecording()
             return
         }
-        guard phase != .submitting, phase != .preparingSpeech else { return }
+        guard !isRoutingTurn, phase != .cueing, phase != .warmingUp else { return }
         if phase == .speaking { PlaybackEngine.shared.stop() }
+        validationID = nil
         lockedTask = nil
+        activeLaneNumber = nil
+        UserDefaults.standard.removeObject(forKey: activeLaneDefaultsKey)
         phase = .unlocked
         lastError = nil
         UserDefaults.standard.removeObject(forKey: lockDefaultsKey)
@@ -187,10 +246,10 @@ final class ListeningSessionController: ObservableObject {
         case .recording:
             finishRecording()
         case .ready, .failed:
-            beginRecording()
+            beginRecording(cueFor: nil)
         case .speaking:
             PlaybackEngine.shared.stop()
-            beginRecording()
+            beginRecording(cueFor: nil)
         default:
             NSSound.beep()
         }
@@ -200,6 +259,7 @@ final class ListeningSessionController: ObservableObject {
         guard phase == .recording || phase == .warmingUp else { return }
         maxRecordingTimer?.invalidate()
         maxRecordingTimer = nil
+        recordingStartID = nil
         Task {
             await vox.cancelRecording()
             phase = lockedTask == nil ? .unlocked : .ready
@@ -207,8 +267,115 @@ final class ListeningSessionController: ObservableObject {
         }
     }
 
-    private func beginRecording() {
-        guard lockedTask != nil else {
+    func lane(_ number: Int) -> VoiceLane? {
+        lanes.first { $0.number == number }
+    }
+
+    func laneShortcutAvailable(_ number: Int) -> Bool {
+        laneShortcutAvailability[number] == true
+    }
+
+    #if DEBUG
+    func installLaneSnapshotFixture() {
+        let task = ListeningTaskLock(
+            id: "019f99a4-7867-7c23-ac29-0c0eca7da603",
+            title: "Prototype SpeakEasy listening mode",
+            cwd: "/Users/arach/dev/SpeakEasy"
+        )
+        let secondTask = ListeningTaskLock(
+            id: "019f9573-3e55-7701-8968-09c12d4fafe5",
+            title: "Polish the Scout relay",
+            cwd: "/Users/arach/dev/openscout"
+        )
+        lockedTask = task
+        lanes = [VoiceLane(number: 2, task: task), VoiceLane(number: 5, task: secondTask)]
+        activeLaneNumber = 2
+        shortcutAvailable = true
+        laneShortcutAvailability = Dictionary(
+            uniqueKeysWithValues: Self.laneRange.map { ($0, $0 != 4) }
+        )
+        phase = .ready
+    }
+    #endif
+
+    private var isRoutingTurn: Bool {
+        [.transcribing, .submitting, .preparingSpeech].contains(phase)
+    }
+
+    private func handleShortcut(_ action: ListeningShortcutAction) {
+        switch action {
+        case .toggleCurrentLane:
+            toggleListening()
+        case .selectLane(let number):
+            activateLane(number, beginListening: true)
+        }
+    }
+
+    private func validateAndLock(
+        taskID: String,
+        expectedLane: Int?,
+        beginAfterLock: Bool
+    ) {
+        if lockedTask?.id != taskID {
+            lockedTask = nil
+            UserDefaults.standard.removeObject(forKey: lockDefaultsKey)
+        }
+        selectedTaskID = taskID
+        phase = .validatingLock
+        lastError = nil
+        openCodexTask(taskID)
+        let requestID = UUID()
+        validationID = requestID
+        Task {
+            do {
+                let validated = try await router.validateTask(taskID)
+                guard validationID == requestID, selectedTaskID == taskID else { return }
+                if let expectedLane,
+                   lane(expectedLane)?.task.id != validated.id {
+                    throw ListeningLoopError.laneAssignmentChanged
+                }
+                let lock = ListeningTaskLock(
+                    id: validated.id,
+                    title: validated.title,
+                    cwd: validated.cwd
+                )
+                lockedTask = lock
+                if let expectedLane {
+                    activeLaneNumber = expectedLane
+                    UserDefaults.standard.set(expectedLane, forKey: activeLaneDefaultsKey)
+                    let refreshed = VoiceLane(number: expectedLane, task: lock)
+                    lanes.removeAll { $0.number == expectedLane }
+                    lanes.append(refreshed)
+                    lanes.sort { $0.number < $1.number }
+                    persistLanes()
+                }
+                else {
+                    activeLaneNumber = lanes.first(where: { $0.task.id == lock.id })?.number
+                    if let activeLaneNumber {
+                        UserDefaults.standard.set(activeLaneNumber, forKey: activeLaneDefaultsKey)
+                    } else {
+                        UserDefaults.standard.removeObject(forKey: activeLaneDefaultsKey)
+                    }
+                }
+                persistLock(lock)
+                phase = .ready
+                diagnostic("locked to Desktop-owned Codex task \(taskID)")
+                applyLaunchLaneAssignmentIfPresent()
+                runLaunchFixtureIfPresent()
+                runLaunchHotkeyTestIfPresent()
+                runLaunchLaneTestIfPresent()
+                if beginAfterLock {
+                    beginRecording(cueFor: expectedLane.flatMap(lane))
+                }
+            } catch {
+                guard validationID == requestID else { return }
+                recordFailure(error)
+            }
+        }
+    }
+
+    private func beginRecording(cueFor lane: VoiceLane?) {
+        guard let lock = lockedTask else {
             phase = .unlocked
             NSSound.beep()
             return
@@ -217,24 +384,49 @@ final class ListeningSessionController: ObservableObject {
         lastError = nil
         lastTranscript = ""
         lastResponse = ""
-        phase = .warmingUp
-
-        // Half duplex: stop narration before opening the microphone, so the
-        // app cannot transcribe its own output.
         PlaybackEngine.shared.stop()
+        let startID = UUID()
+        recordingStartID = startID
+        let narration = narrationConfiguration(from: ConfigManager.shared)
+        let volume = ConfigManager.shared.defaultVolume
+
         Task {
+            if let lane {
+                if let cached = await laneCueStore.cachedCue(for: lane, configuration: narration) {
+                    phase = .cueing
+                    diagnostic("playing cached lane \(lane.number) cue before microphone")
+                    do { try await laneCueStore.play(cached, volume: volume) }
+                    catch { diagnostic("lane cue skipped: \(error.localizedDescription)") }
+                } else {
+                    prepareCue(for: lane)
+                }
+            }
+            guard recordingStartID == startID, lockedTask?.id == lock.id else { return }
+            phase = .warmingUp
             do {
-                try await vox.warmUp()
-                guard phase == .warmingUp else { return }
-                let device = try await vox.startRecording()
+                // Vox starts capture before it warms the model. Natural speech
+                // at hotkey-down is retained while recognition becomes ready.
+                let device = try await vox.startRecordingAndWarm()
+                guard recordingStartID == startID, lockedTask?.id == lock.id else {
+                    await vox.cancelRecording()
+                    return
+                }
                 inputDeviceName = device.name
                 phase = .recording
-                diagnostic("microphone active (\(device.name))")
+                diagnostic("microphone active (\(device.name)); Vox warming concurrently")
                 maxRecordingTimer?.invalidate()
                 maxRecordingTimer = Timer.scheduledTimer(withTimeInterval: 120, repeats: false) { [weak self] _ in
                     Task { @MainActor in self?.finishRecording() }
                 }
+                if let rawDelay = ProcessInfo.processInfo.environment["SPEAKEASY_CANCEL_RECORDING_AFTER_SECONDS"],
+                   let delay = TimeInterval(rawDelay), delay > 0 {
+                    diagnostic("launch validation will cancel recording after \(delay) seconds")
+                    Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+                        Task { @MainActor in self?.cancelRecording() }
+                    }
+                }
             } catch {
+                guard recordingStartID == startID else { return }
                 recordFailure(error)
             }
         }
@@ -244,6 +436,7 @@ final class ListeningSessionController: ObservableObject {
         guard phase == .recording, let lock = lockedTask else { return }
         maxRecordingTimer?.invalidate()
         maxRecordingTimer = nil
+        recordingStartID = nil
         phase = .transcribing
         Task {
             do {
@@ -296,13 +489,35 @@ final class ListeningSessionController: ObservableObject {
         diagnostic("response queued with \(narration.provider) narration from task \(lock.id)")
     }
 
-    private func restoreLock() {
+    private func restoreState() {
+        if let data = UserDefaults.standard.data(forKey: lanesDefaultsKey),
+           let restored = try? JSONDecoder().decode([VoiceLane].self, from: data) {
+            lanes = restored
+                .filter { Self.laneRange.contains($0.number) }
+                .sorted { $0.number < $1.number }
+        }
         guard let data = UserDefaults.standard.data(forKey: lockDefaultsKey),
               let lock = try? JSONDecoder().decode(ListeningTaskLock.self, from: data)
         else { return }
         restoredLockCandidate = lock
         selectedTaskID = lock.id
+        let persistedLane = UserDefaults.standard.object(forKey: activeLaneDefaultsKey) as? Int
+        activeLaneNumber = persistedLane.flatMap { number in
+            lanes.first(where: { $0.number == number && $0.task.id == lock.id })?.number
+        } ?? lanes.first(where: { $0.task.id == lock.id })?.number
         phase = .validatingLock
+    }
+
+    private func persistLock(_ lock: ListeningTaskLock) {
+        if let data = try? JSONEncoder().encode(lock) {
+            UserDefaults.standard.set(data, forKey: lockDefaultsKey)
+        }
+    }
+
+    private func persistLanes() {
+        if let data = try? JSONEncoder().encode(lanes) {
+            UserDefaults.standard.set(data, forKey: lanesDefaultsKey)
+        }
     }
 
     @discardableResult
@@ -314,6 +529,14 @@ final class ListeningSessionController: ObservableObject {
         return true
     }
 
+    private func applyLaunchLaneAssignmentIfPresent() {
+        guard let raw = ProcessInfo.processInfo.environment["SPEAKEASY_ASSIGN_LANE_NUMBER"],
+              let number = Int(raw), Self.laneRange.contains(number),
+              lockedTask != nil
+        else { return }
+        assignLockedTask(toLane: number)
+    }
+
     private func revalidateRestoredLock(from recent: [CodexTaskSummary]) {
         guard let candidate = restoredLockCandidate else { return }
         restoredLockCandidate = nil
@@ -322,6 +545,9 @@ final class ListeningSessionController: ObservableObject {
         } else {
             UserDefaults.standard.removeObject(forKey: lockDefaultsKey)
             selectedTaskID = recent.first?.id ?? ""
+            lockedTask = nil
+            activeLaneNumber = nil
+            UserDefaults.standard.removeObject(forKey: activeLaneDefaultsKey)
             phase = .unlocked
             lastError = "The previously locked Codex task is no longer available. Choose a task to lock again."
         }
@@ -346,68 +572,69 @@ final class ListeningSessionController: ObservableObject {
     }
 
     private func runLaunchHotkeyTestIfPresent() {
-        guard !fixtureHasRun,
+        guard !fixtureHasRun, !launchHotkeyHasRun,
               ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_HOTKEY_ON_LAUNCH"] == "1"
         else { return }
+        launchHotkeyHasRun = true
         diagnostic("triggering registered hotkey action for launch test")
         shortcut?.triggerForTesting()
+    }
+
+    private func runLaunchLaneTestIfPresent() {
+        guard !fixtureHasRun, !launchLaneHasRun,
+              let raw = ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_LANE_ON_LAUNCH"],
+              let number = Int(raw), lane(number) != nil
+        else { return }
+        launchLaneHasRun = true
+        diagnostic("triggering lane \(number) for launch test")
+        shortcut?.triggerLaneForTesting(number)
+    }
+
+    private func prepareCue(for lane: VoiceLane) {
+        let configuration = narrationConfiguration(from: ConfigManager.shared)
+        Task {
+            do {
+                _ = try await laneCueStore.prepare(for: lane, configuration: configuration)
+                diagnostic("premium lane \(lane.number) cue cached")
+            } catch {
+                // A cue is delight, not a routing dependency. Never fall back
+                // to a system voice and never prevent the microphone opening.
+                diagnostic("lane \(lane.number) cue unavailable: \(error.localizedDescription)")
+            }
+        }
     }
 
     private func narrationConfiguration(from config: ConfigManager) -> SpeechNarrationConfiguration {
         switch config.defaultProvider {
         case "openai":
             return SpeechNarrationConfiguration(
-                provider: "openai",
-                voice: config.openaiVoice,
-                model: config.openaiModel,
-                apiKey: config.openaiApiKey,
-                instructions: config.openaiInstructions,
-                rate: config.defaultRate
+                provider: "openai", voice: config.openaiVoice, model: config.openaiModel,
+                apiKey: config.openaiApiKey, instructions: config.openaiInstructions, rate: config.defaultRate
             )
         case "elevenlabs":
             return SpeechNarrationConfiguration(
-                provider: "elevenlabs",
-                voice: config.elevenlabsVoiceId,
-                model: config.elevenlabsModelId,
-                apiKey: config.elevenlabsApiKey,
-                instructions: nil,
-                rate: config.defaultRate
+                provider: "elevenlabs", voice: config.elevenlabsVoiceId, model: config.elevenlabsModelId,
+                apiKey: config.elevenlabsApiKey, instructions: nil, rate: config.defaultRate
             )
         case "groq":
             return SpeechNarrationConfiguration(
-                provider: "groq",
-                voice: config.groqVoice,
-                model: config.groqModel,
-                apiKey: config.groqApiKey,
-                instructions: nil,
-                rate: config.defaultRate
+                provider: "groq", voice: config.groqVoice, model: config.groqModel,
+                apiKey: config.groqApiKey, instructions: nil, rate: config.defaultRate
             )
         case "gemini":
             return SpeechNarrationConfiguration(
-                provider: "gemini",
-                voice: "Puck",
-                model: config.geminiModel,
-                apiKey: config.geminiApiKey,
-                instructions: nil,
-                rate: config.defaultRate
+                provider: "gemini", voice: "Puck", model: config.geminiModel,
+                apiKey: config.geminiApiKey, instructions: nil, rate: config.defaultRate
             )
         case "system":
             return SpeechNarrationConfiguration(
-                provider: "system",
-                voice: config.systemVoice,
-                model: nil,
-                apiKey: "",
-                instructions: nil,
-                rate: config.defaultRate
+                provider: "system", voice: config.systemVoice, model: nil,
+                apiKey: "", instructions: nil, rate: config.defaultRate
             )
         default:
             return SpeechNarrationConfiguration(
-                provider: config.defaultProvider,
-                voice: "",
-                model: nil,
-                apiKey: "",
-                instructions: nil,
-                rate: config.defaultRate
+                provider: config.defaultProvider, voice: "", model: nil,
+                apiKey: "", instructions: nil, rate: config.defaultRate
             )
         }
     }
@@ -420,6 +647,7 @@ final class ListeningSessionController: ObservableObject {
     private func recordFailure(_ error: Error) {
         maxRecordingTimer?.invalidate()
         maxRecordingTimer = nil
+        recordingStartID = nil
         pendingNarrationItemID = nil
         narrationDidStart = false
         lastError = error.localizedDescription
@@ -439,11 +667,13 @@ final class ListeningSessionController: ObservableObject {
 enum ListeningLoopError: LocalizedError {
     case emptyTranscript
     case taskLockChanged
+    case laneAssignmentChanged
 
     var errorDescription: String? {
         switch self {
         case .emptyTranscript: "No speech was detected. Try again and speak closer to the microphone."
         case .taskLockChanged: "The locked Codex task changed before the voice loop completed."
+        case .laneAssignmentChanged: "That voice lane changed while SpeakEasy was validating it. Try again."
         }
     }
 }

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -1,0 +1,449 @@
+import AppKit
+import Combine
+import Foundation
+import VoxCore
+
+enum ListeningPhase: String, Sendable {
+    case unlocked
+    case validatingLock
+    case ready
+    case warmingUp
+    case recording
+    case transcribing
+    case submitting
+    case preparingSpeech
+    case speaking
+    case failed
+
+    var label: String {
+        switch self {
+        case .unlocked: "Choose a task"
+        case .validatingLock: "Checking task"
+        case .ready: "Ready"
+        case .warmingUp: "Preparing speech recognition"
+        case .recording: "Listening"
+        case .transcribing: "Transcribing"
+        case .submitting: "Waiting for Codex"
+        case .preparingSpeech: "Preparing narration"
+        case .speaking: "Speaking"
+        case .failed: "Needs attention"
+        }
+    }
+
+    var acceptsHotkey: Bool {
+        self == .ready || self == .failed || self == .recording || self == .speaking
+    }
+}
+
+struct ListeningTaskLock: Codable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let cwd: String
+}
+
+@MainActor
+final class ListeningSessionController: ObservableObject {
+    static let shared = ListeningSessionController()
+    static let shortcutTitle = GlobalListeningShortcut.title
+
+    @Published private(set) var phase: ListeningPhase = .unlocked
+    @Published private(set) var tasks: [CodexTaskSummary] = []
+    @Published var selectedTaskID = ""
+    @Published private(set) var lockedTask: ListeningTaskLock?
+    @Published private(set) var shortcutAvailable = false
+    @Published private(set) var inputDeviceName: String?
+    @Published private(set) var lastTranscript = ""
+    @Published private(set) var lastResponse = ""
+    @Published private(set) var lastError: String?
+
+    private let vox = VoxListeningService()
+    private let router = CodexThreadRouter()
+    private let narrator = ConfiguredResponseNarrator()
+    private let lockDefaultsKey = "speakeasy.listening.task-lock.v1"
+    private var shortcut: GlobalListeningShortcut?
+    private var maxRecordingTimer: Timer?
+    private var playbackObservation: AnyCancellable?
+    private var fixtureHasRun = false
+    private var restoredLockCandidate: ListeningTaskLock?
+    private var pendingNarrationItemID: UUID?
+    private var narrationDidStart = false
+
+    private init() {
+        restoreLock()
+        playbackObservation = PlaybackEngine.shared.$state
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                guard let self, self.phase == .speaking else { return }
+                if state == .playing,
+                   PlaybackEngine.shared.currentItem?.id == self.pendingNarrationItemID {
+                    self.narrationDidStart = true
+                } else if state == .idle, self.narrationDidStart {
+                    self.pendingNarrationItemID = nil
+                    self.narrationDidStart = false
+                    self.phase = self.lockedTask == nil ? .unlocked : .ready
+                    self.diagnostic("voice loop playback completed")
+                }
+            }
+    }
+
+    func start() {
+        diagnostic("starting listening controller")
+        if shortcut == nil {
+            let shortcut = GlobalListeningShortcut { [weak self] in self?.toggleListening() }
+            self.shortcut = shortcut
+            shortcutAvailable = shortcut.register()
+            diagnostic(shortcutAvailable
+                ? "global shortcut \(Self.shortcutTitle) registered"
+                : "global shortcut \(Self.shortcutTitle) unavailable")
+        }
+        refreshTasks()
+    }
+
+    func stop() {
+        maxRecordingTimer?.invalidate()
+        maxRecordingTimer = nil
+        shortcut?.unregister()
+        shortcut = nil
+        shortcutAvailable = false
+        Task {
+            await vox.cancelRecording()
+            await router.shutdown()
+        }
+    }
+
+    func refreshTasks() {
+        diagnostic("loading recent Codex tasks")
+        Task {
+            do {
+                let recent = try await router.listRecentTasks(limit: 50)
+                diagnostic("loaded \(recent.count) recent Codex tasks")
+                tasks = recent
+                if !applyLaunchLockIfPresent(from: recent) {
+                    revalidateRestoredLock(from: recent)
+                }
+                if selectedTaskID.isEmpty {
+                    selectedTaskID = lockedTask?.id ?? recent.first?.id ?? ""
+                }
+                runLaunchFixtureIfPresent()
+                runLaunchHotkeyTestIfPresent()
+            } catch {
+                recordFailure(error)
+            }
+        }
+    }
+
+    func lockSelectedTask() {
+        guard let task = tasks.first(where: { $0.id == selectedTaskID }) else { return }
+        lock(task)
+    }
+
+    func lock(_ task: CodexTaskSummary) {
+        if lockedTask?.id != task.id {
+            lockedTask = nil
+            UserDefaults.standard.removeObject(forKey: lockDefaultsKey)
+        }
+        selectedTaskID = task.id
+        phase = .validatingLock
+        lastError = nil
+        openCodexTask(task.id)
+        Task {
+            do {
+                let validated = try await router.validateTask(task.id)
+                guard selectedTaskID == task.id else { return }
+                let lock = ListeningTaskLock(
+                    id: validated.id,
+                    title: validated.title,
+                    cwd: validated.cwd
+                )
+                lockedTask = lock
+                phase = .ready
+                if let data = try? JSONEncoder().encode(lock) {
+                    UserDefaults.standard.set(data, forKey: lockDefaultsKey)
+                }
+                diagnostic("locked to Desktop-owned Codex task \(task.id)")
+                runLaunchFixtureIfPresent()
+                runLaunchHotkeyTestIfPresent()
+            } catch {
+                recordFailure(error)
+            }
+        }
+    }
+
+    func unlock() {
+        guard phase != .recording else {
+            cancelRecording()
+            return
+        }
+        guard phase != .submitting, phase != .preparingSpeech else { return }
+        if phase == .speaking { PlaybackEngine.shared.stop() }
+        lockedTask = nil
+        phase = .unlocked
+        lastError = nil
+        UserDefaults.standard.removeObject(forKey: lockDefaultsKey)
+    }
+
+    func toggleListening() {
+        switch phase {
+        case .recording:
+            finishRecording()
+        case .ready, .failed:
+            beginRecording()
+        case .speaking:
+            PlaybackEngine.shared.stop()
+            beginRecording()
+        default:
+            NSSound.beep()
+        }
+    }
+
+    func cancelRecording() {
+        guard phase == .recording || phase == .warmingUp else { return }
+        maxRecordingTimer?.invalidate()
+        maxRecordingTimer = nil
+        Task {
+            await vox.cancelRecording()
+            phase = lockedTask == nil ? .unlocked : .ready
+            diagnostic("recording cancelled")
+        }
+    }
+
+    private func beginRecording() {
+        guard lockedTask != nil else {
+            phase = .unlocked
+            NSSound.beep()
+            return
+        }
+
+        lastError = nil
+        lastTranscript = ""
+        lastResponse = ""
+        phase = .warmingUp
+
+        // Half duplex: stop narration before opening the microphone, so the
+        // app cannot transcribe its own output.
+        PlaybackEngine.shared.stop()
+        Task {
+            do {
+                try await vox.warmUp()
+                guard phase == .warmingUp else { return }
+                let device = try await vox.startRecording()
+                inputDeviceName = device.name
+                phase = .recording
+                diagnostic("microphone active (\(device.name))")
+                maxRecordingTimer?.invalidate()
+                maxRecordingTimer = Timer.scheduledTimer(withTimeInterval: 120, repeats: false) { [weak self] _ in
+                    Task { @MainActor in self?.finishRecording() }
+                }
+            } catch {
+                recordFailure(error)
+            }
+        }
+    }
+
+    private func finishRecording() {
+        guard phase == .recording, let lock = lockedTask else { return }
+        maxRecordingTimer?.invalidate()
+        maxRecordingTimer = nil
+        phase = .transcribing
+        Task {
+            do {
+                let transcript = try await vox.stopAndTranscribe()
+                try await completeLoop(transcript: transcript, lock: lock)
+            } catch {
+                recordFailure(error)
+            }
+        }
+    }
+
+    private func completeLoop(transcript: String, lock: ListeningTaskLock) async throws {
+        let text = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { throw ListeningLoopError.emptyTranscript }
+        guard lockedTask?.id == lock.id else { throw ListeningLoopError.taskLockChanged }
+
+        lastTranscript = text
+        phase = .submitting
+        diagnostic("transcript ready (\(text.count) characters)")
+        let response = try await router.submit(text, to: lock.id)
+        guard lockedTask?.id == lock.id else { throw ListeningLoopError.taskLockChanged }
+
+        lastResponse = response
+        phase = .preparingSpeech
+        let config = ConfigManager.shared
+        let narration = narrationConfiguration(from: config)
+        let audioURL = try await narrator.render(text: response, configuration: narration)
+        guard lockedTask?.id == lock.id else {
+            try? FileManager.default.removeItem(at: audioURL)
+            throw ListeningLoopError.taskLockChanged
+        }
+
+        let itemID = UUID()
+        let item = PlaybackItem(
+            id: itemID,
+            audioPath: audioURL.path,
+            title: lock.title,
+            text: response,
+            provider: narration.provider,
+            createdAt: ISO8601DateFormatter().string(from: Date()),
+            synthesisRateWPM: config.defaultRate,
+            sourceThreadId: lock.id,
+            cleanupAfterPlayback: true
+        )
+        PlaybackEngine.shared.setVolume(Float(config.defaultVolume))
+        pendingNarrationItemID = itemID
+        narrationDidStart = false
+        phase = .speaking
+        try PlaybackEngine.shared.enqueue(item, priority: .high, interrupt: true, autoplay: true)
+        diagnostic("response queued with \(narration.provider) narration from task \(lock.id)")
+    }
+
+    private func restoreLock() {
+        guard let data = UserDefaults.standard.data(forKey: lockDefaultsKey),
+              let lock = try? JSONDecoder().decode(ListeningTaskLock.self, from: data)
+        else { return }
+        restoredLockCandidate = lock
+        selectedTaskID = lock.id
+        phase = .validatingLock
+    }
+
+    @discardableResult
+    private func applyLaunchLockIfPresent(from recent: [CodexTaskSummary]) -> Bool {
+        guard let requestedID = ProcessInfo.processInfo.environment["SPEAKEASY_LOCK_THREAD_ID"],
+              let requested = recent.first(where: { $0.id == requestedID })
+        else { return false }
+        lock(requested)
+        return true
+    }
+
+    private func revalidateRestoredLock(from recent: [CodexTaskSummary]) {
+        guard let candidate = restoredLockCandidate else { return }
+        restoredLockCandidate = nil
+        if let task = recent.first(where: { $0.id == candidate.id }) {
+            lock(task)
+        } else {
+            UserDefaults.standard.removeObject(forKey: lockDefaultsKey)
+            selectedTaskID = recent.first?.id ?? ""
+            phase = .unlocked
+            lastError = "The previously locked Codex task is no longer available. Choose a task to lock again."
+        }
+    }
+
+    private func runLaunchFixtureIfPresent() {
+        guard !fixtureHasRun,
+              let path = ProcessInfo.processInfo.environment["SPEAKEASY_LISTENING_FIXTURE"],
+              let lock = lockedTask
+        else { return }
+        fixtureHasRun = true
+        phase = .transcribing
+        diagnostic("running launch transcription fixture")
+        Task {
+            do {
+                let transcript = try await vox.transcribeFixture(url: URL(fileURLWithPath: path))
+                try await completeLoop(transcript: transcript, lock: lock)
+            } catch {
+                recordFailure(error)
+            }
+        }
+    }
+
+    private func runLaunchHotkeyTestIfPresent() {
+        guard !fixtureHasRun,
+              ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_HOTKEY_ON_LAUNCH"] == "1"
+        else { return }
+        diagnostic("triggering registered hotkey action for launch test")
+        shortcut?.triggerForTesting()
+    }
+
+    private func narrationConfiguration(from config: ConfigManager) -> SpeechNarrationConfiguration {
+        switch config.defaultProvider {
+        case "openai":
+            return SpeechNarrationConfiguration(
+                provider: "openai",
+                voice: config.openaiVoice,
+                model: config.openaiModel,
+                apiKey: config.openaiApiKey,
+                instructions: config.openaiInstructions,
+                rate: config.defaultRate
+            )
+        case "elevenlabs":
+            return SpeechNarrationConfiguration(
+                provider: "elevenlabs",
+                voice: config.elevenlabsVoiceId,
+                model: config.elevenlabsModelId,
+                apiKey: config.elevenlabsApiKey,
+                instructions: nil,
+                rate: config.defaultRate
+            )
+        case "groq":
+            return SpeechNarrationConfiguration(
+                provider: "groq",
+                voice: config.groqVoice,
+                model: config.groqModel,
+                apiKey: config.groqApiKey,
+                instructions: nil,
+                rate: config.defaultRate
+            )
+        case "gemini":
+            return SpeechNarrationConfiguration(
+                provider: "gemini",
+                voice: "Puck",
+                model: config.geminiModel,
+                apiKey: config.geminiApiKey,
+                instructions: nil,
+                rate: config.defaultRate
+            )
+        case "system":
+            return SpeechNarrationConfiguration(
+                provider: "system",
+                voice: config.systemVoice,
+                model: nil,
+                apiKey: "",
+                instructions: nil,
+                rate: config.defaultRate
+            )
+        default:
+            return SpeechNarrationConfiguration(
+                provider: config.defaultProvider,
+                voice: "",
+                model: nil,
+                apiKey: "",
+                instructions: nil,
+                rate: config.defaultRate
+            )
+        }
+    }
+
+    private func openCodexTask(_ taskID: String) {
+        guard let url = URL(string: "codex://threads/\(taskID)") else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func recordFailure(_ error: Error) {
+        maxRecordingTimer?.invalidate()
+        maxRecordingTimer = nil
+        pendingNarrationItemID = nil
+        narrationDidStart = false
+        lastError = error.localizedDescription
+        phase = lockedTask == nil ? .unlocked : .failed
+        diagnostic("failed: \(error.localizedDescription)")
+    }
+
+    private func diagnostic(_ message: String) {
+        let line = "SpeakEasy listening: \(message)"
+        NSLog("%@", line)
+        if let data = "\(line)\n".data(using: .utf8) {
+            try? FileHandle.standardError.write(contentsOf: data)
+        }
+    }
+}
+
+enum ListeningLoopError: LocalizedError {
+    case emptyTranscript
+    case taskLockChanged
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyTranscript: "No speech was detected. Try again and speak closer to the microphone."
+        case .taskLockChanged: "The locked Codex task changed before the voice loop completed."
+        }
+    }
+}

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -43,6 +43,13 @@ struct ListeningTaskLock: Codable, Equatable, Sendable {
     let cwd: String
 }
 
+struct ListeningTurnContext: Equatable, Sendable {
+    let lock: ListeningTaskLock
+    let laneNumber: Int?
+    let narration: SpeechNarrationConfiguration
+    let playbackVolume: Double
+}
+
 @MainActor
 final class ListeningSessionController: ObservableObject {
     static let shared = ListeningSessionController()
@@ -61,6 +68,7 @@ final class ListeningSessionController: ObservableObject {
     @Published private(set) var inputDeviceName: String?
     @Published private(set) var lastTranscript = ""
     @Published private(set) var lastResponse = ""
+    @Published private(set) var lastDelivery: CodexTurnDelivery?
     @Published private(set) var lastError: String?
 
     private let vox = VoxListeningService()
@@ -82,6 +90,7 @@ final class ListeningSessionController: ObservableObject {
     private var narrationDidStart = false
     private var validationID: UUID?
     private var recordingStartID: UUID?
+    private var recordingContext: ListeningTurnContext?
 
     private init() {
         restoreState()
@@ -127,6 +136,7 @@ final class ListeningSessionController: ObservableObject {
         maxRecordingTimer?.invalidate()
         maxRecordingTimer = nil
         recordingStartID = nil
+        recordingContext = nil
         validationID = nil
         shortcut?.unregisterAll()
         shortcut = nil
@@ -180,7 +190,8 @@ final class ListeningSessionController: ObservableObject {
         let assignment = VoiceLane(
             number: number,
             task: lock,
-            voiceOverride: previous?.voiceOverride
+            voiceOverride: previous?.voiceOverride,
+            narrationCue: previous?.narrationCue
         )
         lanes.removeAll { $0.number == number }
         lanes.append(assignment)
@@ -218,6 +229,22 @@ final class ListeningSessionController: ObservableObject {
         } else {
             diagnostic("lane \(number) voice reset to the global provider default")
         }
+        prepareCue(for: assignment)
+    }
+
+    func setNarrationCue(_ cue: String, forLane number: Int) {
+        guard var assignment = lane(number) else { return }
+        let narrationCue = VoiceLane.normalizedNarrationCue(cue)
+        guard assignment.narrationCue != narrationCue else { return }
+        assignment.narrationCue = narrationCue
+        lanes.removeAll { $0.number == number }
+        lanes.append(assignment)
+        lanes.sort { $0.number < $1.number }
+        persistLanes()
+        diagnostic(narrationCue == nil
+            ? "lane \(number) narration cue cleared"
+            : "lane \(number) narration cue updated")
+        prepareCue(for: assignment)
     }
 
     func activateLane(_ number: Int, beginListening: Bool = false) {
@@ -288,11 +315,16 @@ final class ListeningSessionController: ObservableObject {
         }
     }
 
+    func confirmActiveLane() {
+        announceActiveLane()
+    }
+
     func cancelRecording() {
         guard phase == .recording || phase == .warmingUp else { return }
         maxRecordingTimer?.invalidate()
         maxRecordingTimer = nil
         recordingStartID = nil
+        recordingContext = nil
         Task {
             await vox.cancelRecording()
             phase = lockedTask == nil ? .unlocked : .ready
@@ -382,7 +414,8 @@ final class ListeningSessionController: ObservableObject {
                     let refreshed = VoiceLane(
                         number: expectedLane,
                         task: lock,
-                        voiceOverride: lane(expectedLane)?.voiceOverride
+                        voiceOverride: lane(expectedLane)?.voiceOverride,
+                        narrationCue: lane(expectedLane)?.narrationCue
                     )
                     lanes.removeAll { $0.number == expectedLane }
                     lanes.append(refreshed)
@@ -425,9 +458,11 @@ final class ListeningSessionController: ObservableObject {
         lastError = nil
         lastTranscript = ""
         lastResponse = ""
+        lastDelivery = nil
         PlaybackEngine.shared.stop()
         let startID = UUID()
         recordingStartID = startID
+        recordingContext = turnContext(for: lock)
 
         Task {
             guard recordingStartID == startID, lockedTask?.id == lock.id else { return }
@@ -471,7 +506,10 @@ final class ListeningSessionController: ObservableObject {
             return
         }
 
-        let configuration = narrationConfiguration(from: ConfigManager.shared)
+        let configuration = narrationConfiguration(
+            from: ConfigManager.shared,
+            lane: assignment
+        )
         let volume = ConfigManager.shared.defaultVolume
         lastError = nil
         phase = .cueing
@@ -501,22 +539,24 @@ final class ListeningSessionController: ObservableObject {
     }
 
     private func finishRecording() {
-        guard phase == .recording, let lock = lockedTask else { return }
+        guard phase == .recording, let context = recordingContext else { return }
         maxRecordingTimer?.invalidate()
         maxRecordingTimer = nil
         recordingStartID = nil
+        recordingContext = nil
         phase = .transcribing
         Task {
             do {
                 let transcript = try await vox.stopAndTranscribe()
-                try await completeLoop(transcript: transcript, lock: lock)
+                try await completeLoop(transcript: transcript, context: context)
             } catch {
                 recordFailure(error)
             }
         }
     }
 
-    private func completeLoop(transcript: String, lock: ListeningTaskLock) async throws {
+    private func completeLoop(transcript: String, context: ListeningTurnContext) async throws {
+        let lock = context.lock
         let text = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { throw ListeningLoopError.emptyTranscript }
         guard lockedTask?.id == lock.id else { throw ListeningLoopError.taskLockChanged }
@@ -524,14 +564,14 @@ final class ListeningSessionController: ObservableObject {
         lastTranscript = text
         phase = .submitting
         diagnostic("transcript ready (\(text.count) characters)")
-        let response = try await router.submit(text, to: lock.id)
+        let result = try await router.submit(text, to: lock.id)
         guard lockedTask?.id == lock.id else { throw ListeningLoopError.taskLockChanged }
 
-        lastResponse = response
+        lastResponse = result.response
+        lastDelivery = result.delivery
         phase = .preparingSpeech
-        let config = ConfigManager.shared
-        let narration = narrationConfiguration(from: config)
-        let audioURL = try await narrator.render(text: response, configuration: narration)
+        let narration = context.narration
+        let audioURL = try await narrator.render(text: result.response, configuration: narration)
         guard lockedTask?.id == lock.id else {
             try? FileManager.default.removeItem(at: audioURL)
             throw ListeningLoopError.taskLockChanged
@@ -542,19 +582,19 @@ final class ListeningSessionController: ObservableObject {
             id: itemID,
             audioPath: audioURL.path,
             title: lock.title,
-            text: response,
+            text: result.response,
             provider: narration.provider,
             createdAt: ISO8601DateFormatter().string(from: Date()),
-            synthesisRateWPM: config.defaultRate,
+            synthesisRateWPM: narration.rate,
             sourceThreadId: lock.id,
             cleanupAfterPlayback: true
         )
-        PlaybackEngine.shared.setVolume(Float(config.defaultVolume))
+        PlaybackEngine.shared.setVolume(Float(context.playbackVolume))
         pendingNarrationItemID = itemID
         narrationDidStart = false
         phase = .speaking
         try PlaybackEngine.shared.enqueue(item, priority: .high, interrupt: true, autoplay: true)
-        diagnostic("response queued with \(narration.provider) narration from task \(lock.id)")
+        diagnostic("\(result.delivery.rawValue) response queued with \(narration.provider)/\(narration.voice) narration from task \(lock.id)")
     }
 
     private func restoreState() {
@@ -627,12 +667,13 @@ final class ListeningSessionController: ObservableObject {
               let lock = lockedTask
         else { return }
         fixtureHasRun = true
+        let context = turnContext(for: lock)
         phase = .transcribing
         diagnostic("running launch transcription fixture")
         Task {
             do {
                 let transcript = try await vox.transcribeFixture(url: URL(fileURLWithPath: path))
-                try await completeLoop(transcript: transcript, lock: lock)
+                try await completeLoop(transcript: transcript, context: context)
             } catch {
                 recordFailure(error)
             }
@@ -671,7 +712,7 @@ final class ListeningSessionController: ObservableObject {
     }
 
     private func prepareCue(for lane: VoiceLane) {
-        let configuration = narrationConfiguration(from: ConfigManager.shared)
+        let configuration = narrationConfiguration(from: ConfigManager.shared, lane: lane)
         Task {
             do {
                 _ = try await laneCueStore.prepare(for: lane, configuration: configuration)
@@ -684,39 +725,57 @@ final class ListeningSessionController: ObservableObject {
         }
     }
 
-    private func narrationConfiguration(from config: ConfigManager) -> SpeechNarrationConfiguration {
+    private func narrationConfiguration(
+        from config: ConfigManager,
+        lane: VoiceLane? = nil
+    ) -> SpeechNarrationConfiguration {
+        let configuration: SpeechNarrationConfiguration
         switch config.defaultProvider {
         case "openai":
-            return SpeechNarrationConfiguration(
+            configuration = SpeechNarrationConfiguration(
                 provider: "openai", voice: config.openaiVoice, model: config.openaiModel,
                 apiKey: config.openaiApiKey, instructions: config.openaiInstructions, rate: config.defaultRate
             )
         case "elevenlabs":
-            return SpeechNarrationConfiguration(
+            configuration = SpeechNarrationConfiguration(
                 provider: "elevenlabs", voice: config.elevenlabsVoiceId, model: config.elevenlabsModelId,
                 apiKey: config.elevenlabsApiKey, instructions: nil, rate: config.defaultRate
             )
         case "groq":
-            return SpeechNarrationConfiguration(
+            configuration = SpeechNarrationConfiguration(
                 provider: "groq", voice: config.groqVoice, model: config.groqModel,
                 apiKey: config.groqApiKey, instructions: nil, rate: config.defaultRate
             )
         case "gemini":
-            return SpeechNarrationConfiguration(
+            configuration = SpeechNarrationConfiguration(
                 provider: "gemini", voice: "Puck", model: config.geminiModel,
                 apiKey: config.geminiApiKey, instructions: nil, rate: config.defaultRate
             )
         case "system":
-            return SpeechNarrationConfiguration(
+            configuration = SpeechNarrationConfiguration(
                 provider: "system", voice: config.systemVoice, model: nil,
                 apiKey: "", instructions: nil, rate: config.defaultRate
             )
         default:
-            return SpeechNarrationConfiguration(
+            configuration = SpeechNarrationConfiguration(
                 provider: config.defaultProvider, voice: "", model: nil,
                 apiKey: "", instructions: nil, rate: config.defaultRate
             )
         }
+        return configuration.applying(lane: lane)
+    }
+
+    private func turnContext(for lock: ListeningTaskLock) -> ListeningTurnContext {
+        let lane = activeLaneNumber
+            .flatMap { self.lane($0) }
+            .flatMap { $0.task.id == lock.id ? $0 : nil }
+        let config = ConfigManager.shared
+        return ListeningTurnContext(
+            lock: lock,
+            laneNumber: lane?.number,
+            narration: narrationConfiguration(from: config, lane: lane),
+            playbackVolume: config.defaultVolume
+        )
     }
 
     private func openCodexTask(_ taskID: String) {
@@ -728,6 +787,7 @@ final class ListeningSessionController: ObservableObject {
         maxRecordingTimer?.invalidate()
         maxRecordingTimer = nil
         recordingStartID = nil
+        recordingContext = nil
         pendingNarrationItemID = nil
         narrationDidStart = false
         lastError = error.localizedDescription

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -204,6 +204,22 @@ final class ListeningSessionController: ObservableObject {
         diagnostic("lane \(number) removed")
     }
 
+    func setVoiceOverride(provider: String, voiceID: String, forLane number: Int) {
+        guard var assignment = lane(number) else { return }
+        let voiceOverride = LaneVoiceOverride(provider: provider, voiceID: voiceID)
+        guard assignment.voiceOverride != voiceOverride else { return }
+        assignment.voiceOverride = voiceOverride
+        lanes.removeAll { $0.number == number }
+        lanes.append(assignment)
+        lanes.sort { $0.number < $1.number }
+        persistLanes()
+        if let voiceOverride {
+            diagnostic("lane \(number) voice set for \(voiceOverride.provider)")
+        } else {
+            diagnostic("lane \(number) voice reset to the global provider default")
+        }
+    }
+
     func activateLane(_ number: Int, beginListening: Bool = false) {
         guard let assignment = lane(number) else {
             lastError = "Lane \(number) is not assigned yet. Lock a task, then assign it from SpeakEasy."

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -173,10 +173,15 @@ final class ListeningSessionController: ObservableObject {
 
     func assignLockedTask(toLane number: Int) {
         guard Self.laneRange.contains(number), let lock = lockedTask else { return }
-        if let previous = lane(number) {
+        let previous = lane(number)
+        if let previous {
             Task { await laneCueStore.removeCue(for: previous) }
         }
-        let assignment = VoiceLane(number: number, task: lock)
+        let assignment = VoiceLane(
+            number: number,
+            task: lock,
+            voiceOverride: previous?.voiceOverride
+        )
         lanes.removeAll { $0.number == number }
         lanes.append(assignment)
         lanes.sort { $0.number < $1.number }
@@ -358,7 +363,11 @@ final class ListeningSessionController: ObservableObject {
                 if let expectedLane {
                     activeLaneNumber = expectedLane
                     UserDefaults.standard.set(expectedLane, forKey: activeLaneDefaultsKey)
-                    let refreshed = VoiceLane(number: expectedLane, task: lock)
+                    let refreshed = VoiceLane(
+                        number: expectedLane,
+                        task: lock,
+                        voiceOverride: lane(expectedLane)?.voiceOverride
+                    )
                     lanes.removeAll { $0.number == expectedLane }
                     lanes.append(refreshed)
                     lanes.sort { $0.number < $1.number }

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -57,6 +57,7 @@ final class ListeningSessionController: ObservableObject {
     @Published private(set) var activeLaneNumber: Int?
     @Published private(set) var shortcutAvailable = false
     @Published private(set) var laneShortcutAvailability: [Int: Bool] = [:]
+    @Published private(set) var confirmationShortcutAvailable = false
     @Published private(set) var inputDeviceName: String?
     @Published private(set) var lastTranscript = ""
     @Published private(set) var lastResponse = ""
@@ -75,6 +76,7 @@ final class ListeningSessionController: ObservableObject {
     private var fixtureHasRun = false
     private var launchHotkeyHasRun = false
     private var launchLaneHasRun = false
+    private var launchConfirmationHasRun = false
     private var restoredLockCandidate: ListeningTaskLock?
     private var pendingNarrationItemID: UUID?
     private var narrationDidStart = false
@@ -108,11 +110,15 @@ final class ListeningSessionController: ObservableObject {
             self.shortcut = shortcut
             shortcutAvailable = shortcut.registerCurrentLane()
             laneShortcutAvailability = shortcut.registerLanes()
+            confirmationShortcutAvailable = shortcut.registerLaneConfirmation()
             diagnostic(shortcutAvailable
                 ? "global shortcut \(Self.shortcutTitle) registered"
                 : "global shortcut \(Self.shortcutTitle) unavailable")
             let registered = laneShortcutAvailability.filter(\.value).keys.sorted()
             diagnostic("lane shortcuts registered: \(registered.map(String.init).joined(separator: ","))")
+            diagnostic(confirmationShortcutAvailable
+                ? "lane confirmation shortcut \(GlobalListeningShortcut.confirmationTitle) registered"
+                : "lane confirmation shortcut \(GlobalListeningShortcut.confirmationTitle) unavailable")
         }
         refreshTasks()
     }
@@ -126,6 +132,7 @@ final class ListeningSessionController: ObservableObject {
         shortcut = nil
         shortcutAvailable = false
         laneShortcutAvailability = [:]
+        confirmationShortcutAvailable = false
         Task {
             await vox.cancelRecording()
             await router.shutdown()
@@ -148,6 +155,7 @@ final class ListeningSessionController: ObservableObject {
                 runLaunchFixtureIfPresent()
                 runLaunchHotkeyTestIfPresent()
                 runLaunchLaneTestIfPresent()
+                runLaunchConfirmationTestIfPresent()
             } catch {
                 recordFailure(error)
             }
@@ -203,6 +211,10 @@ final class ListeningSessionController: ObservableObject {
             NSSound.beep()
             return
         }
+        guard ![.validatingLock, .cueing, .warmingUp].contains(phase) else {
+            NSSound.beep()
+            return
+        }
         if phase == .recording {
             if activeLaneNumber == number { finishRecording() }
             else {
@@ -246,10 +258,10 @@ final class ListeningSessionController: ObservableObject {
         case .recording:
             finishRecording()
         case .ready, .failed:
-            beginRecording(cueFor: nil)
+            beginRecording()
         case .speaking:
             PlaybackEngine.shared.stop()
-            beginRecording(cueFor: nil)
+            beginRecording()
         default:
             NSSound.beep()
         }
@@ -294,6 +306,7 @@ final class ListeningSessionController: ObservableObject {
         laneShortcutAvailability = Dictionary(
             uniqueKeysWithValues: Self.laneRange.map { ($0, $0 != 4) }
         )
+        confirmationShortcutAvailable = true
         phase = .ready
     }
     #endif
@@ -308,6 +321,8 @@ final class ListeningSessionController: ObservableObject {
             toggleListening()
         case .selectLane(let number):
             activateLane(number, beginListening: true)
+        case .announceActiveLane:
+            announceActiveLane()
         }
     }
 
@@ -364,8 +379,9 @@ final class ListeningSessionController: ObservableObject {
                 runLaunchFixtureIfPresent()
                 runLaunchHotkeyTestIfPresent()
                 runLaunchLaneTestIfPresent()
+                runLaunchConfirmationTestIfPresent()
                 if beginAfterLock {
-                    beginRecording(cueFor: expectedLane.flatMap(lane))
+                    beginRecording()
                 }
             } catch {
                 guard validationID == requestID else { return }
@@ -374,7 +390,7 @@ final class ListeningSessionController: ObservableObject {
         }
     }
 
-    private func beginRecording(cueFor lane: VoiceLane?) {
+    private func beginRecording() {
         guard let lock = lockedTask else {
             phase = .unlocked
             NSSound.beep()
@@ -387,20 +403,8 @@ final class ListeningSessionController: ObservableObject {
         PlaybackEngine.shared.stop()
         let startID = UUID()
         recordingStartID = startID
-        let narration = narrationConfiguration(from: ConfigManager.shared)
-        let volume = ConfigManager.shared.defaultVolume
 
         Task {
-            if let lane {
-                if let cached = await laneCueStore.cachedCue(for: lane, configuration: narration) {
-                    phase = .cueing
-                    diagnostic("playing cached lane \(lane.number) cue before microphone")
-                    do { try await laneCueStore.play(cached, volume: volume) }
-                    catch { diagnostic("lane cue skipped: \(error.localizedDescription)") }
-                } else {
-                    prepareCue(for: lane)
-                }
-            }
             guard recordingStartID == startID, lockedTask?.id == lock.id else { return }
             phase = .warmingUp
             do {
@@ -427,6 +431,45 @@ final class ListeningSessionController: ObservableObject {
                 }
             } catch {
                 guard recordingStartID == startID else { return }
+                recordFailure(error)
+            }
+        }
+    }
+
+    private func announceActiveLane() {
+        guard phase == .ready || phase == .failed,
+              let number = activeLaneNumber,
+              let assignment = lane(number),
+              lockedTask?.id == assignment.task.id
+        else {
+            NSSound.beep()
+            return
+        }
+
+        let configuration = narrationConfiguration(from: ConfigManager.shared)
+        let volume = ConfigManager.shared.defaultVolume
+        lastError = nil
+        phase = .cueing
+        Task {
+            do {
+                let cue: URL
+                if let cached = await laneCueStore.cachedCue(
+                    for: assignment,
+                    configuration: configuration
+                ) {
+                    cue = cached
+                } else {
+                    cue = try await laneCueStore.prepare(
+                        for: assignment,
+                        configuration: configuration
+                    )
+                }
+                guard activeLaneNumber == number, lockedTask?.id == assignment.task.id else { return }
+                diagnostic("announcing active lane \(number) on demand")
+                try await laneCueStore.play(cue, volume: volume)
+                guard activeLaneNumber == number, lockedTask?.id == assignment.task.id else { return }
+                phase = .ready
+            } catch {
                 recordFailure(error)
             }
         }
@@ -588,6 +631,18 @@ final class ListeningSessionController: ObservableObject {
         launchLaneHasRun = true
         diagnostic("triggering lane \(number) for launch test")
         shortcut?.triggerLaneForTesting(number)
+    }
+
+    private func runLaunchConfirmationTestIfPresent() {
+        guard !fixtureHasRun, !launchConfirmationHasRun,
+              ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_LANE_CONFIRMATION_ON_LAUNCH"] == "1",
+              activeLaneNumber != nil,
+              lockedTask != nil,
+              phase == .ready || phase == .failed
+        else { return }
+        launchConfirmationHasRun = true
+        diagnostic("triggering active lane confirmation for launch test")
+        shortcut?.triggerConfirmationForTesting()
     }
 
     private func prepareCue(for lane: VoiceLane) {

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -20,7 +20,7 @@ enum ListeningPhase: String, Sendable {
         switch self {
         case .unlocked: "Choose a task"
         case .validatingLock: "Checking task"
-        case .cueing: "Announcing lane"
+        case .cueing: "Confirming"
         case .ready: "Ready"
         case .warmingUp: "Opening microphone"
         case .recording: "Listening"

--- a/app/Sources/SpeakEasy/MenuBarController.swift
+++ b/app/Sources/SpeakEasy/MenuBarController.swift
@@ -84,7 +84,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
                 accessibilityDescription: description
             ) ?? SpeakeasyIcon.tumbler(filled: true)
             statusItem?.button?.contentTintColor = .systemRed
-        } else if [.validatingLock, .warmingUp, .transcribing, .submitting, .preparingSpeech].contains(listening) {
+        } else if [.validatingLock, .cueing, .warmingUp, .transcribing, .submitting, .preparingSpeech].contains(listening) {
             description = listening.label
             image = NSImage(
                 systemSymbolName: "waveform",
@@ -175,7 +175,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         popover.behavior = .transient
         popover.animates = true
         popover.delegate = self
-        popover.contentSize = NSSize(width: 320, height: 590)
+        popover.contentSize = NSSize(width: 320, height: 640)
         popover.contentViewController = NSHostingController(rootView: makePopoverRoot())
         self.popover = popover
     }

--- a/app/Sources/SpeakEasy/MenuBarController.swift
+++ b/app/Sources/SpeakEasy/MenuBarController.swift
@@ -24,13 +24,15 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         NSApp.setActivationPolicy(.accessory)
         installStatusItem()
         installPopover()
-        observePlaybackState()
+        observeActivityState()
         startIPCServer()
+        ListeningSessionController.shared.start()
     }
 
     func stop() {
         closePopover()
         removeEventMonitor()
+        ListeningSessionController.shared.stop()
         PlayerIPCServer.shared.stop()
 
         if let statusItem {
@@ -61,18 +63,37 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         statusItem = item
     }
 
-    private func observePlaybackState() {
-        stateObservation = PlaybackEngine.shared.$state
+    private func observeActivityState() {
+        stateObservation = Publishers.CombineLatest(
+            PlaybackEngine.shared.$state,
+            ListeningSessionController.shared.$phase
+        )
             .receive(on: RunLoop.main)
-            .sink { [weak self] state in
-                self?.updateStatusIcon(for: state)
+            .sink { [weak self] playback, listening in
+                self?.updateStatusIcon(playback: playback, listening: listening)
             }
     }
 
-    private func updateStatusIcon(for state: PlaybackState) {
+    private func updateStatusIcon(playback: PlaybackState, listening: ListeningPhase) {
         let description: String
         let image: NSImage
-        switch state {
+        if listening == .recording {
+            description = "SpeakEasy is listening"
+            image = NSImage(
+                systemSymbolName: "mic.fill",
+                accessibilityDescription: description
+            ) ?? SpeakeasyIcon.tumbler(filled: true)
+            statusItem?.button?.contentTintColor = .systemRed
+        } else if [.validatingLock, .warmingUp, .transcribing, .submitting, .preparingSpeech].contains(listening) {
+            description = listening.label
+            image = NSImage(
+                systemSymbolName: "waveform",
+                accessibilityDescription: description
+            ) ?? SpeakeasyIcon.tumbler(filled: false)
+            statusItem?.button?.contentTintColor = nil
+        } else {
+            statusItem?.button?.contentTintColor = nil
+            switch playback {
         case .playing:
             description = "SpeakEasy is playing"
             image = SpeakeasyIcon.tumbler(filled: true)
@@ -91,6 +112,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         case .idle:
             description = "SpeakEasy"
             image = SpeakeasyIcon.tumbler(filled: false)
+            }
         }
         image.isTemplate = true
         statusItem?.button?.image = image
@@ -153,7 +175,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         popover.behavior = .transient
         popover.animates = true
         popover.delegate = self
-        popover.contentSize = NSSize(width: 320, height: 420)
+        popover.contentSize = NSSize(width: 320, height: 590)
         popover.contentViewController = NSHostingController(rootView: makePopoverRoot())
         self.popover = popover
     }

--- a/app/Sources/SpeakEasy/PlaybackEngine.swift
+++ b/app/Sources/SpeakEasy/PlaybackEngine.swift
@@ -250,6 +250,7 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
     }
 
     private func finishCurrentItem() {
+        let finishedItem = currentItem
         HUDWindowManager.shared.playbackDidFinish()
         progressTimer?.invalidate()
         progressTimer = nil
@@ -259,6 +260,9 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
         duration = 0
         audioLevel = 0
         state = .idle
+        if finishedItem?.cleanupAfterPlayback == true {
+            try? FileManager.default.removeItem(atPath: finishedItem?.audioPath ?? "")
+        }
     }
 
     private func startProgressTimer() {

--- a/app/Sources/SpeakEasy/PlayerPopoverSnapshot.swift
+++ b/app/Sources/SpeakEasy/PlayerPopoverSnapshot.swift
@@ -11,6 +11,7 @@ enum PlayerPopoverSnapshot {
         }
 
         let outputPath = CommandLine.arguments[argumentIndex + 1]
+        ListeningSessionController.shared.installLaneSnapshotFixture()
         let rootView = PlayerPopoverView()
             .environment(\.theme, .dark)
             .preferredColorScheme(.dark)

--- a/app/Sources/SpeakEasy/PlayerPopoverView.swift
+++ b/app/Sources/SpeakEasy/PlayerPopoverView.swift
@@ -33,6 +33,7 @@ struct PlayerPopoverView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
+            ListeningPopoverSection()
             nowPlayingSection
             scrubberSection
             transportSection

--- a/app/Sources/SpeakEasy/PlayerProtocol.swift
+++ b/app/Sources/SpeakEasy/PlayerProtocol.swift
@@ -41,6 +41,29 @@ struct PlaybackItem: Codable, Identifiable, Equatable {
     let createdAt: String
     let synthesisRateWPM: Int?
     let sourceThreadId: String?
+    let cleanupAfterPlayback: Bool?
+
+    init(
+        id: UUID,
+        audioPath: String,
+        title: String,
+        text: String?,
+        provider: String?,
+        createdAt: String,
+        synthesisRateWPM: Int?,
+        sourceThreadId: String?,
+        cleanupAfterPlayback: Bool? = nil
+    ) {
+        self.id = id
+        self.audioPath = audioPath
+        self.title = title
+        self.text = text
+        self.provider = provider
+        self.createdAt = createdAt
+        self.synthesisRateWPM = synthesisRateWPM
+        self.sourceThreadId = sourceThreadId
+        self.cleanupAfterPlayback = cleanupAfterPlayback
+    }
 }
 
 struct PlayerCommandArguments: Codable {

--- a/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
+++ b/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { randomUUID } = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+
+const MAX_FRAME_BYTES = 256 * 1024 * 1024;
+const FOLLOW_VERSION = 1;
+const STREAM_VERSION = 11;
+const START_TURN_VERSION = 1;
+const STEER_TURN_VERSION = 1;
+const SNAPSHOT_TIMEOUT_MS = 5_000;
+const TURN_TIMEOUT_MS = 30 * 60_000;
+
+function codexHome() {
+  return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+}
+
+function writeResult(result) {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function fail(message, code = 'bridge-failed') {
+  const error = new Error(message);
+  error.code = code;
+  throw error;
+}
+
+function listTasks(limit) {
+  const database = path.join(codexHome(), 'state_5.sqlite');
+  const catalogDatabase = path.join(codexHome(), 'sqlite', 'codex-dev.db');
+  if (!fs.existsSync(database) || !fs.existsSync(catalogDatabase)) {
+    fail('Codex task catalog is unavailable.', 'catalog-unavailable');
+  }
+  const boundedLimit = Math.max(1, Math.min(Number(limit) || 50, 100));
+  const escapedCatalogDatabase = catalogDatabase.replaceAll("'", "''");
+  const query = `
+    ATTACH DATABASE '${escapedCatalogDatabase}' AS desktop_catalog;
+    SELECT
+      state.id AS id,
+      COALESCE(
+        NULLIF(catalog.display_title, ''),
+        NULLIF(state.name, ''),
+        NULLIF(SUBSTR(REPLACE(state.preview, CHAR(10), ' '), 1, 96), ''),
+        'Untitled task'
+      ) AS title,
+      COALESCE(state.preview, '') AS preview,
+      state.cwd AS cwd,
+      CASE WHEN state.updated_at_ms > 0 THEN state.updated_at_ms / 1000.0 ELSE state.updated_at END AS updatedAt
+    FROM threads AS state
+    LEFT JOIN desktop_catalog.local_thread_catalog AS catalog
+      ON catalog.host_id = 'local' AND catalog.thread_id = state.id AND catalog.missing_candidate = 0
+    WHERE
+      state.archived = 0
+    ORDER BY state.recency_at_ms DESC, state.updated_at_ms DESC
+    LIMIT ${boundedLimit};
+  `;
+  const output = execFileSync('/usr/bin/sqlite3', ['-readonly', '-json', database, query], {
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return JSON.parse(output || '[]');
+}
+
+function assertPrivateCodexSocket(socketPath) {
+  const socket = fs.lstatSync(socketPath);
+  const directory = fs.lstatSync(path.dirname(socketPath));
+  if (!socket.isSocket() || socket.uid !== process.getuid()) {
+    fail('Codex Desktop IPC socket is not owned by this user.', 'unsafe-socket');
+  }
+  if (!directory.isDirectory() || directory.uid !== process.getuid() || (directory.mode & 0o022) !== 0) {
+    fail('Codex Desktop IPC directory is not private.', 'unsafe-socket');
+  }
+}
+
+function assertRolloutPath(rolloutPath, threadId) {
+  const sessionsRoot = path.resolve(codexHome(), 'sessions');
+  const resolved = path.resolve(rolloutPath);
+  if (!resolved.startsWith(`${sessionsRoot}${path.sep}`) || !path.basename(resolved).includes(threadId)) {
+    fail('Codex Desktop returned an unsafe task transcript path.', 'unsafe-rollout-path');
+  }
+  const info = fs.lstatSync(resolved);
+  if (!info.isFile() || info.isSymbolicLink() || info.uid !== process.getuid()) {
+    fail('Codex task transcript is not a private user-owned file.', 'unsafe-rollout-path');
+  }
+  return resolved;
+}
+
+function latestActiveTurnId(rolloutPath) {
+  const size = fs.statSync(rolloutPath).size;
+  const maximumScan = 32 * 1024 * 1024;
+  const start = Math.max(0, size - maximumScan);
+  const descriptor = fs.openSync(rolloutPath, 'r');
+  let text;
+  try {
+    const data = Buffer.allocUnsafe(size - start);
+    fs.readSync(descriptor, data, 0, data.length, start);
+    text = data.toString('utf8');
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  if (start > 0) text = text.slice(text.indexOf('\n') + 1);
+
+  let activeTurnId = null;
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    let record;
+    try { record = JSON.parse(line); } catch { continue; }
+    const payload = record?.type === 'event_msg' ? record.payload : null;
+    if (payload?.type === 'task_started' && typeof payload.turn_id === 'string') {
+      activeTurnId = payload.turn_id;
+    } else if (
+      ['task_complete', 'task_failed', 'turn_aborted'].includes(payload?.type) &&
+      payload?.turn_id === activeTurnId
+    ) {
+      activeTurnId = null;
+    }
+  }
+  return activeTurnId;
+}
+
+function frame(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8');
+  if (body.length === 0 || body.length > MAX_FRAME_BYTES) fail('Desktop IPC message is too large.');
+  const output = Buffer.allocUnsafe(body.length + 4);
+  output.writeUInt32LE(body.length, 0);
+  body.copy(output, 4);
+  return output;
+}
+
+class DesktopIPCClient {
+  constructor(threadId) {
+    this.threadId = threadId;
+    this.socketPath = path.join(codexHome(), 'ipc', 'ipc.sock');
+    this.clientId = 'initializing-client';
+    this.ownerClientId = null;
+    this.socket = null;
+    this.buffer = Buffer.alloc(0);
+    this.pending = new Map();
+    this.snapshotWaiter = null;
+  }
+
+  async connect() {
+    assertPrivateCodexSocket(this.socketPath);
+    this.socket = net.connect(this.socketPath);
+    this.socket.on('data', (chunk) => this.onData(chunk));
+    this.socket.on('error', (error) => this.rejectAll(error));
+    this.socket.on('close', () => this.rejectAll(new Error('Codex Desktop IPC connection closed.')));
+    await new Promise((resolve, reject) => {
+      this.socket.once('connect', resolve);
+      this.socket.once('error', reject);
+    });
+    const initialized = await this.request('initialize', { clientType: 'speakeasy' }, {
+      allowUninitialized: true,
+      version: 0,
+      timeoutMs: SNAPSHOT_TIMEOUT_MS,
+    });
+    if (initialized.resultType !== 'success' || typeof initialized.result?.clientId !== 'string') {
+      fail('Codex Desktop rejected the SpeakEasy bridge.', 'desktop-unavailable');
+    }
+    this.clientId = initialized.result.clientId;
+  }
+
+  async follow() {
+    const snapshotPromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.snapshotWaiter = null;
+        reject(Object.assign(
+          new Error('Open the locked task in Codex Desktop, then try the hotkey again.'),
+          { code: 'task-owner-unavailable' },
+        ));
+      }, SNAPSHOT_TIMEOUT_MS);
+      this.snapshotWaiter = {
+        resolve: (snapshot) => {
+          clearTimeout(timer);
+          this.snapshotWaiter = null;
+          resolve(snapshot);
+        },
+        reject,
+      };
+    });
+    this.broadcast('thread-stream-following-changed', {
+      conversationId: this.threadId,
+      hostId: 'local',
+      following: true,
+    }, FOLLOW_VERSION);
+    return snapshotPromise;
+  }
+
+  async startTurn(text, ownerClientId) {
+    const response = await this.request('thread-follower-start-turn', {
+      conversationId: this.threadId,
+      turnStartParams: {
+        input: [{ type: 'text', text, text_elements: [] }],
+        attachments: [],
+      },
+    }, {
+      targetClientId: ownerClientId,
+      version: START_TURN_VERSION,
+      timeoutMs: 30_000,
+    });
+    if (response.resultType !== 'success') {
+      fail(`Codex Desktop could not start the turn: ${response.error || 'unknown error'}`, 'turn-start-failed');
+    }
+    const turnId = response.result?.result?.turn?.id;
+    if (typeof turnId !== 'string' || turnId.length === 0) {
+      fail('Codex Desktop returned an unreadable turn response.', 'protocol-mismatch');
+    }
+    return turnId;
+  }
+
+  async steerTurn(text, ownerClientId, state) {
+    const clientUserMessageId = randomUUID();
+    const context = {
+      prompt: text,
+      workspaceRoots: state.cwd ? [state.cwd] : [],
+      collaborationMode: state.latestCollaborationMode || null,
+      commentAttachments: [],
+      imageAttachments: [],
+      fileAttachments: [],
+      pastedTextAttachments: [],
+      addedFiles: [],
+      appshotContexts: [],
+      mcpAppModelContextAttachments: [],
+    };
+    const response = await this.request('thread-follower-steer-turn', {
+      conversationId: this.threadId,
+      input: [{ type: 'text', text, text_elements: [] }],
+      restoreMessage: {
+        id: clientUserMessageId,
+        text,
+        context,
+        cwd: state.cwd || '/',
+        createdAt: Date.now(),
+      },
+      serviceTier: null,
+      attachments: [],
+      clientUserMessageId,
+    }, {
+      targetClientId: ownerClientId,
+      version: STEER_TURN_VERSION,
+      timeoutMs: 30_000,
+    });
+    if (response.resultType !== 'success') {
+      fail(`Codex Desktop could not steer the active turn: ${response.error || 'unknown error'}`, 'turn-steer-failed');
+    }
+  }
+
+  broadcast(method, params, version) {
+    this.send({
+      type: 'broadcast',
+      method,
+      sourceClientId: this.clientId,
+      params,
+      version,
+    });
+  }
+
+  request(method, params, options = {}) {
+    if (!options.allowUninitialized && this.clientId === 'initializing-client') {
+      fail('Desktop IPC client is not initialized.', 'desktop-unavailable');
+    }
+    const requestId = randomUUID();
+    const timeoutMs = options.timeoutMs || 5_000;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(Object.assign(new Error(`Timed out waiting for ${method}.`), { code: 'desktop-timeout' }));
+      }, timeoutMs);
+      this.pending.set(requestId, { resolve, reject, timer });
+      this.send({
+        type: 'request',
+        requestId,
+        sourceClientId: this.clientId,
+        targetClientId: options.targetClientId,
+        version: options.version || 0,
+        method,
+        params,
+        timeoutMs,
+      });
+    });
+  }
+
+  send(message) {
+    if (!this.socket?.writable) fail('Codex Desktop IPC is not connected.', 'desktop-unavailable');
+    this.socket.write(frame(message));
+  }
+
+  onData(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while (this.buffer.length >= 4) {
+      const length = this.buffer.readUInt32LE(0);
+      if (length === 0 || length > MAX_FRAME_BYTES) {
+        this.rejectAll(new Error(`Invalid Desktop IPC frame length: ${length}`));
+        this.socket?.destroy();
+        return;
+      }
+      if (this.buffer.length < length + 4) return;
+      const message = JSON.parse(this.buffer.subarray(4, length + 4).toString('utf8'));
+      this.buffer = this.buffer.subarray(length + 4);
+      this.onMessage(message);
+    }
+  }
+
+  onMessage(message) {
+    if (message.type === 'response') {
+      const waiter = this.pending.get(message.requestId);
+      if (waiter) {
+        clearTimeout(waiter.timer);
+        this.pending.delete(message.requestId);
+        waiter.resolve(message);
+      }
+      return;
+    }
+    if (message.type !== 'broadcast' || message.method !== 'thread-stream-state-changed') return;
+    if (message.version !== STREAM_VERSION) {
+      this.snapshotWaiter?.reject(Object.assign(
+        new Error('Codex Desktop task streaming protocol changed; update SpeakEasy.'),
+        { code: 'protocol-mismatch' },
+      ));
+      this.snapshotWaiter = null;
+      return;
+    }
+    const { params } = message;
+    if (
+      params?.hostId !== 'local' ||
+      params?.conversationId !== this.threadId ||
+      params?.change?.type !== 'snapshot'
+    ) return;
+    this.ownerClientId = message.sourceClientId;
+    this.snapshotWaiter?.resolve({
+      ownerClientId: message.sourceClientId,
+      state: params.change.conversationState,
+    });
+  }
+
+  rejectAll(error) {
+    for (const waiter of this.pending.values()) {
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+    this.pending.clear();
+    this.snapshotWaiter?.reject(error);
+    this.snapshotWaiter = null;
+  }
+
+  close() {
+    if (this.clientId !== 'initializing-client' && this.socket?.writable) {
+      this.broadcast('thread-stream-following-changed', {
+        conversationId: this.threadId,
+        hostId: 'local',
+        following: false,
+      }, FOLLOW_VERSION);
+    }
+    this.socket?.end();
+  }
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForTurn(rolloutPath, offset, turnId) {
+  const descriptor = fs.openSync(rolloutPath, 'r');
+  let position = offset;
+  let pending = '';
+  const deadline = Date.now() + TURN_TIMEOUT_MS;
+  try {
+    while (Date.now() < deadline) {
+      const size = fs.fstatSync(descriptor).size;
+      if (size > position) {
+        const chunk = Buffer.allocUnsafe(Math.min(size - position, 1024 * 1024));
+        const count = fs.readSync(descriptor, chunk, 0, chunk.length, position);
+        position += count;
+        pending += chunk.subarray(0, count).toString('utf8');
+        const lines = pending.split('\n');
+        pending = lines.pop() || '';
+        for (const line of lines) {
+          if (!line) continue;
+          let record;
+          try { record = JSON.parse(line); } catch { continue; }
+          const payload = record?.payload;
+          if (record?.type !== 'event_msg' || !payload) continue;
+          if (payload.type === 'task_complete' && payload.turn_id === turnId) {
+            const response = String(payload.last_agent_message || '').trim();
+            if (!response) fail('Codex completed without a final answer.', 'empty-response');
+            return response;
+          }
+          if (
+            (payload.type === 'task_failed' || payload.type === 'turn_aborted') &&
+            payload.turn_id === turnId
+          ) {
+            fail(payload.message || 'The Codex turn failed.', 'turn-failed');
+          }
+        }
+      }
+      await sleep(150);
+    }
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  fail('Timed out waiting for the Codex response.', 'turn-timeout');
+}
+
+async function withClient(threadId, action) {
+  const client = new DesktopIPCClient(threadId);
+  try {
+    await client.connect();
+    const snapshot = await client.follow();
+    return await action(client, snapshot);
+  } finally {
+    client.close();
+  }
+}
+
+async function main() {
+  const [command, argument] = process.argv.slice(2);
+  if (command === 'list') {
+    writeResult({ ok: true, tasks: listTasks(argument) });
+    return;
+  }
+  if ((command === 'validate' || command === 'submit') && argument) {
+    const result = await withClient(argument, async (client, snapshot) => {
+      const state = snapshot.state || {};
+      const rolloutPath = assertRolloutPath(state.rolloutPath, argument);
+      if (state.id !== argument) fail('Codex Desktop returned the wrong task.', 'task-mismatch');
+      if (command === 'validate') {
+        return {
+          ok: true,
+          task: { id: state.id, title: state.title || 'Untitled task', cwd: state.cwd || '' },
+        };
+      }
+      const text = (await readStdin()).trim();
+      if (!text) fail('The transcript is empty.', 'empty-transcript');
+      const offset = fs.statSync(rolloutPath).size;
+      const taskIsActive = state?.threadRuntimeStatus?.type === 'active';
+      const activeTurnId = taskIsActive ? latestActiveTurnId(rolloutPath) : null;
+      if (taskIsActive && !activeTurnId) {
+        fail('Codex Desktop reports an active task without a correlatable turn.', 'protocol-mismatch');
+      }
+      let turnId;
+      let delivery;
+      if (activeTurnId) {
+        await client.steerTurn(text, snapshot.ownerClientId, state);
+        turnId = activeTurnId;
+        delivery = 'steered-active-turn';
+      } else {
+        turnId = await client.startTurn(text, snapshot.ownerClientId);
+        delivery = 'started-turn';
+      }
+      const response = await waitForTurn(rolloutPath, offset, turnId);
+      return { ok: true, threadId: argument, turnId, delivery, response };
+    });
+    writeResult(result);
+    return;
+  }
+  fail('Usage: codex-desktop-bridge.cjs list [limit] | validate <task-id> | submit <task-id>', 'usage');
+}
+
+main().catch((error) => {
+  writeResult({
+    ok: false,
+    code: error?.code || 'bridge-failed',
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exitCode = 1;
+});

--- a/app/Sources/SpeakEasy/SpeakEasyApp.swift
+++ b/app/Sources/SpeakEasy/SpeakEasyApp.swift
@@ -74,7 +74,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // A compact non-activating panel stays interactive without blocking the
         // rest of the screen while narration is playing.
         let screen = NSScreen.main ?? NSScreen.screens.first!
-        let panelSize = NSSize(width: 480, height: 180)
+        let panelSize = NSSize(width: HUDLayout.width, height: HUDLayout.height)
         let panelOrigin = hudOrigin(
             position: hudPosition,
             size: panelSize,

--- a/app/Sources/SpeakEasy/SpeakEasyApp.swift
+++ b/app/Sources/SpeakEasy/SpeakEasyApp.swift
@@ -17,6 +17,7 @@ struct SpeakEasyApp: App {
     }
 }
 
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     var hudWindow: NSPanel?
     private var hudWindowManager: HUDWindowManager?
@@ -111,6 +112,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         manager.start(duration: duration)
+        manager.bindListening(ListeningSessionController.shared)
         if manager.isVisible {
             window.orderFrontRegardless()
         } else {

--- a/app/Sources/SpeakEasy/SystemResponseNarrator.swift
+++ b/app/Sources/SpeakEasy/SystemResponseNarrator.swift
@@ -1,0 +1,304 @@
+import Foundation
+
+struct SpeechNarrationConfiguration: Sendable {
+    let provider: String
+    let voice: String
+    let model: String?
+    let apiKey: String
+    let instructions: String?
+    let rate: Int
+}
+
+enum ConfiguredResponseNarratorError: LocalizedError {
+    case missingAPIKey(String)
+    case unsupportedProvider(String)
+    case invalidResponse(String)
+    case generationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey(let provider):
+            return "\(provider.capitalized) narration needs an API key in SpeakEasy settings."
+        case .unsupportedProvider(let provider):
+            return "SpeakEasy listening cannot yet narrate with \(provider)."
+        case .invalidResponse(let provider):
+            return "\(provider.capitalized) returned unreadable audio."
+        case .generationFailed(let detail):
+            return detail
+        }
+    }
+}
+
+/// Renders with the provider explicitly configured in SpeakEasy. Provider
+/// failures are surfaced to the user and never silently downgraded to `say`.
+actor ConfiguredResponseNarrator {
+    func render(text: String, configuration: SpeechNarrationConfiguration) async throws -> URL {
+        let spokenText = Self.flatten(text)
+        switch configuration.provider {
+        case "system":
+            return try renderSystem(text: spokenText, configuration: configuration)
+        case "openai":
+            return try await renderOpenAI(text: spokenText, configuration: configuration)
+        case "elevenlabs":
+            return try await renderElevenLabs(text: spokenText, configuration: configuration)
+        case "groq":
+            return try await renderGroq(text: spokenText, configuration: configuration)
+        case "gemini":
+            return try await renderGemini(text: spokenText, configuration: configuration)
+        default:
+            throw ConfiguredResponseNarratorError.unsupportedProvider(configuration.provider)
+        }
+    }
+
+    private func renderSystem(
+        text: String,
+        configuration: SpeechNarrationConfiguration
+    ) throws -> URL {
+        let url = temporaryURL(extension: "aiff")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+        process.arguments = [
+            "-v", configuration.voice,
+            "-r", String(max(80, min(configuration.rate, 300))),
+            "-o", url.path,
+            text,
+        ]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            try? FileManager.default.removeItem(at: url)
+            throw ConfiguredResponseNarratorError.generationFailed(
+                "macOS speech generation failed with status \(process.terminationStatus)."
+            )
+        }
+        return try secure(url)
+    }
+
+    private func renderOpenAI(
+        text: String,
+        configuration: SpeechNarrationConfiguration
+    ) async throws -> URL {
+        try requireAPIKey(configuration)
+        var body: [String: Any] = [
+            "model": configuration.model?.nilIfEmpty ?? "tts-1",
+            "voice": configuration.voice,
+            "input": text,
+            "speed": max(0.25, min(Double(configuration.rate) / 200, 4)),
+        ]
+        if let instructions = configuration.instructions?.nilIfEmpty {
+            body["instructions"] = instructions
+        }
+        let request = try jsonRequest(
+            url: URL(string: "https://api.openai.com/v1/audio/speech")!,
+            headers: ["Authorization": "Bearer \(configuration.apiKey)"],
+            body: body
+        )
+        return try await downloadAudio(request, provider: "openai", extension: "mp3")
+    }
+
+    private func renderElevenLabs(
+        text: String,
+        configuration: SpeechNarrationConfiguration
+    ) async throws -> URL {
+        try requireAPIKey(configuration)
+        guard let encodedVoice = configuration.voice.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed
+        ) else { throw ConfiguredResponseNarratorError.invalidResponse("elevenlabs") }
+        let request = try jsonRequest(
+            url: URL(string: "https://api.elevenlabs.io/v1/text-to-speech/\(encodedVoice)")!,
+            headers: [
+                "Accept": "audio/mpeg",
+                "xi-api-key": configuration.apiKey,
+            ],
+            body: [
+                "text": text,
+                "model_id": configuration.model?.nilIfEmpty ?? "eleven_multilingual_v2",
+                "voice_settings": ["stability": 0.5, "similarity_boost": 0.5],
+            ]
+        )
+        return try await downloadAudio(request, provider: "elevenlabs", extension: "mp3")
+    }
+
+    private func renderGroq(
+        text: String,
+        configuration: SpeechNarrationConfiguration
+    ) async throws -> URL {
+        try requireAPIKey(configuration)
+        let request = try jsonRequest(
+            url: URL(string: "https://api.groq.com/openai/v1/audio/speech")!,
+            headers: ["Authorization": "Bearer \(configuration.apiKey)"],
+            body: [
+                "model": configuration.model?.nilIfEmpty ?? "canopylabs/orpheus-v1-english",
+                "voice": configuration.voice,
+                "input": text,
+                "response_format": "mp3",
+            ]
+        )
+        return try await downloadAudio(request, provider: "groq", extension: "mp3")
+    }
+
+    private func renderGemini(
+        text: String,
+        configuration: SpeechNarrationConfiguration
+    ) async throws -> URL {
+        try requireAPIKey(configuration)
+        let model = configuration.model?.nilIfEmpty ?? "gemini-2.5-flash-preview-tts"
+        guard let encodedModel = model.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let encodedKey = configuration.apiKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(encodedModel):generateContent?key=\(encodedKey)")
+        else { throw ConfiguredResponseNarratorError.invalidResponse("gemini") }
+        let request = try jsonRequest(
+            url: url,
+            headers: [:],
+            body: [
+                "contents": [["parts": [["text": text]]]],
+                "generationConfig": [
+                    "responseModalities": ["AUDIO"],
+                    "speechConfig": [
+                        "voiceConfig": ["prebuiltVoiceConfig": ["voiceName": configuration.voice]],
+                    ],
+                ],
+            ]
+        )
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validate(response, data: data, provider: "gemini")
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let candidates = object["candidates"] as? [[String: Any]],
+              let content = candidates.first?["content"] as? [String: Any],
+              let parts = content["parts"] as? [[String: Any]],
+              let inlineData = parts.first?["inlineData"] as? [String: Any],
+              let mimeType = inlineData["mimeType"] as? String,
+              let encodedAudio = inlineData["data"] as? String,
+              let audio = Data(base64Encoded: encodedAudio)
+        else { throw ConfiguredResponseNarratorError.invalidResponse("gemini") }
+        let outputURL = temporaryURL(extension: "wav")
+        let output = mimeType.localizedCaseInsensitiveContains("wav")
+            ? audio
+            : try Self.pcmWAV(audio: audio, mimeType: mimeType)
+        try output.write(to: outputURL, options: .atomic)
+        return try secure(outputURL)
+    }
+
+    private func downloadAudio(
+        _ request: URLRequest,
+        provider: String,
+        extension fileExtension: String
+    ) async throws -> URL {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validate(response, data: data, provider: provider)
+        guard !data.isEmpty else { throw ConfiguredResponseNarratorError.invalidResponse(provider) }
+        let url = temporaryURL(extension: fileExtension)
+        try data.write(to: url, options: .atomic)
+        return try secure(url)
+    }
+
+    private func jsonRequest(
+        url: URL,
+        headers: [String: String],
+        body: [String: Any]
+    ) throws -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        for (name, value) in headers { request.setValue(value, forHTTPHeaderField: name) }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func validate(_ response: URLResponse, data: Data, provider: String) throws {
+        guard let response = response as? HTTPURLResponse else {
+            throw ConfiguredResponseNarratorError.invalidResponse(provider)
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            let detail = (try? JSONSerialization.jsonObject(with: data) as? [String: Any])
+                .flatMap { ($0["error"] as? [String: Any])?["message"] as? String }
+            throw ConfiguredResponseNarratorError.generationFailed(
+                detail?.nilIfEmpty ?? "\(provider.capitalized) narration failed with status \(response.statusCode)."
+            )
+        }
+    }
+
+    private func requireAPIKey(_ configuration: SpeechNarrationConfiguration) throws {
+        guard !configuration.apiKey.isEmpty else {
+            throw ConfiguredResponseNarratorError.missingAPIKey(configuration.provider)
+        }
+    }
+
+    private func temporaryURL(extension fileExtension: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("speakeasy-response-\(UUID().uuidString)")
+            .appendingPathExtension(fileExtension)
+    }
+
+    private func secure(_ url: URL) throws -> URL {
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        return url
+    }
+
+    static func flatten(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "```", with: "")
+            .replacingOccurrences(of: "`", with: "")
+            .replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "__", with: "")
+            .replacingOccurrences(of: "#", with: "")
+            .replacingOccurrences(of: "\n- ", with: ". ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .split(whereSeparator: \Character.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    /// Gemini currently returns headerless mono PCM (`audio/L16`) for its
+    /// speech modality. AVFoundation needs a WAV container to play it.
+    static func pcmWAV(audio: Data, mimeType: String) throws -> Data {
+        guard mimeType.localizedCaseInsensitiveContains("audio/l16"), !audio.isEmpty else {
+            throw ConfiguredResponseNarratorError.invalidResponse("gemini")
+        }
+        let parameters = Dictionary(uniqueKeysWithValues: mimeType
+            .split(separator: ";")
+            .dropFirst()
+            .compactMap { component -> (String, String)? in
+                let pair = component.split(separator: "=", maxSplits: 1).map(String.init)
+                guard pair.count == 2 else { return nil }
+                return (pair[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), pair[1])
+            })
+        let sampleRate = UInt32(parameters["rate"] ?? "24000") ?? 24_000
+        let bitsPerSample = UInt16(parameters["bits"] ?? "16") ?? 16
+        let channelCount: UInt16 = 1
+        let byteRate = sampleRate * UInt32(channelCount) * UInt32(bitsPerSample) / 8
+        let blockAlign = channelCount * bitsPerSample / 8
+
+        var wav = Data("RIFF".utf8)
+        wav.appendLittleEndian(UInt32(36 + audio.count))
+        wav.append(Data("WAVEfmt ".utf8))
+        wav.appendLittleEndian(UInt32(16))
+        wav.appendLittleEndian(UInt16(1))
+        wav.appendLittleEndian(channelCount)
+        wav.appendLittleEndian(sampleRate)
+        wav.appendLittleEndian(byteRate)
+        wav.appendLittleEndian(blockAlign)
+        wav.appendLittleEndian(bitsPerSample)
+        wav.append(Data("data".utf8))
+        wav.appendLittleEndian(UInt32(audio.count))
+        wav.append(audio)
+        return wav
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}
+
+private extension Data {
+    mutating func appendLittleEndian(_ value: UInt16) {
+        append(UInt8(value & 0xff))
+        append(UInt8((value >> 8) & 0xff))
+    }
+
+    mutating func appendLittleEndian(_ value: UInt32) {
+        append(UInt8(value & 0xff))
+        append(UInt8((value >> 8) & 0xff))
+        append(UInt8((value >> 16) & 0xff))
+        append(UInt8((value >> 24) & 0xff))
+    }
+}

--- a/app/Sources/SpeakEasy/SystemResponseNarrator.swift
+++ b/app/Sources/SpeakEasy/SystemResponseNarrator.swift
@@ -1,12 +1,32 @@
 import Foundation
 
-struct SpeechNarrationConfiguration: Sendable {
+struct SpeechNarrationConfiguration: Equatable, Sendable {
     let provider: String
     let voice: String
     let model: String?
     let apiKey: String
     let instructions: String?
     let rate: Int
+
+    func applying(lane: VoiceLane?) -> SpeechNarrationConfiguration {
+        guard let lane else { return self }
+        let effectiveVoice = lane.voiceOverride?.provider == provider
+            ? lane.voiceOverride?.voiceID ?? voice
+            : voice
+        let laneCue = VoiceLane.normalizedNarrationCue(lane.narrationCue)
+        let effectiveInstructions = [instructions?.nilIfEmpty, laneCue]
+            .compactMap { $0 }
+            .joined(separator: "\n\n")
+            .nilIfEmpty
+        return SpeechNarrationConfiguration(
+            provider: provider,
+            voice: effectiveVoice,
+            model: model,
+            apiKey: apiKey,
+            instructions: effectiveInstructions,
+            rate: rate
+        )
+    }
 }
 
 enum ConfiguredResponseNarratorError: LocalizedError {

--- a/app/Sources/SpeakEasy/VoiceLane.swift
+++ b/app/Sources/SpeakEasy/VoiceLane.swift
@@ -17,15 +17,18 @@ struct VoiceLane: Codable, Equatable, Identifiable, Sendable {
     let number: Int
     let task: ListeningTaskLock
     var voiceOverride: LaneVoiceOverride?
+    var narrationCue: String?
 
     init(
         number: Int,
         task: ListeningTaskLock,
-        voiceOverride: LaneVoiceOverride? = nil
+        voiceOverride: LaneVoiceOverride? = nil,
+        narrationCue: String? = nil
     ) {
         self.number = number
         self.task = task
         self.voiceOverride = voiceOverride
+        self.narrationCue = Self.normalizedNarrationCue(narrationCue)
     }
 
     var id: Int { number }
@@ -37,5 +40,11 @@ struct VoiceLane: Codable, Equatable, Identifiable, Sendable {
             .prefix(7)
             .joined(separator: " ")
         return words.isEmpty ? "Task \(number)" : words
+    }
+
+    static func normalizedNarrationCue(_ cue: String?) -> String? {
+        guard let cue else { return nil }
+        let normalized = cue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : String(normalized.prefix(240))
     }
 }

--- a/app/Sources/SpeakEasy/VoiceLane.swift
+++ b/app/Sources/SpeakEasy/VoiceLane.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct VoiceLane: Codable, Equatable, Identifiable, Sendable {
+    let number: Int
+    let task: ListeningTaskLock
+
+    var id: Int { number }
+    var shortcutTitle: String { GlobalListeningShortcut.title(forLane: number) }
+
+    var spokenTitle: String {
+        let words = task.title
+            .split(whereSeparator: \Character.isWhitespace)
+            .prefix(7)
+            .joined(separator: " ")
+        return words.isEmpty ? "Task \(number)" : words
+    }
+}

--- a/app/Sources/SpeakEasy/VoiceLane.swift
+++ b/app/Sources/SpeakEasy/VoiceLane.swift
@@ -1,8 +1,32 @@
 import Foundation
 
+struct LaneVoiceOverride: Codable, Equatable, Sendable {
+    let provider: String
+    let voiceID: String
+
+    init?(provider: String, voiceID: String) {
+        let normalizedProvider = provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedVoiceID = voiceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedProvider.isEmpty, !normalizedVoiceID.isEmpty else { return nil }
+        self.provider = normalizedProvider
+        self.voiceID = normalizedVoiceID
+    }
+}
+
 struct VoiceLane: Codable, Equatable, Identifiable, Sendable {
     let number: Int
     let task: ListeningTaskLock
+    var voiceOverride: LaneVoiceOverride?
+
+    init(
+        number: Int,
+        task: ListeningTaskLock,
+        voiceOverride: LaneVoiceOverride? = nil
+    ) {
+        self.number = number
+        self.task = task
+        self.voiceOverride = voiceOverride
+    }
 
     var id: Int { number }
     var shortcutTitle: String { GlobalListeningShortcut.title(forLane: number) }

--- a/app/Sources/SpeakEasy/VoxListeningService.swift
+++ b/app/Sources/SpeakEasy/VoxListeningService.swift
@@ -1,0 +1,42 @@
+import Foundation
+import VoxCore
+import VoxEngine
+
+actor VoxListeningService {
+    static let modelID = "parakeet:v3"
+
+    private let recorder = MicrophoneFileRecorder()
+    private let engine = EngineManager()
+
+    func warmUp() async throws {
+        _ = try await engine.preload(modelId: Self.modelID) { _ in }
+    }
+
+    func startRecording() async throws -> AudioInputDeviceInfo {
+        let recording = try await recorder.start(filePrefix: "speakeasy-listen")
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: recording.url.path
+        )
+        return recording.inputDevice
+    }
+
+    func stopAndTranscribe() async throws -> String {
+        let url = try await recorder.stop()
+        defer { try? FileManager.default.removeItem(at: url) }
+        return try await transcribe(url: url)
+    }
+
+    func transcribeFixture(url: URL) async throws -> String {
+        try await transcribe(url: url)
+    }
+
+    func cancelRecording() async {
+        await recorder.cancel()
+    }
+
+    private func transcribe(url: URL) async throws -> String {
+        let output = try await engine.transcribe(url: url, modelId: Self.modelID)
+        return output.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/app/Sources/SpeakEasy/VoxListeningService.swift
+++ b/app/Sources/SpeakEasy/VoxListeningService.swift
@@ -7,23 +7,35 @@ actor VoxListeningService {
 
     private let recorder = MicrophoneFileRecorder()
     private let engine = EngineManager()
+    private var warmupTask: Task<Void, Error>?
 
     func warmUp() async throws {
         _ = try await engine.preload(modelId: Self.modelID) { _ in }
     }
 
-    func startRecording() async throws -> AudioInputDeviceInfo {
+    /// Opens the microphone first, then warms the local model in parallel with
+    /// the utterance. Stopping waits for warmup before transcription.
+    func startRecordingAndWarm() async throws -> AudioInputDeviceInfo {
         let recording = try await recorder.start(filePrefix: "speakeasy-listen")
         try? FileManager.default.setAttributes(
             [.posixPermissions: 0o600],
             ofItemAtPath: recording.url.path
         )
+        if warmupTask == nil {
+            warmupTask = Task { [engine] in
+                _ = try await engine.preload(modelId: Self.modelID) { _ in }
+            }
+        }
         return recording.inputDevice
     }
 
     func stopAndTranscribe() async throws -> String {
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
+        if let warmupTask {
+            defer { self.warmupTask = nil }
+            try await warmupTask.value
+        }
         return try await transcribe(url: url)
     }
 
@@ -32,6 +44,9 @@ actor VoxListeningService {
     }
 
     func cancelRecording() async {
+        // Keep an in-flight or completed warmup available for the next
+        // utterance. Repeated cancel/re-engage gestures must not fan out model
+        // loads that the underlying Core ML runtime cannot cancel promptly.
         await recorder.cancel()
     }
 

--- a/app/SpeakEasy.entitlements
+++ b/app/SpeakEasy.entitlements
@@ -8,5 +8,8 @@
 
     <key>com.apple.security.network.client</key>
     <true/>
+
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -97,6 +97,7 @@ final class PlayerProtocolTests: XCTestCase {
             phase: .recording,
             taskTitle: "Prototype SpeakEasy listening mode",
             taskID: "019f99a4-7867-7c23-ac29-0c0eca7da603",
+            laneNumber: 2,
             transcript: "",
             error: nil,
             inputDeviceName: "MacBook Air Microphone"
@@ -106,6 +107,35 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertTrue(presentation.detail.contains("⌃⌥Space to send"))
         XCTAssertTrue(presentation.detail.contains("MacBook Air Microphone"))
         XCTAssertEqual(presentation.taskTitle, "Prototype SpeakEasy listening mode")
+        XCTAssertEqual(presentation.laneNumber, 2)
+    }
+
+    func testVoiceLanePersistsItsExactTaskIdentity() throws {
+        let lane = VoiceLane(
+            number: 4,
+            task: ListeningTaskLock(
+                id: "019f99a4-7867-7c23-ac29-0c0eca7da603",
+                title: "Prototype SpeakEasy listening mode",
+                cwd: "/Users/arach/dev/SpeakEasy"
+            )
+        )
+
+        let decoded = try JSONDecoder().decode(
+            VoiceLane.self,
+            from: JSONEncoder().encode(lane)
+        )
+
+        XCTAssertEqual(decoded, lane)
+        XCTAssertEqual(decoded.shortcutTitle, "⌘⌥4")
+        XCTAssertEqual(decoded.task.id, lane.task.id)
+    }
+
+    @MainActor
+    func testLaneShortcutsUseDistinctNumberKeyCodes() {
+        let codes = ListeningSessionController.laneRange.map(GlobalListeningShortcut.keyCode(forLane:))
+        XCTAssertEqual(Set(codes).count, 9)
+        XCTAssertEqual(GlobalListeningShortcut.title(forLane: 1), "⌘⌥1")
+        XCTAssertEqual(GlobalListeningShortcut.title(forLane: 9), "⌘⌥9")
     }
 
     func testCodexTaskLinkRejectsUnsafeThreadIdentifiers() {

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -151,7 +151,8 @@ final class PlayerProtocolTests: XCTestCase {
                 id: "019f99a4-7867-7c23-ac29-0c0eca7da603",
                 title: "Prototype SpeakEasy listening mode",
                 cwd: "/Users/arach/dev/SpeakEasy"
-            )
+            ),
+            voiceOverride: LaneVoiceOverride(provider: "ElevenLabs", voiceID: "  voice-42  ")
         )
 
         let decoded = try JSONDecoder().decode(
@@ -162,6 +163,22 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertEqual(decoded, lane)
         XCTAssertEqual(decoded.shortcutTitle, "⌘⌥4")
         XCTAssertEqual(decoded.task.id, lane.task.id)
+        XCTAssertEqual(decoded.voiceOverride?.provider, "elevenlabs")
+        XCTAssertEqual(decoded.voiceOverride?.voiceID, "voice-42")
+    }
+
+    func testVoiceLaneDecodesLegacyAssignmentsWithoutVoiceOverride() throws {
+        let legacyJSON = #"{"number":3,"task":{"id":"task-3","title":"Legacy task","cwd":"/tmp"}}"#
+        let lane = try JSONDecoder().decode(VoiceLane.self, from: Data(legacyJSON.utf8))
+
+        XCTAssertEqual(lane.number, 3)
+        XCTAssertEqual(lane.task.id, "task-3")
+        XCTAssertNil(lane.voiceOverride)
+    }
+
+    func testLaneVoiceOverrideRejectsBlankProviderOrVoice() {
+        XCTAssertNil(LaneVoiceOverride(provider: "  ", voiceID: "nova"))
+        XCTAssertNil(LaneVoiceOverride(provider: "openai", voiceID: "\n"))
     }
 
     @MainActor

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -92,6 +92,22 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertEqual(wav.suffix(pcm.count), pcm)
     }
 
+    func testConversationHUDNamesTheLockAndExplainsTheHotkey() {
+        let presentation = HUDConversationPresentation(
+            phase: .recording,
+            taskTitle: "Prototype SpeakEasy listening mode",
+            taskID: "019f99a4-7867-7c23-ac29-0c0eca7da603",
+            transcript: "",
+            error: nil,
+            inputDeviceName: "MacBook Air Microphone"
+        )
+
+        XCTAssertEqual(presentation.title, "Listening to you")
+        XCTAssertTrue(presentation.detail.contains("⌃⌥Space to send"))
+        XCTAssertTrue(presentation.detail.contains("MacBook Air Microphone"))
+        XCTAssertEqual(presentation.taskTitle, "Prototype SpeakEasy listening mode")
+    }
+
     func testCodexTaskLinkRejectsUnsafeThreadIdentifiers() {
         XCTAssertEqual(
             CodexTaskLink.url(threadId: "019f9573-3e55-7701-8968-09c12d4fafe5")?.absoluteString,

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -136,6 +136,7 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertEqual(Set(codes).count, 9)
         XCTAssertEqual(GlobalListeningShortcut.title(forLane: 1), "⌘⌥1")
         XCTAssertEqual(GlobalListeningShortcut.title(forLane: 9), "⌘⌥9")
+        XCTAssertEqual(GlobalListeningShortcut.confirmationTitle, "⌘⌥X")
     }
 
     func testCodexTaskLinkRejectsUnsafeThreadIdentifiers() {

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -47,6 +47,49 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertEqual(decoded.arguments?.priority, .high)
         XCTAssertEqual(decoded.arguments?.interrupt, true)
         XCTAssertEqual(decoded.arguments?.item?.sourceThreadId, item.sourceThreadId)
+        XCTAssertNil(decoded.arguments?.item?.cleanupAfterPlayback)
+    }
+
+    func testTemporaryNarrationCanRequestCleanupWithoutBreakingOlderWireItems() throws {
+        let legacyJSON = #"{"id":"daffdeaf-0000-4000-8000-000000000001","audioPath":"/tmp/legacy.aiff","title":"Legacy","createdAt":"2026-07-25T00:00:00Z"}"#
+        let legacy = try JSONDecoder().decode(PlaybackItem.self, from: Data(legacyJSON.utf8))
+        XCTAssertNil(legacy.cleanupAfterPlayback)
+
+        let temporary = PlaybackItem(
+            id: UUID(),
+            audioPath: "/tmp/temporary.aiff",
+            title: "Voice response",
+            text: "Done",
+            provider: "system",
+            createdAt: "2026-07-25T00:00:00Z",
+            synthesisRateWPM: 180,
+            sourceThreadId: "019f9573-3e55-7701-8968-09c12d4fafe5",
+            cleanupAfterPlayback: true
+        )
+        XCTAssertTrue(try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: JSONEncoder().encode(temporary)) as? [String: Any]
+        )["cleanupAfterPlayback"] as? Bool ?? false)
+    }
+
+    func testNarrationFlattenRemovesCommonMarkdown() {
+        XCTAssertEqual(
+            ConfiguredResponseNarrator.flatten("## Result\n- **Passed** with `voice`"),
+            "Result. Passed with voice"
+        )
+    }
+
+    func testGeminiPCMIsWrappedInAPlayableWAVContainer() throws {
+        let pcm = Data([0, 1, 2, 3])
+        let wav = try ConfiguredResponseNarrator.pcmWAV(
+            audio: pcm,
+            mimeType: "audio/L16;codec=pcm;rate=24000"
+        )
+
+        XCTAssertEqual(String(data: wav.prefix(4), encoding: .ascii), "RIFF")
+        XCTAssertEqual(String(data: wav[8..<12], encoding: .ascii), "WAVE")
+        XCTAssertEqual(String(data: wav[36..<40], encoding: .ascii), "data")
+        XCTAssertEqual(wav.count, 44 + pcm.count)
+        XCTAssertEqual(wav.suffix(pcm.count), pcm)
     }
 
     func testCodexTaskLinkRejectsUnsafeThreadIdentifiers() {

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -110,6 +110,40 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertEqual(presentation.laneNumber, 2)
     }
 
+    func testCueingHUDKeepsTaskInHeaderAndExplainsMicOffInBody() {
+        XCTAssertEqual(ListeningPhase.cueing.label, "Confirming")
+
+        let presentation = HUDConversationPresentation(
+            phase: .cueing,
+            taskTitle: "Prototype SpeakEasy listening mode",
+            taskID: "019f99a4-7867-7c23-ac29-0c0eca7da603",
+            laneNumber: 2,
+            transcript: "",
+            error: nil,
+            inputDeviceName: nil
+        )
+
+        XCTAssertEqual(presentation.title, "Lane 2 confirmed")
+        XCTAssertEqual(presentation.detail, "Status check · microphone is off")
+        XCTAssertFalse(presentation.detail.contains(presentation.taskTitle))
+        XCTAssertEqual(presentation.taskTitle, "Prototype SpeakEasy listening mode")
+    }
+
+    func testCompactConversationHUDLayoutKeepsReadableHierarchy() {
+        XCTAssertEqual(HUDLayout.width, 404)
+        XCTAssertEqual(HUDLayout.height, 132)
+        XCTAssertLessThan(HUDLayout.width, 480)
+        XCTAssertLessThan(HUDLayout.height, 180)
+        XCTAssertGreaterThanOrEqual(HUDLayout.titleSize, 13)
+        XCTAssertGreaterThanOrEqual(HUDLayout.detailSize, 10)
+        XCTAssertGreaterThanOrEqual(HUDLayout.iconSize, 30)
+        XCTAssertGreaterThanOrEqual(HUDLayout.energyHeight, 12)
+        XCTAssertGreaterThanOrEqual(HUDLayout.energyBarCount, 24)
+        XCTAssertLessThanOrEqual(HUDPhaseChrome.glowOpacity, 0.12)
+        XCTAssertLessThanOrEqual(HUDPhaseChrome.borderOpacity, 0.24)
+        XCTAssertLessThanOrEqual(HUDPhaseChrome.shadowOpacity, 0.10)
+    }
+
     func testVoiceLanePersistsItsExactTaskIdentity() throws {
         let lane = VoiceLane(
             number: 4,

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -152,7 +152,8 @@ final class PlayerProtocolTests: XCTestCase {
                 title: "Prototype SpeakEasy listening mode",
                 cwd: "/Users/arach/dev/SpeakEasy"
             ),
-            voiceOverride: LaneVoiceOverride(provider: "ElevenLabs", voiceID: "  voice-42  ")
+            voiceOverride: LaneVoiceOverride(provider: "ElevenLabs", voiceID: "  voice-42  "),
+            narrationCue: "  Warm, concise, and energized.  "
         )
 
         let decoded = try JSONDecoder().decode(
@@ -165,6 +166,7 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertEqual(decoded.task.id, lane.task.id)
         XCTAssertEqual(decoded.voiceOverride?.provider, "elevenlabs")
         XCTAssertEqual(decoded.voiceOverride?.voiceID, "voice-42")
+        XCTAssertEqual(decoded.narrationCue, "Warm, concise, and energized.")
     }
 
     func testVoiceLaneDecodesLegacyAssignmentsWithoutVoiceOverride() throws {
@@ -179,6 +181,72 @@ final class PlayerProtocolTests: XCTestCase {
     func testLaneVoiceOverrideRejectsBlankProviderOrVoice() {
         XCTAssertNil(LaneVoiceOverride(provider: "  ", voiceID: "nova"))
         XCTAssertNil(LaneVoiceOverride(provider: "openai", voiceID: "\n"))
+    }
+
+    func testLaneNarrationAppliesOnlyTheMatchingProviderVoice() throws {
+        let task = ListeningTaskLock(id: "task-2", title: "Voice task", cwd: "/tmp")
+        let lane = VoiceLane(
+            number: 2,
+            task: task,
+            voiceOverride: try XCTUnwrap(LaneVoiceOverride(provider: "openai", voiceID: "coral")),
+            narrationCue: "Speak with bright, compact energy."
+        )
+        let openAI = SpeechNarrationConfiguration(
+            provider: "openai",
+            voice: "nova",
+            model: "gpt-4o-mini-tts",
+            apiKey: "test-key",
+            instructions: "Pronounce product names precisely.",
+            rate: 190
+        )
+
+        let applied = openAI.applying(lane: lane)
+        XCTAssertEqual(applied.voice, "coral")
+        XCTAssertEqual(
+            applied.instructions,
+            "Pronounce product names precisely.\n\nSpeak with bright, compact energy."
+        )
+
+        let system = SpeechNarrationConfiguration(
+            provider: "system",
+            voice: "Samantha",
+            model: nil,
+            apiKey: "",
+            instructions: nil,
+            rate: 180
+        ).applying(lane: lane)
+        XCTAssertEqual(system.voice, "Samantha")
+    }
+
+    func testTurnContextKeepsItsNarrationSnapshot() {
+        let lock = ListeningTaskLock(id: "task-7", title: "Snapshot task", cwd: "/tmp")
+        let narration = SpeechNarrationConfiguration(
+            provider: "openai",
+            voice: "coral",
+            model: "gpt-4o-mini-tts",
+            apiKey: "test-key",
+            instructions: "Keep it crisp.",
+            rate: 205
+        )
+        let context = ListeningTurnContext(
+            lock: lock,
+            laneNumber: 7,
+            narration: narration,
+            playbackVolume: 0.65
+        )
+
+        XCTAssertEqual(context.lock, lock)
+        XCTAssertEqual(context.laneNumber, 7)
+        XCTAssertEqual(context.narration, narration)
+        XCTAssertEqual(context.playbackVolume, 0.65)
+    }
+
+    func testCodexDeliveryNamesNewTurnsAndActiveTurnSteers() {
+        XCTAssertEqual(CodexTurnDelivery.startedTurn.label, "Started a new turn in the exact task")
+        XCTAssertEqual(
+            CodexTurnDelivery.steeredActiveTurn.label,
+            "Steered the active turn in the exact task"
+        )
     }
 
     @MainActor

--- a/app/tools/release/common.sh
+++ b/app/tools/release/common.sh
@@ -87,6 +87,16 @@ speakeasy_bundle_swiftpm_frameworks() {
     fi
 }
 
+speakeasy_bundle_swiftpm_resources() {
+    local build_bin_dir="$1"
+    local resources_dir="$2"
+    local resource_bundle
+
+    while IFS= read -r -d '' resource_bundle; do
+        ditto "$resource_bundle" "$resources_dir/$(basename "$resource_bundle")"
+    done < <(find -L "$build_bin_dir" -maxdepth 1 -type d -name '*.bundle' -print0)
+}
+
 speakeasy_verify_bundle_layout() {
     local bundle_path="$1"
     local executable="$bundle_path/Contents/MacOS/SpeakEasy"
@@ -139,6 +149,10 @@ speakeasy_bundle_app() {
         "$build_dir" \
         "$bundle_path/Contents/Frameworks" \
         "$app_root/.build/artifacts"
+
+    speakeasy_bundle_swiftpm_resources \
+        "$build_dir" \
+        "$bundle_path/Contents/Resources"
 
     cp "$app_root/Resources/Info.plist" "$bundle_path/Contents/"
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -388,6 +388,7 @@ interface PlaybackItem {
     createdAt: string;
     synthesisRateWPM?: number;
     sourceThreadId?: string;
+    cleanupAfterPlayback?: boolean;
 }
 interface PlayerCommandArguments {
     item?: PlaybackItem;
@@ -474,4 +475,4 @@ declare const speak: (text: string, options?: SpeakEasyOptions & {
     volume?: number;
 }) => Promise<void>;
 
-export { CONFIG_FILE, CacheMetadata, CacheStats, ElevenLabsProvider, EnqueueOptions, GeminiProvider, GlobalConfig, GroqProvider, OpenAIProvider, PLAYER_PROTOCOL_VERSION, PLAYER_SOCKET_PATH, PROVIDER_ORDER, PlaybackItem, PlaybackState, PlayerCommand, PlayerCommandArguments, PlayerCommandRequest, PlayerCommandResponse, PlayerSnapshot, PlayerUnavailableError, Provider, ProviderConfig, QueuePriority, SpeakEasy, SpeakEasyConfig, SpeakEasyOptions, SystemProvider, TTSAdapter, TTSAdapterCapabilities, TTSAudioFormat, TTSCache, TTSProviderId, TTSRequest, TTSResult, createAdapterRegistry, enqueueInPlayer, getAvailableVoices, getBestVoice, playAudioFile, playTTSResult, say, sendPlayerCommand, speak, stopPlayback };
+export { CONFIG_FILE, type CacheMetadata, type CacheStats, ElevenLabsProvider, type EnqueueOptions, GeminiProvider, type GlobalConfig, GroqProvider, OpenAIProvider, PLAYER_PROTOCOL_VERSION, PLAYER_SOCKET_PATH, PROVIDER_ORDER, type PlaybackItem, type PlaybackState, type PlayerCommand, type PlayerCommandArguments, type PlayerCommandRequest, type PlayerCommandResponse, type PlayerSnapshot, PlayerUnavailableError, type Provider, type ProviderConfig, type QueuePriority, SpeakEasy, type SpeakEasyConfig, type SpeakEasyOptions, SystemProvider, type TTSAdapter, type TTSAdapterCapabilities, type TTSAudioFormat, TTSCache, type TTSProviderId, type TTSRequest, type TTSResult, createAdapterRegistry, enqueueInPlayer, getAvailableVoices, getBestVoice, playAudioFile, playTTSResult, say, sendPlayerCommand, speak, stopPlayback };

--- a/dist/index.js
+++ b/dist/index.js
@@ -28,8 +28,8 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // src/index.ts
-var src_exports = {};
-__export(src_exports, {
+var index_exports = {};
+__export(index_exports, {
   CONFIG_FILE: () => CONFIG_FILE,
   ElevenLabsProvider: () => ElevenLabsProvider,
   GeminiProvider: () => GeminiProvider,
@@ -53,7 +53,7 @@ __export(src_exports, {
   speak: () => speak,
   stopPlayback: () => stopPlayback
 });
-module.exports = __toCommonJS(src_exports);
+module.exports = __toCommonJS(index_exports);
 var fs5 = __toESM(require("fs"));
 var path5 = __toESM(require("path"));
 
@@ -182,8 +182,7 @@ var PREFERRED_VOICES = [
 ];
 var cachedVoices = null;
 function getAvailableVoices() {
-  if (cachedVoices)
-    return cachedVoices;
+  if (cachedVoices) return cachedVoices;
   try {
     const output = (0, import_child_process2.execSync)('say -v "?"', { encoding: "utf-8" });
     cachedVoices = output.split("\n").filter((line) => line.trim()).map((line) => {
@@ -205,13 +204,11 @@ function getBestVoice(language = "en_US") {
   const englishPremium = available.find(
     (v) => v.includes("(Premium)") && (v.includes("en_") || !v.includes("_"))
   );
-  if (englishPremium)
-    return englishPremium;
+  if (englishPremium) return englishPremium;
   const englishEnhanced = available.find(
     (v) => v.includes("(Enhanced)") && (v.includes("en_") || !v.includes("_"))
   );
-  if (englishEnhanced)
-    return englishEnhanced;
+  if (englishEnhanced) return englishEnhanced;
   return "Samantha";
 }
 var SystemProvider = class {
@@ -281,8 +278,7 @@ var import_uuid = require("uuid");
 
 // src/cache-config.ts
 function parseTTL(ttl) {
-  if (typeof ttl === "number")
-    return ttl;
+  if (typeof ttl === "number") return ttl;
   const units = {
     "ms": 1,
     "s": 1e3,
@@ -294,8 +290,7 @@ function parseTTL(ttl) {
     "y": 365 * 24 * 60 * 60 * 1e3
   };
   const match = ttl.toString().match(/^(\d+(?:\.\d+)?)([a-zA-Z]+)$/);
-  if (!match)
-    throw new Error(`Invalid TTL format: ${ttl}`);
+  if (!match) throw new Error(`Invalid TTL format: ${ttl}`);
   const value = parseFloat(match[1]);
   const unit = match[2];
   if (!(unit in units)) {
@@ -304,8 +299,7 @@ function parseTTL(ttl) {
   return value * units[unit];
 }
 function parseSize(size) {
-  if (typeof size === "number")
-    return size;
+  if (typeof size === "number") return size;
   const units = {
     "B": 1,
     "KB": 1024,
@@ -317,8 +311,7 @@ function parseSize(size) {
     "gb": 1024 * 1024 * 1024
   };
   const match = size.toString().match(/^(\d+(?:\.\d+)?)([a-zA-Z]+)$/);
-  if (!match)
-    throw new Error(`Invalid size format: ${size}`);
+  if (!match) throw new Error(`Invalid size format: ${size}`);
   const value = parseFloat(match[1]);
   const unit = match[2];
   if (!(unit in units)) {
@@ -476,13 +469,11 @@ var TTSCache = class {
     this.loadJsonMetadata();
   }
   migrateJsonMetadataIfNeeded() {
-    if (!this.db || !fs3.existsSync(this.metadataFile))
-      return;
+    if (!this.db || !fs3.existsSync(this.metadataFile)) return;
     try {
       const data = JSON.parse(fs3.readFileSync(this.metadataFile, "utf8"));
       const entries = Object.entries(data.entries || {});
-      if (entries.length === 0)
-        return;
+      if (entries.length === 0) return;
       let imported = 0;
       for (const [cacheKey, entry] of entries) {
         if (this.importStoredEntry(cacheKey, entry)) {
@@ -499,28 +490,23 @@ var TTSCache = class {
     }
   }
   migrateLegacySqliteIfNeeded() {
-    if (!this.db)
-      return;
+    if (!this.db) return;
     const legacyMetadataPath = path3.join(this.cacheDir, "metadata.sqlite");
     const legacyKeyvPath = path3.join(this.cacheDir, "tts-cache.sqlite");
     this.importLegacyMetadataDb(legacyMetadataPath);
     this.importLegacyKeyvDb(legacyKeyvPath);
   }
   importStoredEntry(cacheKey, entry) {
-    if (!this.db || this.getSqliteEntry(cacheKey))
-      return false;
-    if (!entry.audioFilePath || !fs3.existsSync(entry.audioFilePath))
-      return false;
+    if (!this.db || this.getSqliteEntry(cacheKey)) return false;
+    if (!entry.audioFilePath || !fs3.existsSync(entry.audioFilePath)) return false;
     this.upsertSqliteEntry(cacheKey, entry);
     return true;
   }
   importLegacyMetadataDb(legacyPath) {
-    if (!this.db || !fs3.existsSync(legacyPath))
-      return;
+    if (!this.db || !fs3.existsSync(legacyPath)) return;
     try {
       const legacy = openBuiltinSqlite(legacyPath);
-      if (!legacy)
-        return;
+      if (!legacy) return;
       const rows = legacy.db.prepare("SELECT * FROM metadata").all();
       let imported = 0;
       for (const row of rows) {
@@ -558,26 +544,20 @@ var TTSCache = class {
     }
   }
   importLegacyKeyvDb(legacyPath) {
-    if (!this.db || !fs3.existsSync(legacyPath))
-      return;
+    if (!this.db || !fs3.existsSync(legacyPath)) return;
     try {
       const legacy = openBuiltinSqlite(legacyPath);
-      if (!legacy)
-        return;
+      if (!legacy) return;
       const rows = legacy.db.prepare("SELECT key, value FROM keyv").all();
       let imported = 0;
       for (const row of rows) {
         const cacheKey = row.key;
-        if (this.getSqliteEntry(cacheKey))
-          continue;
+        if (this.getSqliteEntry(cacheKey)) continue;
         const parsed = JSON.parse(row.value);
         const entry = parsed.value;
-        if (!entry || !this.isValidEntry(entry))
-          continue;
-        if (parsed.expires && Date.now() > parsed.expires)
-          continue;
-        if (!fs3.existsSync(entry.audioFilePath))
-          continue;
+        if (!entry || !this.isValidEntry(entry)) continue;
+        if (parsed.expires && Date.now() > parsed.expires) continue;
+        if (!fs3.existsSync(entry.audioFilePath)) continue;
         const storedEntry = {
           ...entry,
           fileSize: fs3.statSync(entry.audioFilePath).size
@@ -733,18 +713,15 @@ var TTSCache = class {
     }
   }
   getSource() {
-    if (process.argv[1]?.includes("speakeasy-cli"))
-      return "cli";
-    if (process.env.NODE_ENV === "test")
-      return "test";
+    if (process.argv[1]?.includes("speakeasy-cli")) return "cli";
+    if (process.env.NODE_ENV === "test") return "test";
     return "api";
   }
   getSessionId() {
     return `${Date.now()}-${process.pid}`;
   }
   upsertSqliteEntry(cacheKey, entry) {
-    if (!this.db)
-      return;
+    if (!this.db) return;
     const stmt = this.db.prepare(`
       INSERT OR REPLACE INTO entries (
         cache_key, original_text, provider, voice, rate, timestamp,
@@ -777,14 +754,12 @@ var TTSCache = class {
     );
   }
   getSqliteEntry(cacheKey) {
-    if (!this.db)
-      return void 0;
+    if (!this.db) return void 0;
     const row = this.db.prepare("SELECT * FROM entries WHERE cache_key = ?").get(cacheKey);
     return row ? this.rowToStoredEntry(row) : void 0;
   }
   deleteSqliteEntry(cacheKey) {
-    if (!this.db)
-      return;
+    if (!this.db) return;
     this.db.prepare("DELETE FROM entries WHERE cache_key = ?").run(cacheKey);
   }
   deleteEntry(cacheKey, entry) {
@@ -800,21 +775,17 @@ var TTSCache = class {
     }
   }
   enforceMaxSize() {
-    if (!this.maxSize)
-      return;
+    if (!this.maxSize) return;
     const entries = this.useJsonFallback ? Object.entries(this.jsonEntries).map(([cacheKey, entry]) => ({ cacheKey, entry })) : (this.db?.prepare("SELECT cache_key, file_size, timestamp FROM entries ORDER BY timestamp ASC").all() || []).map((row) => ({
       cacheKey: row.cache_key,
       entry: { fileSize: row.file_size }
     }));
     let totalSize = entries.reduce((sum, item) => sum + (item.entry.fileSize || 0), 0);
-    if (totalSize <= this.maxSize)
-      return;
+    if (totalSize <= this.maxSize) return;
     for (const item of entries) {
-      if (totalSize <= this.maxSize)
-        break;
+      if (totalSize <= this.maxSize) break;
       const entry = this.useJsonFallback ? this.jsonEntries[item.cacheKey] : this.getSqliteEntry(item.cacheKey);
-      if (!entry)
-        continue;
+      if (!entry) continue;
       totalSize -= entry.fileSize;
       this.deleteEntry(item.cacheKey, entry);
     }
@@ -892,34 +863,22 @@ var TTSCache = class {
       const needle = options.text.toLowerCase();
       results = results.filter((entry) => entry.originalText.toLowerCase().includes(needle));
     }
-    if (options.provider)
-      results = results.filter((entry) => entry.provider === options.provider);
-    if (options.model)
-      results = results.filter((entry) => entry.model === options.model);
-    if (options.source)
-      results = results.filter((entry) => entry.source === options.source);
-    if (options.fromDate)
-      results = results.filter((entry) => entry.timestamp >= options.fromDate.getTime());
-    if (options.toDate)
-      results = results.filter((entry) => entry.timestamp <= options.toDate.getTime());
-    if (options.minSize !== void 0)
-      results = results.filter((entry) => entry.fileSize >= options.minSize);
-    if (options.maxSize !== void 0)
-      results = results.filter((entry) => entry.fileSize <= options.maxSize);
-    if (options.success !== void 0)
-      results = results.filter((entry) => entry.success === options.success);
+    if (options.provider) results = results.filter((entry) => entry.provider === options.provider);
+    if (options.model) results = results.filter((entry) => entry.model === options.model);
+    if (options.source) results = results.filter((entry) => entry.source === options.source);
+    if (options.fromDate) results = results.filter((entry) => entry.timestamp >= options.fromDate.getTime());
+    if (options.toDate) results = results.filter((entry) => entry.timestamp <= options.toDate.getTime());
+    if (options.minSize !== void 0) results = results.filter((entry) => entry.fileSize >= options.minSize);
+    if (options.maxSize !== void 0) results = results.filter((entry) => entry.fileSize <= options.maxSize);
+    if (options.success !== void 0) results = results.filter((entry) => entry.success === options.success);
     if (options.workingDirectory) {
       const needle = options.workingDirectory.toLowerCase();
       results = results.filter((entry) => entry.workingDirectory?.toLowerCase().includes(needle));
     }
-    if (options.user)
-      results = results.filter((entry) => entry.user === options.user);
-    if (options.sessionId)
-      results = results.filter((entry) => entry.sessionId === options.sessionId);
-    if (options.offset)
-      results = results.slice(options.offset);
-    if (options.limit)
-      results = results.slice(0, options.limit);
+    if (options.user) results = results.filter((entry) => entry.user === options.user);
+    if (options.sessionId) results = results.filter((entry) => entry.sessionId === options.sessionId);
+    if (options.offset) results = results.slice(options.offset);
+    if (options.limit) results = results.slice(0, options.limit);
     return results;
   }
   calculateStats(metadata) {
@@ -1033,8 +992,7 @@ var TTSCache = class {
     if (this.useJsonFallback) {
       return this.filterJsonMetadata(options);
     }
-    if (!this.db)
-      return [];
+    if (!this.db) return [];
     const { sql, params } = this.buildSearchQuery(options);
     return this.db.prepare(sql).all(...params).map((row) => this.rowToMetadata(row));
   }
@@ -1124,8 +1082,7 @@ var TTSCache = class {
         }
         return;
       }
-      if (!this.db)
-        return;
+      if (!this.db) return;
       const oldEntries = this.db.prepare("SELECT cache_key, file_path FROM entries WHERE timestamp < ?").all(cutoff);
       for (const row of oldEntries) {
         const cacheKey = row.cache_key;
@@ -1160,8 +1117,7 @@ var TTSCache = class {
     return !this.useJsonFallback && this.db !== null;
   }
   getSqliteBackend() {
-    if (this.useJsonFallback)
-      return "json";
+    if (this.useJsonFallback) return "json";
     return this.sqliteBackend || "json";
   }
 };
@@ -1252,8 +1208,7 @@ var NotificationHistory = class {
   getAllHistory() {
     const allEntries = [];
     try {
-      if (!fs4.existsSync(this.historyDir))
-        return allEntries;
+      if (!fs4.existsSync(this.historyDir)) return allEntries;
       const files = fs4.readdirSync(this.historyDir).filter((f) => f.startsWith("history-") && f.endsWith(".json")).sort().reverse();
       for (const file of files) {
         try {
@@ -1871,14 +1826,11 @@ function sendPlayerCommand(command, commandArguments, timeoutMs = 5e3) {
     let buffer = "";
     let settled = false;
     const finish = (error, response) => {
-      if (settled)
-        return;
+      if (settled) return;
       settled = true;
       socket.destroy();
-      if (error)
-        reject(error);
-      else if (response)
-        resolve(response);
+      if (error) reject(error);
+      else if (response) resolve(response);
     };
     socket.setTimeout(timeoutMs, () => {
       finish(new PlayerUnavailableError("SpeakEasy player did not respond"));
@@ -1890,8 +1842,7 @@ function sendPlayerCommand(command, commandArguments, timeoutMs = 5e3) {
     socket.on("data", (chunk) => {
       buffer += chunk.toString("utf8");
       const newline = buffer.indexOf("\n");
-      if (newline < 0)
-        return;
+      if (newline < 0) return;
       try {
         const response = JSON.parse(buffer.slice(0, newline));
         if (response.protocolVersion !== PLAYER_PROTOCOL_VERSION) {
@@ -1916,8 +1867,7 @@ function sendPlayerCommand(command, commandArguments, timeoutMs = 5e3) {
       }
     });
     socket.on("end", () => {
-      if (!settled)
-        finish(new Error("SpeakEasy player closed the connection without a response"));
+      if (!settled) finish(new Error("SpeakEasy player closed the connection without a response"));
     });
   });
 }
@@ -2029,8 +1979,7 @@ var SpeakEasy = class {
     }
   }
   async processQueue() {
-    if (this.queue.length === 0)
-      return;
+    if (this.queue.length === 0) return;
     this.isPlaying = true;
     const { text, options } = this.queue.shift();
     try {
@@ -2052,8 +2001,7 @@ var SpeakEasy = class {
     if (this.debug) {
       console.log(`\u{1F50D} Requested provider: ${requestedId}`);
       console.log(`\u{1F50D} Text: "${text}"`);
-      if (silent)
-        console.log(`\u{1F507} Silent mode: audio will not be played`);
+      if (silent) console.log(`\u{1F507} Silent mode: audio will not be played`);
     }
     const requestedAdapter = this.adapters.get(requestedId);
     if (requestedId !== "system" && requestedAdapter && !requestedAdapter.validate()) {
@@ -2065,11 +2013,9 @@ var SpeakEasy = class {
     }
     let lastError = null;
     for (const providerId of PROVIDER_ORDER) {
-      if (providerId !== requestedId && !lastError)
-        continue;
+      if (providerId !== requestedId && !lastError) continue;
       const adapter = this.adapters.get(providerId);
-      if (!adapter?.validate())
-        continue;
+      if (!adapter?.validate()) continue;
       try {
         const request = this.buildRequest(text, providerId);
         if (this.debug) {
@@ -2240,8 +2186,7 @@ var SpeakEasy = class {
       timestamp,
       cached
     });
-    if (!this.hudEnabled)
-      return;
+    if (!this.hudEnabled) return;
     notifyHUD({
       text: text.substring(0, 200),
       provider,

--- a/docs/listening-mode-feasibility.md
+++ b/docs/listening-mode-feasibility.md
@@ -1,0 +1,286 @@
+# Thread-locked listening mode
+
+Status: working vertical-slice prototype
+Date: 2026-07-25
+
+## Product boundary
+
+The product is one explicit loop:
+
+> Lock SpeakEasy to one Codex task, press a hotkey to record one utterance,
+> transcribe it locally with Vox, submit the final text to that exact Desktop
+> task, and narrate that task's real response with the configured SpeakEasy
+> voice.
+
+SpeakEasy is a conduit. Codex Desktop remains the conversation owner. This is
+not a general assistant, ambient recorder, wake-word service, or hidden second
+conversation.
+
+## Integration decision
+
+The prototype uses three boundaries grounded in the current repositories:
+
+1. **SpeakEasy.app owns the interaction.** It owns the exact task lock, Carbon
+   hotkey, visible state, cancellation, half-duplex policy, and playback.
+2. **Vox is embedded as Swift packages.** `VoxCore` and `VoxEngine` provide
+   `MicrophoneFileRecorder` and local Parakeet transcription. There is no Vox
+   app, CLI, clipboard, or accessibility-paste dependency.
+3. **A narrow bundled bridge joins Codex Desktop's existing task lifecycle.**
+   It connects to Desktop's private user-owned local IPC socket, asks the
+   Desktop window that owns the exact task ID to start the turn, and observes
+   that same task's rollout until the returned turn ID completes.
+
+The previous `codex app-server` child approach was rejected. App-server is a
+separate host and therefore creates exactly the shadow-session ambiguity the
+product must avoid. The shipping path never starts app-server and never writes
+Codex SQLite or rollout files.
+
+The Desktop IPC seam is private and versioned, not a supported public Codex
+API. The bridge therefore checks exact protocol versions, socket ownership,
+directory permissions, Desktop task ownership, returned task and turn IDs, and
+rollout location. Any mismatch fails closed with a visible error. There is no
+app-server, clipboard, UI-scripting, or title-matching fallback.
+
+## Confirmed versus assumed Codex capabilities
+
+Confirmed public capabilities:
+
+- `codex://threads/<id>` opens an existing task in Codex Desktop.
+- `codex app-server` is an experimental, separately launched local server. It
+  is useful for independent clients but is not proof that a turn belongs to an
+  already-open Desktop task.
+- Remote Control is a separate CLI feature, not a supported local Desktop
+  submission protocol.
+
+Confirmed by inspection and live testing against the installed Codex Desktop
+build (`0.146.0-alpha.3.1`):
+
+- Desktop exposes a current-user-only length-prefixed JSON IPC socket at
+  `$CODEX_HOME/ipc/ipc.sock`.
+- A follower can announce an exact local task ID and receive a snapshot from
+  the Desktop renderer that owns that task.
+- `thread-follower-start-turn` causes that owning renderer to start the real
+  turn and returns its turn ID.
+- The snapshot contains the exact rollout path used by the Desktop-owned task;
+  completion can be correlated to the returned turn ID.
+- A disposable task accepted a bridge submission and returned
+  `DESKTOP_CONDUIT_OK` through the already-open Desktop conversation without a
+  child app-server.
+
+Not confirmed and not relied upon:
+
+- A public supported API for sending a prompt to an existing Desktop task.
+- A public API for discovering the currently focused Desktop task.
+- Compatibility of the private IPC protocol across Desktop releases.
+- Safe concurrent injection while the target task already has an active turn.
+
+This is suitable as an opt-in technical preview. A durable release should
+replace the private seam with a supported Desktop extension/API when one is
+available.
+
+## Task-lock model
+
+`ListeningTaskLock` contains exact `id`, display `title`, and `cwd`. Only `id`
+is routing authority; title, recency, and directory are display metadata.
+
+Rules:
+
+- The user explicitly selects and locks a task. SpeakEasy opens its exact deep
+  link and accepts the lock only after that Desktop window answers the follower
+  handshake.
+- The lock is snapshotted before an utterance. Later selection or focus changes
+  cannot redirect that utterance.
+- Desktop focus changes never silently change the lock.
+- Switching clears the prior persisted lock before validation. A failed switch
+  leaves the app unlocked rather than falling back to the old task.
+- A restored lock is revalidated on launch before the hotkey becomes useful.
+- Unlock cancels capture; during narration it also stops the SpeakEasy-owned
+  playback item. Submission and synthesis are not silently rerouted.
+- If the task is not open and owned by a Desktop renderer, validation/submission
+  fails with an instruction to open it. The bridge never resumes it elsewhere.
+
+## Interaction loop
+
+```text
+unlocked
+  -> validatingLock
+  -> ready
+  -> warmingUp
+  -> recording
+  -> transcribing
+  -> submitting
+  -> preparingSpeech
+  -> speaking
+  -> ready
+```
+
+1. Pick and lock an exact task.
+2. Press `Control-Option-Space`. SpeakEasy stops its playback first, warms Vox,
+   requests microphone permission if needed, and begins recording.
+3. Press the hotkey again to end the utterance. A 120-second ceiling prevents
+   accidental indefinite capture.
+4. Vox transcribes the temporary audio locally. Empty transcripts do not
+   submit; the raw file is deleted after transcription or cancellation.
+5. SpeakEasy submits exactly once through the owning Desktop task. An idle task
+   receives a new turn; an active task receives an explicit Desktop steer event
+   and remains the same turn. SpeakEasy waits for the final assistant message
+   from that exact new or active turn ID.
+6. SpeakEasy renders that response with its explicitly configured provider,
+   model, voice, rate, and API key, then queues it with the originating task ID.
+   Provider failure is visible and never silently downgraded to macOS `say`.
+7. Playback completion returns the task lock to `ready`. There is no automatic
+   re-engagement.
+
+The first slice uses toggle recording because the existing Carbon abstraction
+has a dependable global pressed event but no tested global key-up lifecycle.
+Push-to-talk can follow after key-up, sleep, and lost-event behavior are proven.
+
+## Interruption and echo prevention
+
+The loop is half duplex. Starting a recording always stops current SpeakEasy
+playback before opening the microphone, which prevents the app from
+transcribing its own narration.
+
+- During recording, the second hotkey submits; the popover cancel control
+  discards the recording without transcription.
+- During narration, the hotkey stops playback and immediately starts a new
+  utterance (barge-in). This is intentionally small behavior, not a prerequisite
+  for routing correctness.
+- During validation, transcription, submission, and synthesis, repeated hotkey
+  presses beep rather than starting duplicate work.
+- Unlock stops narration. Late results are checked against the snapshotted task
+  ID and discarded if the lock changed.
+
+A future version may support interrupting a SpeakEasy-owned Codex turn, but it
+must correlate and interrupt only that returned turn ID. Steering adds context
+to an active turn; it does not interrupt or replace it.
+
+## Privacy, permissions, and accessibility
+
+- The signed app declares microphone usage and the audio-input entitlement.
+- Carbon hotkey registration requires neither Accessibility nor Input
+  Monitoring permission.
+- The menu bar and popover visibly distinguish locked, warming, listening,
+  transcribing, waiting, preparing speech, speaking, and failed states.
+- Controls and status text have accessible labels; status never depends on
+  animation or color alone.
+- Microphone audio is stored only in a temporary file for the explicit
+  utterance and deleted after transcription/cancel. Raw input and transcripts
+  are not added to SpeakEasy history.
+- Generated response audio is mode `0600` and removed after playback. Existing
+  provider cache behavior remains governed by SpeakEasy settings.
+- Listening is never ambient: it starts only from the explicit hotkey/control,
+  stops explicitly or at 120 seconds, and never auto-rearms.
+
+Vox currently produces a whole-utterance final transcript. Partial text is not
+invented in the UI. If Vox gains reliable streaming output, partials may be
+shown as non-submittable previews; only the final generation may route.
+
+## Failure and recovery
+
+- Microphone denied: preserve the lock and show the macOS permission remedy.
+- Missing input device or device removal: cancel capture; never submit partial
+  audio.
+- Empty/failed transcription: preserve the lock and return a visible error.
+- Desktop unavailable, task closed, protocol changed, or unsafe socket/path:
+  fail closed and preserve the transcript for visibility; never use another
+  task or host.
+- Task already busy: use Desktop's explicit same-task steer operation and
+  correlate playback to the currently active turn. If its active turn ID cannot
+  be proven from the private rollout, fail closed before submission.
+- Provider/key/network failure: show narration failure; never substitute a
+  system voice unless `system` is the configured provider.
+- App restart: any capture/work is abandoned and a persisted lock must pass a
+  new Desktop ownership handshake.
+
+## Side inference boundary
+
+No side agent is needed for the shippable first loop. Deterministic transcript
+trim and Markdown-to-speech flattening keep the route inspectable and fast.
+
+OpenScout's local session runner is a useful design reference for a later
+bounded `VoiceTextProjector`, with two allowed operations:
+
+```ts
+interface VoiceTextProjector {
+  cleanTranscript(text: string, signal: AbortSignal): Promise<string>;
+  summarizeForSpeech(text: string, signal: AbortSignal): Promise<string>;
+}
+```
+
+Hard constraints:
+
+- The helper receives text, never the Codex task ID or Desktop bridge.
+- It cannot submit, resume, steer, interrupt, select, or persist a conversation.
+- Its output is bounded and cancelable; newest utterance wins.
+- Transcript cleanup must preserve meaning and display the submitted final text.
+- Speech summarization changes only narration, never the actual task response.
+- Failure falls back to deterministic trim/flatten without changing routing.
+
+This keeps the main task as the only conversational memory while still allowing
+tight inference loops where they improve listening quality.
+
+## Smallest shippable slice
+
+Included in this prototype:
+
+- explicit exact-ID Desktop-validated lock
+- `Control-Option-Space` toggle capture
+- embedded Vox final transcription
+- exact Desktop-owned submission and response correlation
+- explicit same-task steering when the locked task is already active
+- configured provider/voice narration with no implicit system fallback
+- playback barge-in, recording cancel, 120-second limit, privacy indicators,
+  relaunch revalidation, and fail-closed errors
+
+Explicit non-goals:
+
+- ambient listening, wake words, VAD auto-submit, or auto-reengagement
+- partial transcript submission
+- inferred task selection or following Desktop focus
+- a shadow Codex/app-server thread
+- side-agent ownership of routing or conversational history
+- generalized voice-assistant tools/actions
+- concurrent turn merging or arbitrary active-turn interruption
+- production compatibility promises for private Desktop IPC
+
+## Staged path
+
+1. **Technical preview:** ship the current exact-task toggle loop behind an
+   opt-in label and collect compatibility/latency/failure telemetry without
+   storing transcript content.
+2. **Interaction polish:** add reliable push-to-talk key-up, Escape cancel,
+   optional transcript review, stronger VoiceOver announcements, and device
+   change recovery.
+3. **Speech modes:** persist per-task `off`, `full`, and `summary` settings. Add
+   the bounded projector only for cleanup/summary, never routing.
+4. **Endpointing:** evaluate local VAD and echo cancellation only with prominent
+   indicators and conservative no-auto-submit defaults.
+5. **Supported host contract:** migrate from inspected private IPC to a public
+   Codex Desktop integration when available, retaining the same exact-lock and
+   fail-closed invariants.
+
+## Validation record
+
+- Read-only Desktop follower snapshot succeeded for the originating task
+  `019f99a4-7867-7c23-ac29-0c0eca7da603`.
+- A live bridge turn on disposable Desktop task
+  `019f99ba-2ae5-7fc2-abef-32000a7f09f2` returned
+  `DESKTOP_CONDUIT_OK` from the exact visible task with no child app-server.
+- The signed app then completed a live loop on the originating task
+  `019f99a4-7867-7c23-ac29-0c0eca7da603`: Vox transcribed a spoken fixture into
+  the visible 72-character user message, the Desktop bridge explicitly steered
+  the active turn, the response was `Exact task voice loop passed.`, ElevenLabs
+  queued the audio, and the native player logged playback completion.
+- `node --check` passes for the bundled bridge.
+- `pnpm build` passes for the TypeScript package.
+- `pnpm test:privacy` passes both privacy tests.
+- `swift test` passes all native tests, including protocol compatibility,
+  temporary-audio cleanup encoding, Markdown narration flattening, safe deep
+  links, settings bounds, and Gemini PCM-to-WAV wrapping.
+- `app/build-app.sh` produces a signed app containing the Vox resources,
+  microphone usage description, audio-input entitlement, and bundled Desktop
+  bridge; `codesign --verify --deep --strict` passes.
+
+The app-level utterance-to-response-to-premium-playback gate is satisfied.
+SpeakEasy remains locked to the originating task for normal global-hotkey use.

--- a/docs/listening-mode-feasibility.md
+++ b/docs/listening-mode-feasibility.md
@@ -105,7 +105,8 @@ Rules:
 unlocked
   -> validatingLock
   -> ready
-  -> warmingUp
+  -> cueing (assigned lane with a cached cue only)
+  -> opening microphone + concurrent Vox warmup
   -> recording
   -> transcribing
   -> submitting
@@ -115,8 +116,8 @@ unlocked
 ```
 
 1. Pick and lock an exact task.
-2. Press `Control-Option-Space`. SpeakEasy stops its playback first, warms Vox,
-   requests microphone permission if needed, and begins recording.
+2. Press `Control-Option-Space`. SpeakEasy stops its playback, opens the
+   microphone immediately, and warms Vox in parallel with the utterance.
 3. Press the hotkey again to end the utterance. A 120-second ceiling prevents
    accidental indefinite capture.
 4. Vox transcribes the temporary audio locally. Empty transcripts do not
@@ -134,6 +135,26 @@ unlocked
 The first slice uses toggle recording because the existing Carbon abstraction
 has a dependable global pressed event but no tested global key-up lifecycle.
 Push-to-talk can follow after key-up, sleep, and lost-event behavior are proven.
+
+### Voice lanes
+
+Nine persistent voice lanes map `Option-Command-1` through
+`Option-Command-9` to exact task locks. A lane shortcut selects its task,
+revalidates Desktop ownership, and begins listening in one action. The original
+`Control-Option-Space` shortcut continues toggling the current lock.
+
+- Lane registration is independent; a chord conflict disables only that lane
+  and is shown in the popover.
+- An unassigned lane never guesses a task. The popover explains how to assign
+  the current exact lock.
+- A lane cannot reroute audio already being recorded or a turn already being
+  submitted. The current utterance keeps its snapshotted task ID.
+- Assignment generates a compact task-name cue with the configured premium
+  provider. Cues are cached privately. A cached cue finishes before capture to
+  prevent feedback; a missing/failed cue is skipped without system-voice
+  fallback or microphone delay.
+- Every lane activation reopens and revalidates the exact task, including after
+  app restarts or Codex task changes.
 
 ## Interruption and echo prevention
 
@@ -226,6 +247,7 @@ Included in this prototype:
 
 - explicit exact-ID Desktop-validated lock
 - `Control-Option-Space` toggle capture
+- persistent exact-task lanes on `Option-Command-1...9`
 - embedded Vox final transcription
 - exact Desktop-owned submission and response correlation
 - explicit same-task steering when the locked task is already active
@@ -272,6 +294,11 @@ Explicit non-goals:
   the visible 72-character user message, the Desktop bridge explicitly steered
   the active turn, the response was `Exact task voice loop passed.`, ElevenLabs
   queued the audio, and the native player logged playback completion.
+- The signed lane build registered all nine `Option-Command` shortcuts, restored
+  lane 1 to the originating task, revalidated the exact task, played a cached
+  ElevenLabs task-name cue before capture, opened the MacBook Air microphone,
+  warmed Vox concurrently, and canceled the validation recording without
+  transcription or submission.
 - `node --check` passes for the bundled bridge.
 - `pnpm build` passes for the TypeScript package.
 - `pnpm test:privacy` passes both privacy tests.

--- a/docs/listening-mode-feasibility.md
+++ b/docs/listening-mode-feasibility.md
@@ -105,7 +105,7 @@ Rules:
 unlocked
   -> validatingLock
   -> ready
-  -> cueing (assigned lane with a cached cue only)
+  -> cueing (only when identification is explicitly requested)
   -> opening microphone + concurrent Vox warmup
   -> recording
   -> transcribing
@@ -149,10 +149,10 @@ revalidates Desktop ownership, and begins listening in one action. The original
   the current exact lock.
 - A lane cannot reroute audio already being recorded or a turn already being
   submitted. The current utterance keeps its snapshotted task ID.
-- Assignment generates a compact task-name cue with the configured premium
-  provider. Cues are cached privately. A cached cue finishes before capture to
-  prevent feedback; a missing/failed cue is skipped without system-voice
-  fallback or microphone delay.
+- Assignment generates and privately caches a compact task-name cue with the
+  configured provider. Normal lane activation is silent and immediate.
+  `Option-Command-X` announces the active lane on demand without opening the
+  microphone; provider failure is visible and never invokes a fallback voice.
 - Every lane activation reopens and revalidates the exact task, including after
   app restarts or Codex task changes.
 
@@ -294,11 +294,12 @@ Explicit non-goals:
   the visible 72-character user message, the Desktop bridge explicitly steered
   the active turn, the response was `Exact task voice loop passed.`, ElevenLabs
   queued the audio, and the native player logged playback completion.
-- The signed lane build registered all nine `Option-Command` shortcuts, restored
-  lane 1 to the originating task, revalidated the exact task, played a cached
-  ElevenLabs task-name cue before capture, opened the MacBook Air microphone,
-  warmed Vox concurrently, and canceled the validation recording without
-  transcription or submission.
+- The signed lane build registered all nine `Option-Command` lane shortcuts,
+  restored lane 1 to the originating task, revalidated the exact task, opened
+  the MacBook Air microphone immediately, warmed Vox concurrently, and canceled
+  the validation recording without transcription or submission. The separate
+  `Option-Command-X` confirmation path played the cached ElevenLabs task name
+  without opening the microphone.
 - `node --check` passes for the bundled bridge.
 - `pnpm build` passes for the TypeScript package.
 - `pnpm test:privacy` passes both privacy tests.

--- a/src/player-protocol.ts
+++ b/src/player-protocol.ts
@@ -27,6 +27,7 @@ export interface PlaybackItem {
   createdAt: string;
   synthesisRateWPM?: number;
   sourceThreadId?: string;
+  cleanupAfterPlayback?: boolean;
 }
 
 export interface PlayerCommandArguments {


### PR DESCRIPTION
## What changed

- embed Vox recording and local transcription in the native SpeakEasy app
- route speech into the exact Codex Desktop task, including active-turn steering, without launching a shadow app-server
- narrate the correlated task response with the configured SpeakEasy provider and voice
- add persistent exact-task voice lanes on Option-Command-1 through Option-Command-9
- add provider-scoped voice overrides per lane while inheriting the global provider, model, credentials, rate, and volume
- add a compact active-lane voice ID editor with explicit save, reset, and inherited-voice behavior
- add optional per-lane OpenAI narration cues for speaking style without modifying submitted task text
- snapshot the lane voice, narration cue, rate, and volume when the microphone opens so a turn cannot change voice mid-flight
- surface whether each utterance started a new turn or steered the active turn in the exact task
- make each lane shortcut revalidate its task and select-and-listen immediately, while Control-Option-Space continues the current lane
- add Option-Command-X and a compact speaker button as on-demand lane/task confirmation without opening the microphone
- cache compact configured-voice task cues privately; normal lane activation stays silent
- open the microphone before Vox warmup, then warm locally in parallel with the utterance
- replace the 480×180 HUD with a 404×132 compact hierarchy and restrained jade/gold/steel/lavender phase system
- unify confirmation, listening, submission, and speaking chrome while preserving exact task/lane identity, accessibility, and Reduce Motion
- preserve fail-closed routing: an active recording/turn cannot be silently redirected to another lane
- document the private Desktop integration boundary, staged rollout, and explicit non-goals

## Why

SpeakEasy should be a voice conduit for a task the user deliberately locks, not a separate assistant or hidden conversation. Voice lanes make exact tasks reachable from anywhere without weakening that ownership model. Provider-scoped voices give lanes distinct identities without introducing per-lane credential or provider complexity. Spoken confirmation is explicit so routine lane use stays fast and quiet. The compact HUD keeps state legible without dominating the screen.

## Validation

- `pnpm build`
- `pnpm test:privacy` (2 passing)
- `swift test` (17 passing)
- `node --check app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs`
- provider-scoped voice persistence and legacy lane decoding tests
- matching-provider voice override, narration-cue composition, and immutable turn-context tests
- signed app bundle build and `codesign --verify --deep --strict`
- rendered 320×720 popover snapshots for the voice editor and cue/steer state
- two Grok/Scout visual iterations across confirmation, recording, submitting, and speaking snapshots
- live disposable-task Desktop routing test with no child app-server
- live exact-task loop: Vox transcription → visible user message → correlated response → ElevenLabs narration → playback completion
- signed lane loop: all nine Option-Command number shortcuts registered; lane 1 restored and revalidated this exact task; mic opened without a spoken preamble; Vox warmed concurrently
- signed confirmation loop: Option-Command-X registered and announced lane 1 plus its cached ElevenLabs task name without opening the microphone
- latest signed exact-task fixture arrived in the originating active task through `steered-active-turn`; the resident app remains attached to narrate the final response

## Compatibility note

The Codex Desktop follower IPC used by this technical preview is private and versioned. The bridge validates protocol versions and ownership and fails closed when the integration cannot be proven safe.
