### PR TITLE
Add a dedicated microphone picker

### DIFF
--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -87,29 +87,7 @@ struct ListeningPopoverSection: View {
 
             laneStrip(currentTask: lock)
 
-            Button(action: listening.toggleListening) {
-                HStack(spacing: 7) {
-                    Image(systemName: listening.phase == .recording ? "stop.fill" : "mic.fill")
-                    Text(buttonLabel)
-                    Spacer()
-                    Text(ListeningSessionController.shortcutTitle)
-                        .font(.system(size: 10, design: .rounded))
-                        .opacity(0.75)
-                }
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(listening.phase == .recording ? .white : .black.opacity(0.78))
-                .padding(.horizontal, 10)
-                .frame(height: 30)
-                .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(listening.phase == .recording ? Color.red : accent)
-                )
-            }
-            .buttonStyle(.plain)
-            .disabled(!listening.phase.acceptsHotkey)
-            .opacity(listening.phase.acceptsHotkey ? 1 : 0.55)
-            .accessibilityLabel(buttonLabel)
-            .accessibilityHint("Global shortcut \(ListeningSessionController.shortcutTitle)")
+            captureComposer
 
             HStack(spacing: 5) {
                 Circle()
@@ -117,6 +95,7 @@ struct ListeningPopoverSection: View {
                     .frame(width: 5, height: 5)
                     .accessibilityHidden(true)
                 Text(listening.shortcutAvailable ? "Global shortcut active" : "Shortcut unavailable")
+                Text("· \(ListeningSessionController.shortcutTitle)")
                 if let device = listening.inputDeviceName, listening.phase == .recording {
                     Text("· \(device)")
                 }
@@ -125,6 +104,117 @@ struct ListeningPopoverSection: View {
             .foregroundColor(theme.textTertiary)
             .accessibilityElement(children: .combine)
         }
+        .onAppear { listening.refreshInputDevices() }
+    }
+
+    private var captureComposer: some View {
+        HStack(spacing: 0) {
+            Button(action: listening.toggleListening) {
+                HStack(spacing: 7) {
+                    Image(systemName: listening.phase == .recording ? "stop.fill" : "mic.fill")
+                    Text(buttonLabel)
+                        .lineLimit(1)
+                    Spacer(minLength: 4)
+                }
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(listening.phase == .recording ? .white : .black.opacity(0.78))
+                .padding(.horizontal, 10)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(listening.phase == .recording ? Color.red : accent)
+            }
+            .buttonStyle(.plain)
+            .disabled(!listening.phase.acceptsHotkey)
+            .opacity(listening.phase.acceptsHotkey ? 1 : 0.55)
+            .accessibilityLabel(buttonLabel)
+            .accessibilityHint("Global shortcut \(ListeningSessionController.shortcutTitle)")
+
+            Rectangle()
+                .fill(theme.text.opacity(0.12))
+                .frame(width: 0.5)
+
+            microphoneMenu
+                .frame(width: 126)
+        }
+        .frame(height: 34)
+        .background(theme.text.opacity(0.045))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(theme.text.opacity(0.10), lineWidth: 0.75)
+        }
+    }
+
+    private var microphoneMenu: some View {
+        Menu {
+            Button {
+                listening.selectSystemDefaultInput()
+            } label: {
+                HStack {
+                    Text("System Default")
+                    if listening.inputPreference == nil {
+                        Spacer()
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            if !listening.inputDevices.isEmpty {
+                Divider()
+            }
+
+            ForEach(listening.inputDevices) { device in
+                Button {
+                    listening.selectInputDevice(device)
+                } label: {
+                    HStack {
+                        Text(device.isSystemDefault ? "\(device.name) · default" : device.name)
+                        if listening.inputPreference?.id == device.id {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+
+            if let preference = listening.inputPreference,
+               !preference.isAvailable(in: listening.inputDevices) {
+                Divider()
+                Label("\(preference.name) unavailable", systemImage: "exclamationmark.triangle")
+            }
+
+            Divider()
+            Button {
+                listening.refreshInputDevices()
+            } label: {
+                Label("Refresh Inputs", systemImage: "arrow.clockwise")
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 7, weight: .semibold))
+                    .foregroundStyle(theme.textTertiary)
+
+                Text(listening.phase == .recording
+                    ? (listening.inputDeviceName ?? listening.selectedInputDeviceShortLabel)
+                    : listening.selectedInputDeviceShortLabel)
+                    .font(.system(size: 9.5, weight: .medium))
+                    .foregroundColor(listening.selectedInputIsAvailable ? theme.textSecondary : .orange)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(listening.selectedInputIsAvailable ? Color.clear : Color.orange.opacity(0.10))
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .disabled(isBusy || listening.phase == .recording)
+        .help(listening.selectedInputDeviceLabel)
+        .accessibilityLabel("Microphone: \(listening.selectedInputDeviceLabel)")
+        .accessibilityHint("Choose a fixed microphone or follow the system default")
     }
 
     private func laneStrip(currentTask: ListeningTaskLock) -> some View {

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -50,6 +50,15 @@ struct ListeningTurnContext: Equatable, Sendable {
     let playbackVolume: Double
 }
 
+struct ListeningInputPreference: Codable, Equatable, Sendable {
+    let id: String
+    let name: String
+
+    func isAvailable(in devices: [AudioInputDeviceInfo]) -> Bool {
+        devices.contains { $0.id == id }
+    }
+}
+
 enum CodexTaskLockPresentation: Equatable, Sendable {
     case background
     case revealInCodex
@@ -72,6 +81,8 @@ final class ListeningSessionController: ObservableObject {
     @Published private(set) var shortcutAvailable = false
     @Published private(set) var laneShortcutAvailability: [Int: Bool] = [:]
     @Published private(set) var confirmationShortcutAvailable = false
+    @Published private(set) var inputDevices: [AudioInputDeviceInfo] = []
+    @Published private(set) var inputPreference: ListeningInputPreference?
     @Published private(set) var inputDeviceName: String?
     @Published private(set) var lastTranscript = ""
     @Published private(set) var lastResponse = ""
@@ -85,6 +96,7 @@ final class ListeningSessionController: ObservableObject {
     private let lockDefaultsKey = "speakeasy.listening.task-lock.v1"
     private let lanesDefaultsKey = "speakeasy.listening.voice-lanes.v1"
     private let activeLaneDefaultsKey = "speakeasy.listening.active-lane.v1"
+    private let inputPreferenceDefaultsKey = "speakeasy.listening.input-device.v1"
     private var shortcut: GlobalListeningShortcut?
     private var maxRecordingTimer: Timer?
     private var playbackObservation: AnyCancellable?
@@ -119,6 +131,7 @@ final class ListeningSessionController: ObservableObject {
 
     func start() {
         diagnostic("starting listening controller")
+        refreshInputDevices()
         if shortcut == nil {
             let shortcut = GlobalListeningShortcut { [weak self] action in
                 self?.handleShortcut(action)
@@ -353,6 +366,49 @@ final class ListeningSessionController: ObservableObject {
         laneShortcutAvailability[number] == true
     }
 
+    var selectedInputDeviceLabel: String {
+        if let inputPreference {
+            return inputPreference.isAvailable(in: inputDevices)
+                ? inputPreference.name
+                : "\(inputPreference.name) · unavailable"
+        }
+        return AudioInputDevices.effectiveLabel(preferredID: nil)
+    }
+
+    var selectedInputDeviceShortLabel: String {
+        if let inputPreference { return inputPreference.name }
+        return inputDevices.first(where: \.isSystemDefault)?.name ?? "System Default"
+    }
+
+    var selectedInputIsAvailable: Bool {
+        guard let inputPreference else { return !inputDevices.isEmpty }
+        return inputPreference.isAvailable(in: inputDevices)
+    }
+
+    func refreshInputDevices() {
+        inputDevices = AudioInputDevices.available()
+        diagnostic("found \(inputDevices.count) microphone inputs")
+    }
+
+    func selectSystemDefaultInput() {
+        guard canChangeInputDevice else { return }
+        inputPreference = nil
+        UserDefaults.standard.removeObject(forKey: inputPreferenceDefaultsKey)
+        refreshInputDevices()
+        diagnostic("microphone follows the system default")
+    }
+
+    func selectInputDevice(_ device: AudioInputDeviceInfo) {
+        guard canChangeInputDevice else { return }
+        let preference = ListeningInputPreference(id: device.id, name: device.name)
+        inputPreference = preference
+        if let data = try? JSONEncoder().encode(preference) {
+            UserDefaults.standard.set(data, forKey: inputPreferenceDefaultsKey)
+        }
+        refreshInputDevices()
+        diagnostic("dedicated microphone set to \(device.name)")
+    }
+
     #if DEBUG
     func installLaneSnapshotFixture() {
         let task = ListeningTaskLock(
@@ -373,12 +429,21 @@ final class ListeningSessionController: ObservableObject {
             uniqueKeysWithValues: Self.laneRange.map { ($0, $0 != 4) }
         )
         confirmationShortcutAvailable = true
+        inputDevices = [
+            AudioInputDeviceInfo(id: "studio-mic", name: "Studio USB Mic", isSystemDefault: false),
+            AudioInputDeviceInfo(id: "system-mic", name: "MacBook Air Mic", isSystemDefault: true)
+        ]
+        inputPreference = ListeningInputPreference(id: "studio-mic", name: "Studio USB Mic")
         phase = .ready
     }
     #endif
 
     private var isRoutingTurn: Bool {
         [.transcribing, .submitting, .preparingSpeech].contains(phase)
+    }
+
+    private var canChangeInputDevice: Bool {
+        ![.warmingUp, .recording, .transcribing, .submitting, .preparingSpeech].contains(phase)
     }
 
     private func handleShortcut(_ action: ListeningShortcutAction) {
@@ -488,7 +553,10 @@ final class ListeningSessionController: ObservableObject {
             do {
                 // Vox starts capture before it warms the model. Natural speech
                 // at hotkey-down is retained while recognition becomes ready.
-                let device = try await vox.startRecordingAndWarm()
+                let device = try await vox.startRecordingAndWarm(
+                    preferredInputDeviceID: inputPreference?.id,
+                    preferredInputDeviceName: inputPreference?.name
+                )
                 guard recordingStartID == startID, lockedTask?.id == lock.id else {
                     await vox.cancelRecording()
                     return
@@ -509,6 +577,7 @@ final class ListeningSessionController: ObservableObject {
                 }
             } catch {
                 guard recordingStartID == startID else { return }
+                refreshInputDevices()
                 recordFailure(error)
             }
         }
@@ -617,6 +686,10 @@ final class ListeningSessionController: ObservableObject {
     }
 
     private func restoreState() {
+        if let data = UserDefaults.standard.data(forKey: inputPreferenceDefaultsKey),
+           let preference = try? JSONDecoder().decode(ListeningInputPreference.self, from: data) {
+            inputPreference = preference
+        }
         if let data = UserDefaults.standard.data(forKey: lanesDefaultsKey),
            let restored = try? JSONDecoder().decode([VoiceLane].self, from: data) {
             lanes = restored

--- a/app/Sources/SpeakEasy/VoxListeningService.swift
+++ b/app/Sources/SpeakEasy/VoxListeningService.swift
@@ -12,6 +12,17 @@ struct ListeningTranscriptionResult: Equatable, Sendable {
     let engine: ListeningTranscriptionEngine
 }
 
+enum VoxListeningServiceError: LocalizedError {
+    case selectedInputUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .selectedInputUnavailable(let name):
+            "Your dedicated microphone “\(name)” is unavailable. Reconnect it or choose another input."
+        }
+    }
+}
+
 actor VoxListeningService {
     static let modelID = "parakeet:v3"
 
@@ -40,8 +51,23 @@ actor VoxListeningService {
 
     /// Opens the microphone first, then warms the local model in parallel with
     /// the utterance. Apple Speech handles the result until Parakeet is ready.
-    func startRecordingAndWarm() async throws -> AudioInputDeviceInfo {
-        let recording = try await recorder.start(filePrefix: "speakeasy-listen")
+    func startRecordingAndWarm(
+        preferredInputDeviceID: String? = nil,
+        preferredInputDeviceName: String? = nil
+    ) async throws -> AudioInputDeviceInfo {
+        let normalizedID = preferredInputDeviceID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let normalizedID, !normalizedID.isEmpty,
+           !AudioInputDevices.available().contains(where: { $0.id == normalizedID }) {
+            throw VoxListeningServiceError.selectedInputUnavailable(
+                preferredInputDeviceName ?? "Selected microphone"
+            )
+        }
+
+        let recording = try await recorder.start(
+            preferredInputDeviceID: normalizedID,
+            filePrefix: "speakeasy-listen"
+        )
         try? FileManager.default.setAttributes(
             [.posixPermissions: 0o600],
             ofItemAtPath: recording.url.path

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import VoxCore
 @testable import SpeakEasy
 
 final class PlayerProtocolTests: XCTestCase {
@@ -268,6 +269,20 @@ final class PlayerProtocolTests: XCTestCase {
             VoxListeningService.preferredEngine(parakeetReady: true),
             .parakeet
         )
+    }
+
+    func testDedicatedMicrophonePreferenceRetainsStableIdentity() throws {
+        let preference = ListeningInputPreference(id: "device-uid-42", name: "Studio Mic")
+        let decoded = try JSONDecoder().decode(
+            ListeningInputPreference.self,
+            from: JSONEncoder().encode(preference)
+        )
+
+        XCTAssertEqual(decoded, preference)
+        XCTAssertTrue(preference.isAvailable(in: [
+            AudioInputDeviceInfo(id: "device-uid-42", name: "Studio Mic", isSystemDefault: false)
+        ]))
+        XCTAssertFalse(preference.isAvailable(in: []))
     }
 
     @MainActor


### PR DESCRIPTION
## What changed

- add a compact split listen/microphone composer to the SpeakEasy menu-bar popover
- enumerate Vox audio inputs and persist a fixed device by stable ID and human-readable name
- route every thread-locked voice turn through the selected device
- retain disconnected fixed selections and fail visibly instead of silently falling back
- keep System Default and Refresh Inputs available from the same compact menu

## Why

SpeakEasy should stay attached to a deliberate microphone even when macOS changes its system default. The previous capture path always followed the default device.

## Validation

- `swift test --package-path app` — 20 tests passed
- rendered and inspected the 320-point player popover snapshot through three UI iterations
- `app/build-app.sh` — release build and Developer ID signing passed
- relaunched the signed resident app and verified the bundle signature