### PR TITLE
Keep voice lanes backgrounded with instant Apple fallback

### DIFF
--- a/app/Resources/Info.plist
+++ b/app/Resources/Info.plist
@@ -32,6 +32,8 @@
     <true/>
     <key>NSMicrophoneUsageDescription</key>
     <string>SpeakEasy uses the microphone only while you explicitly record an utterance for a locked Codex task.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>SpeakEasy uses Apple Speech to transcribe explicit voice turns while its on-device Parakeet model becomes ready.</string>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
     <key>LSApplicationCategoryType</key>

--- a/app/Sources/SpeakEasy/AppleSpeechFileTranscriber.swift
+++ b/app/Sources/SpeakEasy/AppleSpeechFileTranscriber.swift
@@ -1,0 +1,148 @@
+import Foundation
+@preconcurrency import Speech
+
+enum AppleSpeechTranscriptionError: LocalizedError {
+    case audioFileMissing
+    case permissionDenied
+    case recognizerUnavailable
+    case alreadyRunning
+    case emptyTranscript
+    case recognitionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .audioFileMissing:
+            "The recorded audio file is no longer available."
+        case .permissionDenied:
+            "Apple Speech recognition permission was not granted."
+        case .recognizerUnavailable:
+            "Apple Speech recognition is unavailable right now."
+        case .alreadyRunning:
+            "Apple Speech is already transcribing another utterance."
+        case .emptyTranscript:
+            "Apple Speech did not detect any words."
+        case .recognitionFailed(let message):
+            "Apple Speech recognition failed: \(message)"
+        }
+    }
+}
+
+/// File-based Apple Speech fallback used while Vox's Parakeet model warms.
+///
+/// This mirrors the HudsonKit/Talkie cold-start pattern without coupling the
+/// app to HudsonVoice, which is not part of the released HudsonKit XCFramework.
+actor AppleSpeechFileTranscriber {
+    private let locale: Locale
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var continuation: CheckedContinuation<String, Error>?
+    private var authorizationTask: Task<Bool, Never>?
+
+    init(locale: Locale = .autoupdatingCurrent) {
+        self.locale = locale
+    }
+
+    deinit {
+        recognitionTask?.cancel()
+    }
+
+    func requestAuthorizationIfNeeded() async -> Bool {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized:
+            return true
+        case .notDetermined:
+            if let authorizationTask {
+                return await authorizationTask.value
+            }
+            let task = Task {
+                await withCheckedContinuation { continuation in
+                    SFSpeechRecognizer.requestAuthorization { status in
+                        continuation.resume(returning: status == .authorized)
+                    }
+                }
+            }
+            authorizationTask = task
+            let authorized = await task.value
+            authorizationTask = nil
+            return authorized
+        case .denied, .restricted:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    func transcribe(url: URL) async throws -> String {
+        guard recognitionTask == nil, continuation == nil else {
+            throw AppleSpeechTranscriptionError.alreadyRunning
+        }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw AppleSpeechTranscriptionError.audioFileMissing
+        }
+        guard await requestAuthorizationIfNeeded() else {
+            throw AppleSpeechTranscriptionError.permissionDenied
+        }
+        guard let recognizer = SFSpeechRecognizer(locale: locale), recognizer.isAvailable else {
+            throw AppleSpeechTranscriptionError.recognizerUnavailable
+        }
+
+        let request = SFSpeechURLRecognitionRequest(url: url)
+        request.shouldReportPartialResults = false
+        request.addsPunctuation = true
+        if recognizer.supportsOnDeviceRecognition {
+            request.requiresOnDeviceRecognition = true
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+                recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+                    Task {
+                        await self?.handle(result: result, error: error)
+                    }
+                }
+            }
+        } onCancel: {
+            Task { [weak self] in await self?.cancel() }
+        }
+    }
+
+    private func handle(result: SFSpeechRecognitionResult?, error: Error?) {
+        guard continuation != nil else { return }
+        if let result, result.isFinal {
+            let text = result.bestTranscription.formattedString
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else {
+                resume(throwing: AppleSpeechTranscriptionError.emptyTranscript)
+                return
+            }
+            resume(returning: text)
+            return
+        }
+        if let error {
+            resume(throwing: AppleSpeechTranscriptionError.recognitionFailed(error.localizedDescription))
+        }
+    }
+
+    private func cancel() {
+        recognitionTask?.cancel()
+        resume(throwing: CancellationError(), cancelTask: false)
+    }
+
+    private func resume(returning text: String, cancelTask: Bool = true) {
+        let continuation = continuation
+        reset(cancelTask: cancelTask)
+        continuation?.resume(returning: text)
+    }
+
+    private func resume(throwing error: Error, cancelTask: Bool = true) {
+        let continuation = continuation
+        reset(cancelTask: cancelTask)
+        continuation?.resume(throwing: error)
+    }
+
+    private func reset(cancelTask: Bool) {
+        if cancelTask { recognitionTask?.cancel() }
+        recognitionTask = nil
+        continuation = nil
+    }
+}

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -50,6 +50,13 @@ struct ListeningTurnContext: Equatable, Sendable {
     let playbackVolume: Double
 }
 
+enum CodexTaskLockPresentation: Equatable, Sendable {
+    case background
+    case revealInCodex
+
+    var revealsCodex: Bool { self == .revealInCodex }
+}
+
 @MainActor
 final class ListeningSessionController: ObservableObject {
     static let shared = ListeningSessionController()
@@ -178,7 +185,12 @@ final class ListeningSessionController: ObservableObject {
     }
 
     func lock(_ task: CodexTaskSummary) {
-        validateAndLock(taskID: task.id, expectedLane: nil, beginAfterLock: false)
+        validateAndLock(
+            taskID: task.id,
+            expectedLane: nil,
+            beginAfterLock: false,
+            presentation: .revealInCodex
+        )
     }
 
     func assignLockedTask(toLane number: Int) {
@@ -281,7 +293,8 @@ final class ListeningSessionController: ObservableObject {
         validateAndLock(
             taskID: assignment.task.id,
             expectedLane: number,
-            beginAfterLock: beginListening
+            beginAfterLock: beginListening,
+            presentation: .background
         )
     }
 
@@ -382,7 +395,8 @@ final class ListeningSessionController: ObservableObject {
     private func validateAndLock(
         taskID: String,
         expectedLane: Int?,
-        beginAfterLock: Bool
+        beginAfterLock: Bool,
+        presentation: CodexTaskLockPresentation
     ) {
         if lockedTask?.id != taskID {
             lockedTask = nil
@@ -391,7 +405,9 @@ final class ListeningSessionController: ObservableObject {
         selectedTaskID = taskID
         phase = .validatingLock
         lastError = nil
-        openCodexTask(taskID)
+        if presentation.revealsCodex {
+            openCodexTask(taskID)
+        }
         let requestID = UUID()
         validationID = requestID
         Task {
@@ -432,7 +448,9 @@ final class ListeningSessionController: ObservableObject {
                 }
                 persistLock(lock)
                 phase = .ready
-                diagnostic("locked to Desktop-owned Codex task \(taskID)")
+                diagnostic(presentation.revealsCodex
+                    ? "locked to Desktop-owned Codex task \(taskID) and revealed it"
+                    : "locked to Desktop-owned Codex task \(taskID) in the background")
                 applyLaunchLaneAssignmentIfPresent()
                 runLaunchFixtureIfPresent()
                 runLaunchHotkeyTestIfPresent()
@@ -633,7 +651,12 @@ final class ListeningSessionController: ObservableObject {
         guard let requestedID = ProcessInfo.processInfo.environment["SPEAKEASY_LOCK_THREAD_ID"],
               let requested = recent.first(where: { $0.id == requestedID })
         else { return false }
-        lock(requested)
+        validateAndLock(
+            taskID: requested.id,
+            expectedLane: nil,
+            beginAfterLock: false,
+            presentation: .background
+        )
         return true
     }
 
@@ -649,7 +672,12 @@ final class ListeningSessionController: ObservableObject {
         guard let candidate = restoredLockCandidate else { return }
         restoredLockCandidate = nil
         if let task = recent.first(where: { $0.id == candidate.id }) {
-            lock(task)
+            validateAndLock(
+                taskID: task.id,
+                expectedLane: activeLaneNumber,
+                beginAfterLock: false,
+                presentation: .background
+            )
         } else {
             UserDefaults.standard.removeObject(forKey: lockDefaultsKey)
             selectedTaskID = recent.first?.id ?? ""

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -565,8 +565,9 @@ final class ListeningSessionController: ObservableObject {
         phase = .transcribing
         Task {
             do {
-                let transcript = try await vox.stopAndTranscribe()
-                try await completeLoop(transcript: transcript, context: context)
+                let result = try await vox.stopAndTranscribe()
+                diagnostic("\(result.engine.rawValue) transcript selected")
+                try await completeLoop(transcript: result.text, context: context)
             } catch {
                 recordFailure(error)
             }

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -711,7 +711,8 @@ final class ListeningSessionController: ObservableObject {
 
     private func runLaunchHotkeyTestIfPresent() {
         guard !fixtureHasRun, !launchHotkeyHasRun,
-              ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_HOTKEY_ON_LAUNCH"] == "1"
+              ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_HOTKEY_ON_LAUNCH"] == "1",
+              phase == .ready || phase == .failed
         else { return }
         launchHotkeyHasRun = true
         diagnostic("triggering registered hotkey action for launch test")
@@ -721,7 +722,8 @@ final class ListeningSessionController: ObservableObject {
     private func runLaunchLaneTestIfPresent() {
         guard !fixtureHasRun, !launchLaneHasRun,
               let raw = ProcessInfo.processInfo.environment["SPEAKEASY_TRIGGER_LANE_ON_LAUNCH"],
-              let number = Int(raw), lane(number) != nil
+              let number = Int(raw), lane(number) != nil,
+              phase == .ready || phase == .failed
         else { return }
         launchLaneHasRun = true
         diagnostic("triggering lane \(number) for launch test")

--- a/app/Sources/SpeakEasy/VoxListeningService.swift
+++ b/app/Sources/SpeakEasy/VoxListeningService.swift
@@ -2,45 +2,106 @@ import Foundation
 import VoxCore
 import VoxEngine
 
+enum ListeningTranscriptionEngine: String, Equatable, Sendable {
+    case appleSpeech
+    case parakeet
+}
+
+struct ListeningTranscriptionResult: Equatable, Sendable {
+    let text: String
+    let engine: ListeningTranscriptionEngine
+}
+
 actor VoxListeningService {
     static let modelID = "parakeet:v3"
 
+    private enum ParakeetState {
+        case cold
+        case warming
+        case ready
+    }
+
     private let recorder = MicrophoneFileRecorder()
     private let engine = EngineManager()
+    private let appleSpeech = AppleSpeechFileTranscriber()
+    private var parakeetState = ParakeetState.cold
     private var warmupTask: Task<Void, Error>?
 
+    static func preferredEngine(parakeetReady: Bool) -> ListeningTranscriptionEngine {
+        parakeetReady ? .parakeet : .appleSpeech
+    }
+
     func warmUp() async throws {
-        _ = try await engine.preload(modelId: Self.modelID) { _ in }
+        startWarmupIfNeeded()
+        if let warmupTask {
+            try await warmupTask.value
+        }
     }
 
     /// Opens the microphone first, then warms the local model in parallel with
-    /// the utterance. Stopping waits for warmup before transcription.
+    /// the utterance. Apple Speech handles the result until Parakeet is ready.
     func startRecordingAndWarm() async throws -> AudioInputDeviceInfo {
         let recording = try await recorder.start(filePrefix: "speakeasy-listen")
         try? FileManager.default.setAttributes(
             [.posixPermissions: 0o600],
             ofItemAtPath: recording.url.path
         )
-        if warmupTask == nil {
-            warmupTask = Task { [engine] in
-                _ = try await engine.preload(modelId: Self.modelID) { _ in }
+        startWarmupIfNeeded()
+        if parakeetState != .ready {
+            Task { [appleSpeech] in
+                _ = await appleSpeech.requestAuthorizationIfNeeded()
             }
         }
         return recording.inputDevice
     }
 
-    func stopAndTranscribe() async throws -> String {
+    func stopAndTranscribe() async throws -> ListeningTranscriptionResult {
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
-        if let warmupTask {
-            defer { self.warmupTask = nil }
-            try await warmupTask.value
+
+        let preferred = Self.preferredEngine(parakeetReady: parakeetState == .ready)
+        if preferred == .parakeet {
+            do {
+                return ListeningTranscriptionResult(
+                    text: try await transcribeWithParakeet(url: url),
+                    engine: .parakeet
+                )
+            } catch {
+                return ListeningTranscriptionResult(
+                    text: try await appleSpeech.transcribe(url: url),
+                    engine: .appleSpeech
+                )
+            }
         }
-        return try await transcribe(url: url)
+
+        do {
+            return ListeningTranscriptionResult(
+                text: try await appleSpeech.transcribe(url: url),
+                engine: .appleSpeech
+            )
+        } catch {
+            // Permission denial or temporary Apple unavailability must not make
+            // dictation unusable. In this recovery path only, allow the already
+            // running Parakeet warmup to finish and use it for this utterance.
+            if parakeetState == .ready {
+                return ListeningTranscriptionResult(
+                    text: try await transcribeWithParakeet(url: url),
+                    engine: .parakeet
+                )
+            }
+            if let warmupTask {
+                try await warmupTask.value
+                return ListeningTranscriptionResult(
+                    text: try await transcribeWithParakeet(url: url),
+                    engine: .parakeet
+                )
+            }
+            throw error
+        }
     }
 
     func transcribeFixture(url: URL) async throws -> String {
-        try await transcribe(url: url)
+        try await transcribeWithParakeet(url: url)
     }
 
     func cancelRecording() async {
@@ -50,7 +111,26 @@ actor VoxListeningService {
         await recorder.cancel()
     }
 
-    private func transcribe(url: URL) async throws -> String {
+    private func startWarmupIfNeeded() {
+        guard parakeetState == .cold, warmupTask == nil else { return }
+        parakeetState = .warming
+        warmupTask = Task { [weak self, engine] in
+            do {
+                _ = try await engine.preload(modelId: Self.modelID) { _ in }
+                await self?.finishWarmup(succeeded: true)
+            } catch {
+                await self?.finishWarmup(succeeded: false)
+                throw error
+            }
+        }
+    }
+
+    private func finishWarmup(succeeded: Bool) {
+        parakeetState = succeeded ? .ready : .cold
+        warmupTask = nil
+    }
+
+    private func transcribeWithParakeet(url: URL) async throws -> String {
         let output = try await engine.transcribe(url: url, modelId: Self.modelID)
         return output.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -259,6 +259,17 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertTrue(CodexTaskLockPresentation.revealInCodex.revealsCodex)
     }
 
+    func testColdStartUsesAppleSpeechUntilParakeetIsReady() {
+        XCTAssertEqual(
+            VoxListeningService.preferredEngine(parakeetReady: false),
+            .appleSpeech
+        )
+        XCTAssertEqual(
+            VoxListeningService.preferredEngine(parakeetReady: true),
+            .parakeet
+        )
+    }
+
     @MainActor
     func testLaneShortcutsUseDistinctNumberKeyCodes() {
         let codes = ListeningSessionController.laneRange.map(GlobalListeningShortcut.keyCode(forLane:))

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -254,6 +254,11 @@ final class PlayerProtocolTests: XCTestCase {
         )
     }
 
+    func testOnlyExplicitTaskSelectionRevealsCodex() {
+        XCTAssertFalse(CodexTaskLockPresentation.background.revealsCodex)
+        XCTAssertTrue(CodexTaskLockPresentation.revealInCodex.revealsCodex)
+    }
+
     @MainActor
     func testLaneShortcutsUseDistinctNumberKeyCodes() {
         let codes = ListeningSessionController.laneRange.map(GlobalListeningShortcut.keyCode(forLane:))


### PR DESCRIPTION
## What changed

- validate lane hotkeys, launch locks, and restored locks against the exact Codex task without revealing or focusing Codex
- transcribe cold-start utterances with Apple Speech while Vox warms Parakeet in parallel
- prefer Parakeet once it is ready, with reciprocal fallback when either engine is unavailable
- add the required Speech Recognition privacy usage string and deterministic launch-path coverage

## Why

Voice lanes should act as a conduit to an exact Codex task from any foreground app. The prior lane activation opened the Codex URL, and the first utterance waited for Parakeet warmup before transcription.

## Validation

- `swift test --package-path app` — 19 tests passed
- `plutil -lint app/Resources/Info.plist`
- `app/build-app.sh` — release build and Developer ID signing passed
- signed LaunchServices run kept Finder frontmost while validating the exact task
- signed cold-start run opened the selected AirPods microphone before Parakeet warmup completed and returned to ready after cancellation