### PR TITLE
✨ add task-scoped completion presentation

### DIFF
--- a/app/Package.swift
+++ b/app/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
             path: "Sources/SpeakEasy",
             resources: [
                 .copy("Resources/codex-desktop-bridge.cjs"),
+                .copy("Resources/codex-luna-presenter.cjs"),
                 .copy("Resources/Pad")
             ]
         ),

--- a/app/Sources/SpeakEasy/CodexCompletionObserver.swift
+++ b/app/Sources/SpeakEasy/CodexCompletionObserver.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+struct CodexCompletionProvenance: Codable, Equatable, Sendable {
+    let owner: String
+    let hostID: String
+    let protocolVersion: Int
+    let rolloutPath: String
+    let rolloutIdentity: String
+}
+
+struct CodexCompletionEvent: Codable, Equatable, Sendable {
+    let taskID: String
+    let turnID: String
+    let response: String
+    let completedAt: Date
+    let cursorOffset: Int64
+    let provenance: CodexCompletionProvenance
+}
+
+enum CodexCompletionBridgeMessage: Equatable, Sendable {
+    case baseline(taskID: String, cursorOffset: Int64, rolloutIdentity: String)
+    case cursor(taskID: String, turnID: String, cursorOffset: Int64)
+    case completion(CodexCompletionEvent)
+}
+
+enum CodexCompletionBridgeError: LocalizedError, Equatable {
+    case malformedResponse
+    case bridgeFailed(String)
+    case taskMismatch
+    case invalidCursor
+    case invalidProvenance
+    case emptyResponse
+    case observerAlreadyRunning
+    case runtimeUnavailable
+    case bridgeUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .malformedResponse:
+            return "Codex Desktop returned an unreadable completion event."
+        case .bridgeFailed(let message):
+            return message
+        case .taskMismatch:
+            return "Codex Desktop returned a completion for a different task."
+        case .invalidCursor:
+            return "Codex Desktop returned an invalid completion cursor."
+        case .invalidProvenance:
+            return "SpeakEasy could not prove that the completion came from Codex Desktop."
+        case .emptyResponse:
+            return "Codex completed without a final assistant response."
+        case .observerAlreadyRunning:
+            return "SpeakEasy is already watching this completion subscription."
+        case .runtimeUnavailable:
+            return "SpeakEasy needs Bun or Node.js to watch Codex Desktop completions."
+        case .bridgeUnavailable:
+            return "The SpeakEasy Codex Desktop bridge is missing. Reinstall the app."
+        }
+    }
+}
+
+/// The parser is intentionally independent from Process and Desktop IPC so a
+/// malformed, cross-task, or non-Desktop event can be tested without starting
+/// Codex. It accepts only the structured bridge contract.
+enum CodexCompletionBridgeLineParser {
+    private struct Envelope: Decodable {
+        let ok: Bool?
+        let type: String?
+        let taskID: String?
+        let turnID: String?
+        let response: String?
+        let completedAt: String?
+        let cursor: Int64?
+        let rolloutIdentity: String?
+        let error: String?
+        let provenance: CodexCompletionProvenance?
+    }
+
+    static func parse(_ line: String, expectedTaskID: String) throws -> CodexCompletionBridgeMessage {
+        guard let data = line.data(using: .utf8),
+              let envelope = try? JSONDecoder().decode(Envelope.self, from: data)
+        else { throw CodexCompletionBridgeError.malformedResponse }
+
+        if envelope.ok == false {
+            throw CodexCompletionBridgeError.bridgeFailed(envelope.error ?? "Codex Desktop completion bridge failed.")
+        }
+        guard let type = envelope.type else { throw CodexCompletionBridgeError.malformedResponse }
+        guard envelope.taskID == expectedTaskID else { throw CodexCompletionBridgeError.taskMismatch }
+        guard let cursor = envelope.cursor, cursor >= 0 else {
+            throw CodexCompletionBridgeError.invalidCursor
+        }
+
+        switch type {
+        case "baseline":
+            guard let rolloutIdentity = envelope.rolloutIdentity, !rolloutIdentity.isEmpty else {
+                throw CodexCompletionBridgeError.invalidProvenance
+            }
+            return .baseline(taskID: expectedTaskID, cursorOffset: cursor, rolloutIdentity: rolloutIdentity)
+        case "cursor":
+            guard let turnID = envelope.turnID, !turnID.isEmpty else {
+                throw CodexCompletionBridgeError.malformedResponse
+            }
+            return .cursor(taskID: expectedTaskID, turnID: turnID, cursorOffset: cursor)
+        case "completion":
+            guard let turnID = envelope.turnID, !turnID.isEmpty,
+                  let response = envelope.response?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !response.isEmpty,
+                  let completedAtValue = envelope.completedAt,
+                  let completedAt = ISO8601DateFormatter().date(from: completedAtValue),
+                  let provenance = envelope.provenance,
+                  provenance.owner == "codex-desktop",
+                  provenance.hostID == "local",
+                  provenance.protocolVersion == 11,
+                  provenance.rolloutPath.isEmpty == false,
+                  provenance.rolloutIdentity.isEmpty == false
+            else {
+                if envelope.response?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+                    throw CodexCompletionBridgeError.emptyResponse
+                }
+                throw CodexCompletionBridgeError.invalidProvenance
+            }
+            return .completion(CodexCompletionEvent(
+                taskID: expectedTaskID,
+                turnID: turnID,
+                response: response,
+                completedAt: completedAt,
+                cursorOffset: cursor,
+                provenance: provenance
+            ))
+        default:
+            throw CodexCompletionBridgeError.malformedResponse
+        }
+    }
+}
+
+enum CodexCompletionObserverState: String, Sendable {
+    case subscribed
+    case watching
+    case unavailable
+    case failed
+}
+
+/// Owns a separate long-lived bridge process. It deliberately does not share
+/// CodexThreadRouter.activeProcess: a background follower and an interactive
+/// voice submission may coexist without cancelling one another.
+@MainActor
+final class CodexCompletionObserver {
+    private var process: Process?
+    private var outputPipe: Pipe?
+    private var standardErrorPipe: Pipe?
+    private var outputBuffer = Data()
+    private var stopping = false
+    private var taskID: String?
+    private var onState: ((CodexCompletionObserverState, String?) -> Void)?
+    private var onMessage: ((CodexCompletionBridgeMessage) -> Void)?
+
+    var isRunning: Bool { process != nil }
+
+    func start(
+        taskID: String,
+        cursorOffset: Int64?,
+        rolloutIdentity: String?,
+        onState: @escaping (CodexCompletionObserverState, String?) -> Void,
+        onMessage: @escaping (CodexCompletionBridgeMessage) -> Void
+    ) throws {
+        guard process == nil else { throw CodexCompletionBridgeError.observerAlreadyRunning }
+        guard let runtime = CodexThreadRouter.resolveJavaScriptRuntime() else {
+            throw CodexCompletionBridgeError.runtimeUnavailable
+        }
+        guard let bridge = CodexThreadRouter.resolveBridgeScript() else {
+            throw CodexCompletionBridgeError.bridgeUnavailable
+        }
+
+        let process = Process()
+        let output = Pipe()
+        let standardError = Pipe()
+        process.executableURL = runtime
+        process.arguments = [bridge.path, "observe", taskID]
+            + (cursorOffset.map { [String($0)] } ?? [])
+            + (rolloutIdentity.map { [$0] } ?? [])
+        process.standardOutput = output
+        process.standardError = standardError
+        self.process = process
+        self.outputPipe = output
+        self.standardErrorPipe = standardError
+        self.outputBuffer = Data()
+        self.stopping = false
+        self.taskID = taskID
+        self.onState = onState
+        self.onMessage = onMessage
+
+        output.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            Task { @MainActor [weak self] in
+                self?.consume(data)
+            }
+        }
+        process.terminationHandler = { [weak self] process in
+            Task { @MainActor [weak self] in
+                self?.terminated(status: process.terminationStatus)
+            }
+        }
+
+        do {
+            try process.run()
+            onState(.watching, nil)
+        } catch {
+            stop()
+            throw CodexCompletionBridgeError.bridgeFailed(error.localizedDescription)
+        }
+    }
+
+    func stop() {
+        stopping = true
+        outputPipe?.fileHandleForReading.readabilityHandler = nil
+        process?.terminationHandler = nil
+        process?.terminate()
+        process = nil
+        outputPipe = nil
+        standardErrorPipe = nil
+        outputBuffer.removeAll(keepingCapacity: false)
+        taskID = nil
+    }
+
+    private func consume(_ data: Data) {
+        guard process != nil, let taskID else { return }
+        outputBuffer.append(data)
+        while let newline = outputBuffer.firstIndex(of: 0x0A) {
+            let lineData = outputBuffer.prefix(upTo: newline)
+            outputBuffer.removeSubrange(...newline)
+            guard let line = String(data: lineData, encoding: .utf8), !line.isEmpty else {
+                fail(CodexCompletionBridgeError.malformedResponse.localizedDescription)
+                return
+            }
+            do {
+                let message = try CodexCompletionBridgeLineParser.parse(line, expectedTaskID: taskID)
+                onMessage?(message)
+            } catch {
+                fail(error.localizedDescription)
+                return
+            }
+        }
+    }
+
+    private func terminated(status: Int32) {
+        guard process != nil else { return }
+        let wasStopping = stopping
+        process = nil
+        outputPipe?.fileHandleForReading.readabilityHandler = nil
+        outputPipe = nil
+        standardErrorPipe = nil
+        if !wasStopping {
+            onState?(status == 0 ? .unavailable : .failed, "Codex Desktop completion observer exited (\(status)).")
+        }
+    }
+
+    private func fail(_ message: String) {
+        onState?(.failed, message)
+        stop()
+    }
+}

--- a/app/Sources/SpeakEasy/CodexCompletionObserver.swift
+++ b/app/Sources/SpeakEasy/CodexCompletionObserver.swift
@@ -75,6 +75,12 @@ enum CodexCompletionBridgeLineParser {
         let provenance: CodexCompletionProvenance?
     }
 
+    private static func parseTimestamp(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+    }
+
     static func parse(_ line: String, expectedTaskID: String) throws -> CodexCompletionBridgeMessage {
         guard let data = line.data(using: .utf8),
               let envelope = try? JSONDecoder().decode(Envelope.self, from: data)
@@ -105,7 +111,7 @@ enum CodexCompletionBridgeLineParser {
                   let response = envelope.response?.trimmingCharacters(in: .whitespacesAndNewlines),
                   !response.isEmpty,
                   let completedAtValue = envelope.completedAt,
-                  let completedAt = ISO8601DateFormatter().date(from: completedAtValue),
+                  let completedAt = parseTimestamp(completedAtValue),
                   let provenance = envelope.provenance,
                   provenance.owner == "codex-desktop",
                   provenance.hostID == "local",

--- a/app/Sources/SpeakEasy/CodexLunaCompletionPresenter.swift
+++ b/app/Sources/SpeakEasy/CodexLunaCompletionPresenter.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+enum CompletionPresentationSource: String, Codable, Equatable, Sendable {
+    case luna
+    case deterministic
+}
+
+struct CompletionPresentationRequest: Codable, Equatable, Sendable {
+    let taskID: String
+    let turnID: String
+    let taskTitle: String
+    let projectPath: String
+    let response: String
+}
+
+struct CompletionPresentationResult: Equatable, Sendable {
+    let spokenText: String
+    let source: CompletionPresentationSource
+    let model: String?
+    let fallbackReason: String?
+}
+
+protocol CompletionPresenting: Sendable {
+    func present(_ request: CompletionPresentationRequest) async -> CompletionPresentationResult
+}
+
+enum CompletionSpeechProjector {
+    private static let maximumCharacters = 900
+
+    /// A model-independent safety net. It removes material that is actively
+    /// hostile to speech, but never invents a summary of the canonical answer.
+    static func project(_ response: String) -> String {
+        var text = response
+        text = replacing(pattern: "(?s)```.*?```", in: text, with: " ")
+        text = replacing(pattern: "!\\[([^]]*)\\]\\([^)]*\\)", in: text, with: "$1")
+        text = replacing(pattern: "\\[([^]]+)\\]\\([^)]*\\)", in: text, with: "$1")
+        text = replacing(pattern: "(?m)^\\s{0,3}#{1,6}\\s*", in: text, with: "")
+        text = replacing(pattern: "(?m)^\\s*(?:[-*+] |\\d+[.)]\\s+)", in: text, with: ". ")
+        for marker in ["`", "**", "__", "~~", "> "] {
+            text = text.replacingOccurrences(of: marker, with: "")
+        }
+        text = text
+            .split(whereSeparator: \Character.isWhitespace)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !text.isEmpty else {
+            return "Codex completed the task. The full response is available in Codex."
+        }
+        guard text.count > maximumCharacters else { return text }
+
+        let prefix = String(text.prefix(maximumCharacters))
+        let sentenceBoundary = prefix.lastIndex(where: { ".!?".contains($0) })
+        let wordBoundary = prefix.lastIndex(of: " ")
+        let boundary = sentenceBoundary ?? wordBoundary ?? prefix.endIndex
+        let clipped = prefix[..<boundary].trimmingCharacters(in: .whitespacesAndNewlines)
+        return "\(clipped). The full response is available in Codex."
+    }
+
+    private static func replacing(pattern: String, in text: String, with replacement: String) -> String {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return text }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return expression.stringByReplacingMatches(in: text, range: range, withTemplate: replacement)
+    }
+}
+
+enum CodexLunaCompletionPresenterError: LocalizedError {
+    case runtimeUnavailable
+    case bridgeUnavailable
+    case codexUnavailable
+    case processFailed(String)
+    case invalidResponse
+    case provenanceMismatch
+
+    var errorDescription: String? {
+        switch self {
+        case .runtimeUnavailable:
+            "SpeakEasy needs Bun or Node.js for Luna presentation."
+        case .bridgeUnavailable:
+            "The SpeakEasy Luna presenter bridge is missing. Reinstall the app."
+        case .codexUnavailable:
+            "Codex is unavailable for Luna presentation."
+        case .processFailed(let detail):
+            detail
+        case .invalidResponse:
+            "Luna returned an unreadable spoken presentation."
+        case .provenanceMismatch:
+            "Luna presentation did not preserve the exact source task and turn."
+        }
+    }
+}
+
+/// Presentation is deliberately isolated from the Desktop-owned observer. The
+/// bridge starts a second app-server process and an ephemeral Luna thread, then
+/// returns spoken text only. Any failure becomes deterministic projection.
+actor CodexLunaCompletionPresenter: CompletionPresenting {
+    static let model = "gpt-5.6-luna"
+
+    private struct BridgeEnvelope: Decodable {
+        let ok: Bool
+        let spokenText: String?
+        let model: String?
+        let ephemeral: Bool?
+        let sourceTaskID: String?
+        let sourceTurnID: String?
+        let error: String?
+    }
+
+    func present(_ request: CompletionPresentationRequest) async -> CompletionPresentationResult {
+        do {
+            let envelope = try await invoke(request)
+            guard envelope.ok,
+                  envelope.ephemeral == true,
+                  envelope.model == Self.model,
+                  envelope.sourceTaskID == request.taskID,
+                  envelope.sourceTurnID == request.turnID,
+                  let spokenText = envelope.spokenText?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !spokenText.isEmpty,
+                  spokenText.count <= 900
+            else { throw CodexLunaCompletionPresenterError.provenanceMismatch }
+            return CompletionPresentationResult(
+                spokenText: spokenText,
+                source: .luna,
+                model: Self.model,
+                fallbackReason: nil
+            )
+        } catch {
+            return CompletionPresentationResult(
+                spokenText: CompletionSpeechProjector.project(request.response),
+                source: .deterministic,
+                model: nil,
+                fallbackReason: error.localizedDescription
+            )
+        }
+    }
+
+    private func invoke(_ request: CompletionPresentationRequest) async throws -> BridgeEnvelope {
+        guard let runtime = CodexThreadRouter.resolveJavaScriptRuntime() else {
+            throw CodexLunaCompletionPresenterError.runtimeUnavailable
+        }
+        guard let bridge = Self.resolveBridgeScript() else {
+            throw CodexLunaCompletionPresenterError.bridgeUnavailable
+        }
+        guard let codex = Self.resolveCodexExecutable() else {
+            throw CodexLunaCompletionPresenterError.codexUnavailable
+        }
+
+        let standardInput = try JSONEncoder().encode(request)
+        let process = Process()
+        let input = Pipe()
+        let output = Pipe()
+        let standardError = Pipe()
+        process.executableURL = runtime
+        process.arguments = [bridge.path, codex.path]
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = standardError
+
+        return try await withCheckedThrowingContinuation { continuation in
+            process.terminationHandler = { process in
+                let data = (try? output.fileHandleForReading.readToEnd()) ?? nil
+                let errorData = (try? standardError.fileHandleForReading.readToEnd()) ?? nil
+                guard process.terminationStatus == 0,
+                      let data,
+                      let envelope = try? JSONDecoder().decode(BridgeEnvelope.self, from: data)
+                else {
+                    let bridgeEnvelope = data.flatMap { try? JSONDecoder().decode(BridgeEnvelope.self, from: $0) }
+                    let standardErrorText = errorData
+                        .flatMap { String(data: $0, encoding: .utf8) }?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    let detail = bridgeEnvelope?.error
+                        ?? standardErrorText?.nilIfEmpty
+                        ?? "Luna presenter exited unexpectedly."
+                    continuation.resume(throwing: CodexLunaCompletionPresenterError.processFailed(detail))
+                    return
+                }
+                continuation.resume(returning: envelope)
+            }
+            do {
+                try process.run()
+                try input.fileHandleForWriting.write(contentsOf: standardInput)
+                try input.fileHandleForWriting.close()
+            } catch {
+                process.terminationHandler = nil
+                if process.isRunning { process.terminate() }
+                continuation.resume(throwing: CodexLunaCompletionPresenterError.processFailed(error.localizedDescription))
+            }
+        }
+    }
+
+    private static func resolveBridgeScript() -> URL? {
+        if let override = ProcessInfo.processInfo.environment["SPEAKEASY_LUNA_PRESENTER_PATH"],
+           FileManager.default.isReadableFile(atPath: override) {
+            return URL(fileURLWithPath: override)
+        }
+        return Bundle.module.url(forResource: "codex-luna-presenter", withExtension: "cjs")
+    }
+
+    private static func resolveCodexExecutable() -> URL? {
+        let environment = ProcessInfo.processInfo.environment
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidates = [
+            environment["SPEAKEASY_CODEX_BIN"],
+            environment["CODEX_BIN"],
+            "/Applications/ChatGPT.app/Contents/Resources/codex",
+            "/Applications/Codex.app/Contents/Resources/codex",
+            "\(home)/.local/bin/codex",
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex",
+        ].compactMap { $0 }
+        if let path = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return URL(fileURLWithPath: path)
+        }
+
+        let shell = Process()
+        let output = Pipe()
+        shell.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        shell.arguments = ["-lic", "command -v codex"]
+        shell.standardOutput = output
+        shell.standardError = FileHandle.nullDevice
+        guard (try? shell.run()) != nil else { return nil }
+        shell.waitUntilExit()
+        guard shell.terminationStatus == 0,
+              let data = try? output.fileHandleForReading.readToEnd(),
+              let path = String(data: data, encoding: .utf8)?
+                .split(separator: "\n")
+                .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+                .first(where: { FileManager.default.isExecutableFile(atPath: $0) })
+        else { return nil }
+        return URL(fileURLWithPath: path)
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/app/Sources/SpeakEasy/CodexLunaCompletionPresenter.swift
+++ b/app/Sources/SpeakEasy/CodexLunaCompletionPresenter.swift
@@ -194,7 +194,7 @@ actor CodexLunaCompletionPresenter: CompletionPresenting {
            FileManager.default.isReadableFile(atPath: override) {
             return URL(fileURLWithPath: override)
         }
-        return Bundle.module.url(forResource: "codex-luna-presenter", withExtension: "cjs")
+        return SpeakEasyResources.url(forResource: "codex-luna-presenter", withExtension: "cjs")
     }
 
     private static func resolveCodexExecutable() -> URL? {

--- a/app/Sources/SpeakEasy/CodexThreadRouter.swift
+++ b/app/Sources/SpeakEasy/CodexThreadRouter.swift
@@ -190,7 +190,10 @@ actor CodexThreadRouter {
         )
     }
 
-    private static func resolveBridgeScript() -> URL? {
+    /// Shared by the interactive conduit and the independent completion
+    /// observer. Keeping resolution here avoids the observer inventing a
+    /// second runtime or bridge path.
+    static func resolveBridgeScript() -> URL? {
         let environment = ProcessInfo.processInfo.environment
         if let override = environment["SPEAKEASY_CODEX_BRIDGE_PATH"],
            FileManager.default.isReadableFile(atPath: override) {
@@ -199,7 +202,7 @@ actor CodexThreadRouter {
         return Bundle.module.url(forResource: "codex-desktop-bridge", withExtension: "cjs")
     }
 
-    private static func resolveJavaScriptRuntime() -> URL? {
+    static func resolveJavaScriptRuntime() -> URL? {
         let environment = ProcessInfo.processInfo.environment
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let candidates = [

--- a/app/Sources/SpeakEasy/CompletionSubscriptionController.swift
+++ b/app/Sources/SpeakEasy/CompletionSubscriptionController.swift
@@ -1,0 +1,504 @@
+import Combine
+import Foundation
+
+enum CompletionSubscriptionPresentationState: String, Sendable {
+    case off
+    case subscribed
+    case watching
+    case muted
+    case unavailable
+    case failed
+
+    var label: String {
+        switch self {
+        case .off: "Off"
+        case .subscribed: "Subscribed"
+        case .watching: "Watching"
+        case .muted: "Muted"
+        case .unavailable: "Unavailable"
+        case .failed: "Needs attention"
+        }
+    }
+}
+
+/// Independent completion mode. It has no reference to the listening phase,
+/// active lane, microphone, or interactive Codex submission state.
+@MainActor
+final class CompletionSubscriptionController: ObservableObject {
+    static let shared = CompletionSubscriptionController()
+
+    @Published private(set) var subscription: CompletionSubscription?
+    @Published private(set) var channel: CompletionChannelConfiguration
+    @Published private(set) var activities: [CompletionActivity]
+    @Published private(set) var observerState: CompletionSubscriptionPresentationState = .off
+    @Published private(set) var lastError: String?
+
+    private let store: CompletionSubscriptionStore
+    private let observer: CodexCompletionObserver
+    private let narrator = ConfiguredResponseNarrator()
+    private var playbackObservations: Set<AnyCancellable> = []
+    private var processingTail: Task<Void, Never>?
+    private var started = false
+
+    init(
+        store: CompletionSubscriptionStore = CompletionSubscriptionStore(),
+        observer: CodexCompletionObserver? = nil
+    ) {
+        self.store = store
+        self.observer = observer ?? CodexCompletionObserver()
+        do {
+            let snapshot = try store.load()
+            subscription = snapshot.subscription
+            channel = snapshot.channel
+            activities = snapshot.activities
+            observerState = subscription?.isEnabled == true ? .subscribed : .off
+        } catch {
+            subscription = nil
+            channel = .init()
+            activities = []
+            observerState = .failed
+            lastError = error.localizedDescription
+        }
+        observePlayback()
+    }
+
+    var state: CompletionSubscriptionPresentationState { observerState }
+
+    var queueCount: Int {
+        activities.filter { $0.state == .queued || $0.state == .playing }.count
+    }
+
+    var mostRecentActivity: CompletionActivity? { activities.last }
+
+    func start() {
+        guard !started else { return }
+        started = true
+        guard subscription?.isEnabled == true else { return }
+        startObservation()
+        recoverPendingActivities()
+    }
+
+    func stop() {
+        observer.stop()
+        started = false
+        processingTail?.cancel()
+        processingTail = nil
+        if subscription?.isEnabled == true { observerState = .subscribed }
+    }
+
+    func isSubscribed(to taskID: String) -> Bool {
+        subscription?.task.id == taskID
+    }
+
+    func subscribe(to task: ListeningTaskLock) {
+        observer.stop()
+        subscription = CompletionSubscription(task: task)
+        observerState = .subscribed
+        lastError = nil
+        persist()
+        guard started else { return }
+        startObservation()
+        recoverPendingActivities()
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        guard var subscription else { return }
+        subscription.isEnabled = enabled
+        self.subscription = subscription
+        persist()
+        if enabled {
+            guard started else { return }
+            startObservation()
+            recoverPendingActivities()
+        } else {
+            observer.stop()
+            observerState = .off
+        }
+    }
+
+    func unsubscribe() {
+        observer.stop()
+        subscription = nil
+        observerState = .off
+        lastError = nil
+        persist()
+    }
+
+    func setMuted(_ muted: Bool) {
+        channel.isMuted = muted
+        if muted {
+            for activity in activities where activity.state == .queued {
+                PlaybackEngine.shared.removeQueuedCompletion(activityID: activity.id)
+                updateActivity(activity.id) { $0.state = .muted }
+            }
+        }
+        persist()
+        guard subscription?.isEnabled == true else { return }
+        observerState = muted ? .muted : (observer.isRunning ? .watching : .subscribed)
+    }
+
+    func setProvider(_ provider: String?) {
+        channel.provider = provider?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        persist()
+    }
+
+    func setVoice(_ voice: String?) {
+        channel.voice = voice?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        persist()
+    }
+
+    func setNarrationCue(_ cue: String?) {
+        channel.narrationCue = cue?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        persist()
+    }
+
+    func setPlaybackRate(_ rate: Float) {
+        channel.playbackRate = min(max(rate.isFinite ? rate : 1, 0.5), 2)
+        persist()
+    }
+
+    func setVolume(_ volume: Double) {
+        channel.volume = min(max(volume.isFinite ? volume : 0.7, 0), 1)
+        persist()
+    }
+
+    func dismiss(_ activityID: UUID) {
+        guard let index = activities.firstIndex(where: { $0.id == activityID }) else { return }
+        if PlaybackEngine.shared.currentItem?.completionActivityID == activityID {
+            PlaybackEngine.shared.stop()
+        } else {
+            PlaybackEngine.shared.removeQueuedCompletion(activityID: activityID)
+        }
+        activities[index].state = .dismissed
+        activities[index].failure = nil
+        persist()
+    }
+
+    /// Manual replay is an explicit user action and is allowed while the
+    /// channel is muted. It changes only the speech projection, never Codex.
+    func replay(_ activityID: UUID) {
+        guard let activity = activities.first(where: { $0.id == activityID }) else { return }
+        enqueueForReplay(activity)
+    }
+
+    private func startObservation() {
+        guard let subscription, subscription.isEnabled else {
+            observerState = .off
+            return
+        }
+        observer.stop()
+        do {
+            try observer.start(
+                taskID: subscription.task.id,
+                cursorOffset: subscription.cursorOffset,
+                rolloutIdentity: subscription.rolloutIdentity,
+                onState: { [weak self] state, error in
+                    guard let self else { return }
+                    switch state {
+                    case .watching:
+                        self.observerState = self.channel.isMuted ? .muted : .watching
+                    case .unavailable:
+                        self.observerState = .unavailable
+                    case .failed:
+                        self.observerState = .failed
+                    case .subscribed:
+                        self.observerState = .subscribed
+                    }
+                    if let error {
+                        self.lastError = error
+                        self.persist()
+                    }
+                },
+                onMessage: { [weak self] message in
+                    self?.handle(message)
+                }
+            )
+        } catch {
+            if let bridgeError = error as? CodexCompletionBridgeError,
+               bridgeError == .runtimeUnavailable || bridgeError == .bridgeUnavailable {
+                observerState = .unavailable
+            } else {
+                observerState = .failed
+            }
+            lastError = error.localizedDescription
+            persist()
+        }
+    }
+
+    private func handle(_ message: CodexCompletionBridgeMessage) {
+        guard let subscription else { return }
+        switch message {
+        case .baseline(let taskID, let cursorOffset, let rolloutIdentity):
+            guard taskID == subscription.task.id else {
+                failClosed(CodexCompletionBridgeError.taskMismatch)
+                return
+            }
+            var next = subscription
+            next.cursorOffset = max(cursorOffset, 0)
+            next.rolloutIdentity = rolloutIdentity
+            self.subscription = next
+            persist()
+        case .cursor(let taskID, let turnID, let cursorOffset):
+            guard taskID == subscription.task.id else {
+                failClosed(CodexCompletionBridgeError.taskMismatch)
+                return
+            }
+            var next = subscription
+            next.lastObservedTurnID = turnID
+            next.cursorOffset = max(cursorOffset, next.cursorOffset ?? 0)
+            self.subscription = next
+            persist()
+        case .completion(let event):
+            guard event.taskID == subscription.task.id else {
+                failClosed(CodexCompletionBridgeError.taskMismatch)
+                return
+            }
+            if let rolloutIdentity = subscription.rolloutIdentity,
+               rolloutIdentity != event.provenance.rolloutIdentity {
+                failClosed(CodexCompletionBridgeError.invalidProvenance)
+                return
+            }
+            let previous = processingTail
+            processingTail = Task { @MainActor [weak self] in
+                await previous?.value
+                guard let self, !Task.isCancelled else { return }
+                await self.process(event)
+            }
+        }
+    }
+
+    private func process(_ event: CodexCompletionEvent) async {
+        guard var subscription, subscription.isEnabled, event.taskID == subscription.task.id else { return }
+
+        let key = subscription.dedupeKey(turnID: event.turnID)
+        if subscription.enqueuedTurnIDs.contains(key) {
+            if let index = activities.firstIndex(where: { $0.dedupeKey == key }) {
+                activities[index].deduplicatedCount += 1
+                activities[index].state = .deduplicated
+            }
+            subscription.cursorOffset = max(event.cursorOffset, subscription.cursorOffset ?? 0)
+            subscription.lastObservedTurnID = event.turnID
+            self.subscription = subscription
+            persist()
+            return
+        }
+
+        let activityID: UUID
+        if let existing = activities.first(where: { $0.dedupeKey == key }) {
+            activityID = existing.id
+        } else {
+            let activity = CompletionActivity(
+                taskID: event.taskID,
+                turnID: event.turnID,
+                response: event.response,
+                completedAt: event.completedAt,
+                state: .detected,
+                provider: channel.provider,
+                cursorOffset: event.cursorOffset
+            )
+            activities.append(activity)
+            activityID = activity.id
+        }
+        subscription.cursorOffset = max(event.cursorOffset, subscription.cursorOffset ?? 0)
+        subscription.lastObservedTurnID = event.turnID
+        self.subscription = subscription
+        persist() // detection and cursor survive a crash before TTS finishes
+
+        if channel.isMuted {
+            updateActivity(activityID) { $0.state = .muted }
+            persist()
+            return
+        }
+        await synthesizeAndEnqueue(activityID: activityID, markDurable: true)
+    }
+
+    private func recoverPendingActivities() {
+        guard subscription?.isEnabled == true else { return }
+        for activity in activities {
+            switch activity.state {
+            case .detected:
+                guard !channel.isMuted else {
+                    updateActivity(activity.id) { $0.state = .muted }
+                    continue
+                }
+                enqueueActivityTask(activity.id, markDurable: true)
+            case .queued, .playing:
+                enqueueActivityTask(activity.id, markDurable: false)
+            default:
+                break
+            }
+        }
+        persist()
+    }
+
+    private func enqueueActivityTask(_ activityID: UUID, markDurable: Bool) {
+        let previous = processingTail
+        processingTail = Task { @MainActor [weak self] in
+            await previous?.value
+            guard let self, !Task.isCancelled else { return }
+            await self.synthesizeAndEnqueue(activityID: activityID, markDurable: markDurable)
+        }
+    }
+
+    private func enqueueForReplay(_ activity: CompletionActivity) {
+        let previous = processingTail
+        processingTail = Task { @MainActor [weak self] in
+            await previous?.value
+            guard let self, !Task.isCancelled else { return }
+            if let audioPath = activity.audioPath,
+               FileManager.default.fileExists(atPath: audioPath) {
+                self.enqueuePrepared(activityID: activity.id, audioPath: audioPath, markDurable: false)
+            } else {
+                await self.synthesizeAndEnqueue(activityID: activity.id, markDurable: false)
+            }
+        }
+    }
+
+    private func synthesizeAndEnqueue(activityID: UUID, markDurable: Bool) async {
+        guard let activity = activities.first(where: { $0.id == activityID }),
+              !activity.response.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return }
+        if let audioPath = activity.audioPath,
+           FileManager.default.fileExists(atPath: audioPath) {
+            enqueuePrepared(activityID: activityID, audioPath: audioPath, markDurable: markDurable)
+            return
+        }
+
+        do {
+            let narration = channelNarrationConfiguration()
+            let audioURL = try await narrator.render(text: activity.response, configuration: narration)
+            guard subscription?.task.id == activity.taskID else {
+                try? FileManager.default.removeItem(at: audioURL)
+                return
+            }
+            updateActivity(activityID) {
+                $0.audioPath = audioURL.path
+                $0.provider = narration.provider
+            }
+            enqueuePrepared(activityID: activityID, audioPath: audioURL.path, markDurable: markDurable)
+        } catch {
+            updateActivity(activityID) {
+                $0.state = .failed
+                $0.failure = error.localizedDescription
+            }
+            lastError = error.localizedDescription
+            persist()
+        }
+    }
+
+    private func enqueuePrepared(activityID: UUID, audioPath: String, markDurable: Bool) {
+        guard let index = activities.firstIndex(where: { $0.id == activityID }),
+              FileManager.default.fileExists(atPath: audioPath)
+        else { return }
+        let activity = activities[index]
+        let narration = channelNarrationConfiguration()
+        if markDurable, var subscription {
+            let key = subscription.dedupeKey(turnID: activity.turnID)
+            subscription.enqueuedTurnIDs.insert(key)
+            subscription.lastEnqueuedTurnID = activity.turnID
+            self.subscription = subscription
+        }
+        activities[index].state = .queued
+        activities[index].failure = nil
+        persist() // the exactly-once enqueue decision is durable before queue handoff
+
+        let item = PlaybackItem(
+            id: UUID(),
+            audioPath: audioPath,
+            title: subscription?.task.title ?? "Codex completion",
+            text: activity.response,
+            provider: narration.provider,
+            createdAt: ISO8601DateFormatter().string(from: Date()),
+            synthesisRateWPM: narration.rate,
+            sourceThreadId: activity.taskID,
+            cleanupAfterPlayback: true,
+            playbackRate: channel.playbackRate,
+            channel: .completions,
+            completionActivityID: activity.id
+        )
+        PlaybackEngine.shared.setVolume(Float(channel.volume))
+        do {
+            try PlaybackEngine.shared.enqueue(item, priority: .normal, interrupt: false, autoplay: true)
+        } catch {
+            updateActivity(activityID) {
+                $0.state = .failed
+                $0.failure = error.localizedDescription
+            }
+            lastError = error.localizedDescription
+            persist()
+        }
+    }
+
+    private func observePlayback() {
+        PlaybackEngine.shared.$currentItem
+            .receive(on: RunLoop.main)
+            .sink { [weak self] item in
+                guard let self, let activityID = item?.completionActivityID,
+                      let index = self.activities.firstIndex(where: { $0.id == activityID })
+                else { return }
+                self.activities[index].state = .playing
+                self.persist()
+            }
+            .store(in: &playbackObservations)
+
+        PlaybackEngine.shared.$lastFinishedItemID
+            .receive(on: RunLoop.main)
+            .sink { [weak self] itemID in
+                guard let self, let itemID,
+                      let item = self.activities.first(where: { $0.id == itemID })
+                else { return }
+                self.updateActivity(item.id) {
+                    $0.state = .announced
+                    $0.failure = nil
+                }
+                self.persist()
+            }
+            .store(in: &playbackObservations)
+    }
+
+    private func channelNarrationConfiguration() -> SpeechNarrationConfiguration {
+        let base = SpeechNarrationConfiguration.configured(from: ConfigManager.shared, provider: channel.provider)
+        let voice = channel.voice ?? base.voice
+        let instructions = [base.instructions, channel.narrationCue]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty }
+            .joined(separator: "\n\n")
+            .nilIfEmpty
+        return SpeechNarrationConfiguration(
+            provider: base.provider,
+            voice: voice,
+            model: base.model,
+            apiKey: base.apiKey,
+            instructions: instructions,
+            rate: base.rate
+        )
+    }
+
+    private func updateActivity(_ activityID: UUID, _ update: (inout CompletionActivity) -> Void) {
+        guard let index = activities.firstIndex(where: { $0.id == activityID }) else { return }
+        update(&activities[index])
+    }
+
+    private func failClosed(_ error: Error) {
+        observer.stop()
+        observerState = .failed
+        lastError = error.localizedDescription
+        persist()
+    }
+
+    private func persist() {
+        do {
+            try store.save(CompletionSubscriptionSnapshot(
+                subscription: subscription,
+                channel: channel,
+                activities: activities
+            ))
+        } catch {
+            lastError = error.localizedDescription
+            observerState = .failed
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/app/Sources/SpeakEasy/CompletionSubscriptionController.swift
+++ b/app/Sources/SpeakEasy/CompletionSubscriptionController.swift
@@ -32,9 +32,11 @@ final class CompletionSubscriptionController: ObservableObject {
     @Published private(set) var activities: [CompletionActivity]
     @Published private(set) var observerState: CompletionSubscriptionPresentationState = .off
     @Published private(set) var lastError: String?
+    @Published private(set) var isFeatureEnabled: Bool
 
     private let store: CompletionSubscriptionStore
     private let observer: CodexCompletionObserver
+    private let presenter: any CompletionPresenting
     private let narrator = ConfiguredResponseNarrator()
     private var playbackObservations: Set<AnyCancellable> = []
     private var processingTail: Task<Void, Never>?
@@ -42,16 +44,20 @@ final class CompletionSubscriptionController: ObservableObject {
 
     init(
         store: CompletionSubscriptionStore = CompletionSubscriptionStore(),
-        observer: CodexCompletionObserver? = nil
+        observer: CodexCompletionObserver? = nil,
+        presenter: (any CompletionPresenting)? = nil,
+        featureEnabled: Bool? = nil
     ) {
         self.store = store
         self.observer = observer ?? CodexCompletionObserver()
+        self.presenter = presenter ?? CodexLunaCompletionPresenter()
+        self.isFeatureEnabled = featureEnabled ?? ConfigManager.shared.observerPresenterEnabled
         do {
             let snapshot = try store.load()
             subscription = snapshot.subscription
             channel = snapshot.channel
             activities = snapshot.activities
-            observerState = subscription?.isEnabled == true ? .subscribed : .off
+            observerState = isFeatureEnabled && subscription?.isEnabled == true ? .subscribed : .off
         } catch {
             subscription = nil
             channel = .init()
@@ -73,6 +79,10 @@ final class CompletionSubscriptionController: ObservableObject {
     func start() {
         guard !started else { return }
         started = true
+        guard isFeatureEnabled else {
+            observerState = .off
+            return
+        }
         guard subscription?.isEnabled == true else { return }
         startObservation()
         recoverPendingActivities()
@@ -91,6 +101,7 @@ final class CompletionSubscriptionController: ObservableObject {
     }
 
     func subscribe(to task: ListeningTaskLock) {
+        guard isFeatureEnabled else { return }
         observer.stop()
         subscription = CompletionSubscription(task: task)
         observerState = .subscribed
@@ -102,6 +113,7 @@ final class CompletionSubscriptionController: ObservableObject {
     }
 
     func setEnabled(_ enabled: Bool) {
+        guard isFeatureEnabled || !enabled else { return }
         guard var subscription else { return }
         subscription.isEnabled = enabled
         self.subscription = subscription
@@ -182,7 +194,7 @@ final class CompletionSubscriptionController: ObservableObject {
     }
 
     private func startObservation() {
-        guard let subscription, subscription.isEnabled else {
+        guard isFeatureEnabled, let subscription, subscription.isEnabled else {
             observerState = .off
             return
         }
@@ -268,7 +280,11 @@ final class CompletionSubscriptionController: ObservableObject {
     }
 
     private func process(_ event: CodexCompletionEvent) async {
-        guard var subscription, subscription.isEnabled, event.taskID == subscription.task.id else { return }
+        guard isFeatureEnabled,
+              var subscription,
+              subscription.isEnabled,
+              event.taskID == subscription.task.id
+        else { return }
 
         let key = subscription.dedupeKey(turnID: event.turnID)
         if subscription.enqueuedTurnIDs.contains(key) {
@@ -313,7 +329,7 @@ final class CompletionSubscriptionController: ObservableObject {
     }
 
     private func recoverPendingActivities() {
-        guard subscription?.isEnabled == true else { return }
+        guard isFeatureEnabled, subscription?.isEnabled == true else { return }
         for activity in activities {
             switch activity.state {
             case .detected:
@@ -355,7 +371,8 @@ final class CompletionSubscriptionController: ObservableObject {
     }
 
     private func synthesizeAndEnqueue(activityID: UUID, markDurable: Bool) async {
-        guard let activity = activities.first(where: { $0.id == activityID }),
+        guard isFeatureEnabled,
+              let activity = activities.first(where: { $0.id == activityID }),
               !activity.response.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { return }
         if let audioPath = activity.audioPath,
@@ -365,8 +382,34 @@ final class CompletionSubscriptionController: ObservableObject {
         }
 
         do {
+            let spokenText: String
+            if let existing = activity.spokenText?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !existing.isEmpty {
+                spokenText = existing
+            } else {
+                guard let task = subscription?.task, task.id == activity.taskID else { return }
+                let presentation = await presenter.present(CompletionPresentationRequest(
+                    taskID: activity.taskID,
+                    turnID: activity.turnID,
+                    taskTitle: task.title,
+                    projectPath: task.cwd,
+                    response: activity.response
+                ))
+                guard subscription?.task.id == activity.taskID,
+                      activities.contains(where: { $0.id == activityID && $0.turnID == activity.turnID })
+                else { return }
+                spokenText = presentation.spokenText
+                updateActivity(activityID) {
+                    $0.spokenText = presentation.spokenText
+                    $0.presentationSource = presentation.source
+                    $0.presentationModel = presentation.model
+                    $0.presentationFailure = presentation.fallbackReason
+                }
+                persist()
+            }
             let narration = channelNarrationConfiguration()
-            let audioURL = try await narrator.render(text: activity.response, configuration: narration)
+            let audioURL = try await narrator.render(text: spokenText, configuration: narration)
             guard subscription?.task.id == activity.taskID else {
                 try? FileManager.default.removeItem(at: audioURL)
                 return
@@ -391,6 +434,7 @@ final class CompletionSubscriptionController: ObservableObject {
               FileManager.default.fileExists(atPath: audioPath)
         else { return }
         let activity = activities[index]
+        let spokenText = activity.spokenText ?? CompletionSpeechProjector.project(activity.response)
         let narration = channelNarrationConfiguration()
         if markDurable, var subscription {
             let key = subscription.dedupeKey(turnID: activity.turnID)
@@ -406,7 +450,7 @@ final class CompletionSubscriptionController: ObservableObject {
             id: UUID(),
             audioPath: audioPath,
             title: subscription?.task.title ?? "Codex completion",
-            text: activity.response,
+            text: spokenText,
             provider: narration.provider,
             createdAt: ISO8601DateFormatter().string(from: Date()),
             synthesisRateWPM: narration.rate,

--- a/app/Sources/SpeakEasy/CompletionSubscriptions.swift
+++ b/app/Sources/SpeakEasy/CompletionSubscriptions.swift
@@ -1,0 +1,312 @@
+import Foundation
+
+/// The one announcement channel shipped in the first completion slice. This
+/// is deliberately a channel policy, not another voice lane or Codex task.
+struct CompletionChannelConfiguration: Codable, Equatable, Sendable {
+    static let id = "completions"
+
+    var channelID: String
+    var provider: String?
+    var voice: String?
+    var narrationCue: String?
+    var playbackRate: Float
+    var volume: Double
+    var isMuted: Bool
+
+    init(
+        channelID: String = Self.id,
+        provider: String? = nil,
+        voice: String? = nil,
+        narrationCue: String? = nil,
+        playbackRate: Float = 1,
+        volume: Double = 0.7,
+        isMuted: Bool = false
+    ) {
+        self.channelID = channelID
+        self.provider = provider?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        self.voice = voice?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        self.narrationCue = narrationCue?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        self.playbackRate = min(max(playbackRate.isFinite ? playbackRate : 1, 0.5), 2)
+        self.volume = min(max(volume.isFinite ? volume : 0.7, 0), 1)
+        self.isMuted = isMuted
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case channelID, provider, voice, narrationCue, playbackRate, volume, isMuted
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            channelID: try container.decodeIfPresent(String.self, forKey: .channelID) ?? Self.id,
+            provider: try container.decodeIfPresent(String.self, forKey: .provider),
+            voice: try container.decodeIfPresent(String.self, forKey: .voice),
+            narrationCue: try container.decodeIfPresent(String.self, forKey: .narrationCue),
+            playbackRate: try container.decodeIfPresent(Float.self, forKey: .playbackRate) ?? 1,
+            volume: try container.decodeIfPresent(Double.self, forKey: .volume) ?? 0.7,
+            isMuted: try container.decodeIfPresent(Bool.self, forKey: .isMuted) ?? false
+        )
+    }
+}
+
+struct CompletionSubscription: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 2
+
+    let task: ListeningTaskLock
+    var channelID: String
+    var isEnabled: Bool
+    var lastObservedTurnID: String?
+    var lastEnqueuedTurnID: String?
+    var cursorOffset: Int64?
+    var rolloutIdentity: String?
+    var enqueuedTurnIDs: Set<String>
+    var subscribedAt: Date
+    var schemaVersion: Int
+
+    init(
+        task: ListeningTaskLock,
+        channelID: String = CompletionChannelConfiguration.id,
+        isEnabled: Bool = true,
+        lastObservedTurnID: String? = nil,
+        lastEnqueuedTurnID: String? = nil,
+        cursorOffset: Int64? = nil,
+        rolloutIdentity: String? = nil,
+        enqueuedTurnIDs: Set<String> = [],
+        subscribedAt: Date = Date(),
+        schemaVersion: Int = Self.currentSchemaVersion
+    ) {
+        self.task = task
+        self.channelID = channelID
+        self.isEnabled = isEnabled
+        self.lastObservedTurnID = lastObservedTurnID
+        self.lastEnqueuedTurnID = lastEnqueuedTurnID
+        self.cursorOffset = cursorOffset
+        self.rolloutIdentity = rolloutIdentity
+        self.enqueuedTurnIDs = enqueuedTurnIDs
+        self.subscribedAt = subscribedAt
+        self.schemaVersion = schemaVersion
+    }
+
+    /// The durable dedupe identity is always exact task + exact turn. Never
+    /// substitute title, project, path, response text, or recency here.
+    func dedupeKey(turnID: String) -> String {
+        "\(task.id)::\(turnID)"
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case task, channelID, isEnabled, lastObservedTurnID, lastEnqueuedTurnID
+        case cursorOffset, rolloutIdentity, enqueuedTurnIDs, subscribedAt, schemaVersion
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let task = try container.decode(ListeningTaskLock.self, forKey: .task)
+        let oldLastEnqueued = try container.decodeIfPresent(String.self, forKey: .lastEnqueuedTurnID)
+        let legacySet = oldLastEnqueued.map { ["\(task.id)::\($0)"] } ?? []
+        self.init(
+            task: task,
+            channelID: try container.decodeIfPresent(String.self, forKey: .channelID)
+                ?? CompletionChannelConfiguration.id,
+            isEnabled: try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true,
+            lastObservedTurnID: try container.decodeIfPresent(String.self, forKey: .lastObservedTurnID),
+            lastEnqueuedTurnID: oldLastEnqueued,
+            cursorOffset: try container.decodeIfPresent(Int64.self, forKey: .cursorOffset),
+            rolloutIdentity: try container.decodeIfPresent(String.self, forKey: .rolloutIdentity),
+            enqueuedTurnIDs: Set(
+                (try container.decodeIfPresent([String].self, forKey: .enqueuedTurnIDs) ?? []) + legacySet
+            ),
+            subscribedAt: try container.decodeIfPresent(Date.self, forKey: .subscribedAt) ?? Date(),
+            schemaVersion: try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
+                ?? Self.currentSchemaVersion
+        )
+    }
+}
+
+enum CompletionActivityState: String, Codable, Equatable, Sendable {
+    case detected
+    case muted
+    case queued
+    case playing
+    case announced
+    case failed
+    case dismissed
+    case deduplicated
+}
+
+struct CompletionActivity: Codable, Equatable, Identifiable, Sendable {
+    let id: UUID
+    let taskID: String
+    let turnID: String
+    let response: String
+    let completedAt: Date
+    let detectedAt: Date
+    var state: CompletionActivityState
+    var audioPath: String?
+    var provider: String?
+    var failure: String?
+    var cursorOffset: Int64?
+    var deduplicatedCount: Int
+
+    init(
+        id: UUID = UUID(),
+        taskID: String,
+        turnID: String,
+        response: String,
+        completedAt: Date,
+        detectedAt: Date = Date(),
+        state: CompletionActivityState = .detected,
+        audioPath: String? = nil,
+        provider: String? = nil,
+        failure: String? = nil,
+        cursorOffset: Int64? = nil,
+        deduplicatedCount: Int = 0
+    ) {
+        self.id = id
+        self.taskID = taskID
+        self.turnID = turnID
+        self.response = response
+        self.completedAt = completedAt
+        self.detectedAt = detectedAt
+        self.state = state
+        self.audioPath = audioPath
+        self.provider = provider
+        self.failure = failure
+        self.cursorOffset = cursorOffset
+        self.deduplicatedCount = deduplicatedCount
+    }
+
+    var dedupeKey: String { "\(taskID)::\(turnID)" }
+}
+
+struct CompletionSubscriptionSnapshot: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 2
+
+    var schemaVersion: Int
+    var subscription: CompletionSubscription?
+    var channel: CompletionChannelConfiguration
+    var activities: [CompletionActivity]
+
+    init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        subscription: CompletionSubscription? = nil,
+        channel: CompletionChannelConfiguration = .init(),
+        activities: [CompletionActivity] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.subscription = subscription
+        self.channel = channel
+        self.activities = activities
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion, subscription, channel, activities
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            schemaVersion: try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
+                ?? Self.currentSchemaVersion,
+            subscription: try container.decodeIfPresent(CompletionSubscription.self, forKey: .subscription),
+            channel: try container.decodeIfPresent(CompletionChannelConfiguration.self, forKey: .channel)
+                ?? .init(),
+            activities: try container.decodeIfPresent([CompletionActivity].self, forKey: .activities) ?? []
+        )
+    }
+
+    func normalized() -> Self {
+        var copy = self
+        copy.schemaVersion = Self.currentSchemaVersion
+        copy.channel = CompletionChannelConfiguration(
+            channelID: CompletionChannelConfiguration.id,
+            provider: channel.provider,
+            voice: channel.voice,
+            narrationCue: channel.narrationCue,
+            playbackRate: channel.playbackRate,
+            volume: channel.volume,
+            isMuted: channel.isMuted
+        )
+        copy.activities = Array(activities.suffix(100))
+        if var subscription = copy.subscription {
+            subscription.schemaVersion = CompletionSubscription.currentSchemaVersion
+            subscription.channelID = CompletionChannelConfiguration.id
+            copy.subscription = subscription
+        }
+        return copy
+    }
+}
+
+enum CompletionSubscriptionStoreError: LocalizedError, Equatable {
+    case unsupportedSchema(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedSchema(let version):
+            return "SpeakEasy completion subscriptions use an unsupported schema (\(version))."
+        }
+    }
+}
+
+struct CompletionSubscriptionStore: Sendable {
+    let fileURL: URL
+
+    init(fileURL: URL = Self.defaultFileURL()) {
+        self.fileURL = fileURL
+    }
+
+    func load() throws -> CompletionSubscriptionSnapshot {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return .init() }
+        let data = try Data(contentsOf: fileURL)
+        let snapshot = try JSONDecoder.speakeasy.decode(CompletionSubscriptionSnapshot.self, from: data)
+        guard snapshot.schemaVersion <= CompletionSubscriptionSnapshot.currentSchemaVersion else {
+            throw CompletionSubscriptionStoreError.unsupportedSchema(snapshot.schemaVersion)
+        }
+        if let subscription = snapshot.subscription,
+           subscription.schemaVersion > CompletionSubscription.currentSchemaVersion {
+            throw CompletionSubscriptionStoreError.unsupportedSchema(subscription.schemaVersion)
+        }
+        return snapshot.normalized()
+    }
+
+    func save(_ snapshot: CompletionSubscriptionSnapshot) throws {
+        let directory = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        var data = try JSONEncoder.speakeasy.encode(snapshot.normalized())
+        data.append(0x0A)
+        try data.write(to: fileURL, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+    }
+
+    static func defaultFileURL(fileManager: FileManager = .default) -> URL {
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
+        return base
+            .appendingPathComponent("SpeakEasy", isDirectory: true)
+            .appendingPathComponent("completion-subscriptions.json", isDirectory: false)
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}
+
+private extension JSONEncoder {
+    static var speakeasy: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+}
+
+private extension JSONDecoder {
+    static var speakeasy: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/app/Sources/SpeakEasy/CompletionSubscriptions.swift
+++ b/app/Sources/SpeakEasy/CompletionSubscriptions.swift
@@ -146,6 +146,10 @@ struct CompletionActivity: Codable, Equatable, Identifiable, Sendable {
     var failure: String?
     var cursorOffset: Int64?
     var deduplicatedCount: Int
+    var spokenText: String?
+    var presentationSource: CompletionPresentationSource?
+    var presentationModel: String?
+    var presentationFailure: String?
 
     init(
         id: UUID = UUID(),
@@ -159,7 +163,11 @@ struct CompletionActivity: Codable, Equatable, Identifiable, Sendable {
         provider: String? = nil,
         failure: String? = nil,
         cursorOffset: Int64? = nil,
-        deduplicatedCount: Int = 0
+        deduplicatedCount: Int = 0,
+        spokenText: String? = nil,
+        presentationSource: CompletionPresentationSource? = nil,
+        presentationModel: String? = nil,
+        presentationFailure: String? = nil
     ) {
         self.id = id
         self.taskID = taskID
@@ -173,6 +181,10 @@ struct CompletionActivity: Codable, Equatable, Identifiable, Sendable {
         self.failure = failure
         self.cursorOffset = cursorOffset
         self.deduplicatedCount = deduplicatedCount
+        self.spokenText = spokenText
+        self.presentationSource = presentationSource
+        self.presentationModel = presentationModel
+        self.presentationFailure = presentationFailure
     }
 
     var dedupeKey: String { "\(taskID)::\(turnID)" }

--- a/app/Sources/SpeakEasy/ConfigModel.swift
+++ b/app/Sources/SpeakEasy/ConfigModel.swift
@@ -7,6 +7,13 @@ struct GlobalConfig: Codable {
     var cache: Cache?
     var hud: HUD?
     var deck: Deck?
+    var features: Features?
+
+    /// Experimental product slices remain opt-in until their failure and
+    /// privacy boundaries have been exercised in release builds.
+    struct Features: Codable {
+        var observerPresenter: Bool?
+    }
 
     /// Bridge settings for `speakeasy deck` — the CLI reads these as defaults,
     /// the Deck section in this app writes them.
@@ -220,6 +227,15 @@ class ConfigManager: ObservableObject {
             config.defaults?.volume = newValue
             markUnsaved()
         }
+    }
+
+    /// The environment value is an emergency override: `0` always disables
+    /// the experiment and `1` enables it without rewriting user settings.
+    var observerPresenterEnabled: Bool {
+        ObserverPresenterFeature.isEnabled(
+            environment: ProcessInfo.processInfo.environment,
+            configured: config.features?.observerPresenter
+        )
     }
 
     // OpenAI

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -265,6 +265,9 @@ struct ListeningPopoverSection: View {
                     .foregroundColor(completions.channel.isMuted ? .orange : theme.textSecondary)
                     .help(completions.channel.isMuted ? "Unmute completion announcements" : "Mute completion announcements")
                     .accessibilityLabel(completions.channel.isMuted ? "Unmute Completions channel" : "Mute Completions channel")
+                    Button("Remove") { completions.unsubscribe() }
+                        .buttonStyle(.popoverTextTertiary)
+                        .help("Remove the exact-task completion subscription")
                 }
                 .accessibilityElement(children: .contain)
                 .accessibilityLabel("Completions channel, (completions.state.label)")

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -12,6 +12,7 @@ struct ListeningPopoverSection: View {
     }
 
     @ObservedObject private var listening = ListeningSessionController.shared
+    @ObservedObject private var completions = CompletionSubscriptionController.shared
     @ObservedObject private var config = ConfigManager.shared
     @Environment(\.theme) private var theme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -206,6 +207,8 @@ struct ListeningPopoverSection: View {
                 .foregroundStyle(theme.textTertiary)
                 .fixedSize(horizontal: false, vertical: true)
 
+            completionControls(for: lock)
+
             captureComposer
 
             laneStrip(currentTask: lock)
@@ -213,6 +216,89 @@ struct ListeningPopoverSection: View {
             shortcutStatus
         }
         .onAppear { listening.refreshInputDevices() }
+    }
+
+    private func completionControls(for lock: ListeningTaskLock) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: Binding(
+                get: { completions.isSubscribed(to: lock.id) && completions.subscription?.isEnabled == true },
+                set: { enabled in
+                    if enabled {
+                        completions.subscribe(to: lock)
+                    } else if completions.isSubscribed(to: lock.id) {
+                        completions.setEnabled(false)
+                    }
+                }
+            )) {
+                HStack(spacing: 6) {
+                    Image(systemName: "speaker.wave.2.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text("Announce completions")
+                        .font(PopoverType.secondaryStrong)
+                }
+            }
+            .toggleStyle(.switch)
+            .tint(accent)
+            .accessibilityHint("Watch only this exact Codex task for future completed turns")
+
+            if completions.isSubscribed(to: lock.id), completions.subscription?.isEnabled == true {
+                HStack(spacing: 7) {
+                    Text("Channel: Completions")
+                        .font(PopoverType.caption)
+                        .foregroundColor(theme.textSecondary)
+                    Text(completions.state.label)
+                        .font(PopoverType.caption)
+                        .foregroundColor(completionStateColor)
+                    if completions.queueCount > 0 {
+                        Text("· (completions.queueCount) queued")
+                            .font(PopoverType.caption)
+                            .foregroundColor(theme.textTertiary)
+                    }
+                    Spacer(minLength: 0)
+                    Button {
+                        completions.setMuted(!completions.channel.isMuted)
+                    } label: {
+                        Image(systemName: completions.channel.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
+                            .font(.system(size: 10, weight: .semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(completions.channel.isMuted ? .orange : theme.textSecondary)
+                    .help(completions.channel.isMuted ? "Unmute completion announcements" : "Mute completion announcements")
+                    .accessibilityLabel(completions.channel.isMuted ? "Unmute Completions channel" : "Mute Completions channel")
+                }
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Completions channel, (completions.state.label)")
+
+                if let activity = completions.mostRecentActivity, activity.taskID == lock.id {
+                    HStack(spacing: 6) {
+                        Image(systemName: activity.state == .failed ? "exclamationmark.triangle" : "checkmark.circle")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundColor(activity.state == .failed ? .orange : theme.textTertiary)
+                        Text("Turn (activity.turnID.prefix(8)) · (activity.state.rawValue)")
+                            .font(PopoverType.caption)
+                            .foregroundColor(theme.textTertiary)
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                        if activity.state != .announced && activity.state != .dismissed {
+                            Button("Replay") { completions.replay(activity.id) }
+                                .buttonStyle(.popoverTextTertiary)
+                        }
+                        Button("Dismiss") { completions.dismiss(activity.id) }
+                            .buttonStyle(.popoverTextTertiary)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var completionStateColor: Color {
+        switch completions.state {
+        case .failed, .unavailable: .orange
+        case .muted: .orange
+        case .watching: accent
+        default: theme.textTertiary
+        }
     }
 
     /// Ready reads as a tinted, not filled, control. A second solid mint slab
@@ -418,7 +504,7 @@ struct ListeningPopoverSection: View {
                 .accessibilityLabel("Play active lane cue")
             }
 
-            HStack(spacing: 4) {
+                HStack(spacing: 4) {
                 ForEach(ListeningSessionController.laneRange, id: \.self) { number in
                     laneChip(number: number, currentTask: currentTask)
                 }
@@ -640,6 +726,12 @@ struct ListeningPopoverSection: View {
                     .lineLimit(1)
                 }
                 Spacer(minLength: 0)
+                if completions.isSubscribed(to: task.id) {
+                    Image(systemName: "speaker.wave.2.fill")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(accent)
+                        .accessibilityLabel("Completion announcements subscribed")
+                }
             }
             .padding(.horizontal, 7)
             .frame(height: 42)

--- a/app/Sources/SpeakEasy/ListeningPopoverSection.swift
+++ b/app/Sources/SpeakEasy/ListeningPopoverSection.swift
@@ -207,7 +207,9 @@ struct ListeningPopoverSection: View {
                 .foregroundStyle(theme.textTertiary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            completionControls(for: lock)
+            if completions.isFeatureEnabled {
+                completionControls(for: lock)
+            }
 
             captureComposer
 
@@ -233,13 +235,13 @@ struct ListeningPopoverSection: View {
                 HStack(spacing: 6) {
                     Image(systemName: "speaker.wave.2.fill")
                         .font(.system(size: 10, weight: .semibold))
-                    Text("Announce completions")
+                    Text("Present completions")
                         .font(PopoverType.secondaryStrong)
                 }
             }
             .toggleStyle(.switch)
             .tint(accent)
-            .accessibilityHint("Watch only this exact Codex task for future completed turns")
+            .accessibilityHint("Observe only this exact Codex task and present future completions with Luna")
 
             if completions.isSubscribed(to: lock.id), completions.subscription?.isEnabled == true {
                 HStack(spacing: 7) {

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -126,6 +126,7 @@ final class ListeningSessionController: ObservableObject {
                 } else if state == .idle, self.narrationDidStart {
                     self.pendingNarrationItemID = nil
                     self.narrationDidStart = false
+                    PlaybackEngine.shared.setInteractiveBusy(false)
                     self.phase = self.lockedTask == nil ? .unlocked : .ready
                     self.diagnostic("voice loop playback completed")
                 }
@@ -161,6 +162,7 @@ final class ListeningSessionController: ObservableObject {
         recordingStartID = nil
         recordingContext = nil
         stopAfterWarmupRequested = false
+        PlaybackEngine.shared.setInteractiveBusy(false)
         validationID = nil
         shortcut?.unregisterAll()
         shortcut = nil
@@ -358,6 +360,7 @@ final class ListeningSessionController: ObservableObject {
             return
         }
         if phase == .speaking { PlaybackEngine.shared.stop() }
+        PlaybackEngine.shared.setInteractiveBusy(false)
         activeLaneNumber = number
         persistLaneConfiguration()
         // Keep the destination visible in the HUD while its exact Desktop
@@ -379,6 +382,7 @@ final class ListeningSessionController: ObservableObject {
         }
         guard !isRoutingTurn, phase != .cueing, phase != .warmingUp else { return }
         if phase == .speaking { PlaybackEngine.shared.stop() }
+        PlaybackEngine.shared.setInteractiveBusy(false)
         validationID = nil
         lockedTask = nil
         activeLaneNumber = nil
@@ -418,6 +422,7 @@ final class ListeningSessionController: ObservableObject {
         stopAfterWarmupRequested = false
         Task {
             await vox.cancelRecording()
+            PlaybackEngine.shared.setInteractiveBusy(false)
             phase = lockedTask == nil ? .unlocked : .ready
             diagnostic("recording cancelled")
         }
@@ -660,6 +665,7 @@ final class ListeningSessionController: ObservableObject {
         lastTranscript = ""
         lastResponse = ""
         lastDelivery = nil
+        PlaybackEngine.shared.setInteractiveBusy(true)
         PlaybackEngine.shared.stop()
         let startID = UUID()
         recordingStartID = startID
@@ -1055,6 +1061,7 @@ final class ListeningSessionController: ObservableObject {
         stopAfterWarmupRequested = false
         pendingNarrationItemID = nil
         narrationDidStart = false
+        PlaybackEngine.shared.setInteractiveBusy(false)
         lastError = error.localizedDescription
         phase = lockedTask == nil ? .unlocked : .failed
         diagnostic("failed: \(error.localizedDescription)")

--- a/app/Sources/SpeakEasy/ListeningSessionController.swift
+++ b/app/Sources/SpeakEasy/ListeningSessionController.swift
@@ -665,6 +665,7 @@ final class ListeningSessionController: ObservableObject {
         lastTranscript = ""
         lastResponse = ""
         lastDelivery = nil
+        PlaybackEngine.shared.deferCurrentCompletion()
         PlaybackEngine.shared.setInteractiveBusy(true)
         PlaybackEngine.shared.stop()
         let startID = UUID()

--- a/app/Sources/SpeakEasy/MenuBarController.swift
+++ b/app/Sources/SpeakEasy/MenuBarController.swift
@@ -27,6 +27,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         observeActivityState()
         startIPCServer()
         ListeningSessionController.shared.start()
+        CompletionSubscriptionController.shared.start()
         SpeakEasyPadIntegration.shared.start()
     }
 
@@ -34,6 +35,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         closePopover()
         removeEventMonitor()
         SpeakEasyPadIntegration.shared.stop()
+        CompletionSubscriptionController.shared.stop()
         ListeningSessionController.shared.stop()
         PlayerIPCServer.shared.stop()
 

--- a/app/Sources/SpeakEasy/ObserverPresenterFeature.swift
+++ b/app/Sources/SpeakEasy/ObserverPresenterFeature.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum ObserverPresenterFeature {
+    static let environmentKey = "SPEAKEASY_OBSERVER_PRESENTER"
+
+    /// Default-off release flag. An explicit environment value wins so a bad
+    /// presenter can be disabled without editing or migrating persisted state.
+    static func isEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        configured: Bool?
+    ) -> Bool {
+        if let value = environment[environmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() {
+            if ["1", "true", "yes", "on"].contains(value) { return true }
+            if ["0", "false", "no", "off"].contains(value) { return false }
+        }
+        return configured ?? false
+    }
+}

--- a/app/Sources/SpeakEasy/PlaybackEngine.swift
+++ b/app/Sources/SpeakEasy/PlaybackEngine.swift
@@ -12,9 +12,11 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
     @Published private(set) var duration: TimeInterval = 0
     @Published private(set) var audioLevel: Float = 0
     @Published private(set) var lastError: String?
+    @Published private(set) var lastFinishedItemID: UUID?
     @Published var autoplayEnabled = true
     @Published private(set) var volume: Float = 0.8
     @Published private(set) var playbackRate: Float = 1
+    @Published private(set) var interactiveBusy = false
 
     private var player: AVAudioPlayer?
     private var progressTimer: Timer?
@@ -49,8 +51,21 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
             queue.append(item)
         }
 
-        if (autoplay ?? autoplayEnabled) && currentItem == nil {
+        if (autoplay ?? autoplayEnabled) && currentItem == nil && canStartNextItem {
             try playNext()
+        }
+    }
+
+    /// Completion narration is background work. It may remain queued while a
+    /// microphone turn or interactive response owns the player.
+    func setInteractiveBusy(_ busy: Bool) {
+        interactiveBusy = busy
+        guard !busy, currentItem == nil, autoplayEnabled else { return }
+        do {
+            try playNext()
+        } catch {
+            state = .failed
+            lastError = error.localizedDescription
         }
     }
 
@@ -94,6 +109,10 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
 
     func removeQueueItem(id: UUID) {
         queue.removeAll { $0.id == id }
+    }
+
+    func removeQueuedCompletion(activityID: UUID) {
+        queue.removeAll { $0.completionActivityID == activityID }
     }
 
     func seek(to position: TimeInterval) {
@@ -140,6 +159,8 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
 
         volume = 0.8
         playbackRate = 1
+        interactiveBusy = false
+        lastFinishedItemID = nil
         autoplayEnabled = true
         lastError = nil
 
@@ -252,7 +273,7 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
     nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            self.finishCurrentItem()
+            self.finishCurrentItem(naturallyFinished: true)
             if self.autoplayEnabled {
                 do {
                     try self.playNext()
@@ -264,11 +285,21 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
         }
     }
 
+    private var canStartNextItem: Bool {
+        guard let next = queue.first else { return false }
+        return next.effectiveChannel != .completions || !interactiveBusy
+    }
+
     private func playNext() throws {
         guard !queue.isEmpty else {
             if currentItem == nil {
                 state = .idle
             }
+            return
+        }
+
+        if queue[0].effectiveChannel == .completions && interactiveBusy {
+            state = .idle
             return
         }
 
@@ -309,11 +340,14 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
         if resetPosition {
             player?.currentTime = 0
         }
-        finishCurrentItem()
+        finishCurrentItem(naturallyFinished: false)
     }
 
-    private func finishCurrentItem() {
+    private func finishCurrentItem(naturallyFinished: Bool) {
         let finishedItem = currentItem
+        if naturallyFinished {
+            lastFinishedItemID = finishedItem?.id
+        }
         HUDWindowManager.shared.playbackDidFinish()
         progressTimer?.invalidate()
         progressTimer = nil

--- a/app/Sources/SpeakEasy/PlaybackEngine.swift
+++ b/app/Sources/SpeakEasy/PlaybackEngine.swift
@@ -98,6 +98,14 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
         stopCurrent(resetPosition: true)
     }
 
+    /// Temporarily yield a background completion to an interactive turn
+    /// without deleting its audio or activity record.
+    func deferCurrentCompletion() {
+        guard let item = currentItem, item.effectiveChannel == .completions else { return }
+        stopCurrent(resetPosition: true, removeAudio: false)
+        queue.insert(item, at: 0)
+    }
+
     func skip() throws {
         stopCurrent(resetPosition: true)
         try playNext()
@@ -335,15 +343,15 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
         }
     }
 
-    private func stopCurrent(resetPosition: Bool) {
+    private func stopCurrent(resetPosition: Bool, removeAudio: Bool = true) {
         player?.stop()
         if resetPosition {
             player?.currentTime = 0
         }
-        finishCurrentItem(naturallyFinished: false)
+        finishCurrentItem(naturallyFinished: false, removeAudio: removeAudio)
     }
 
-    private func finishCurrentItem(naturallyFinished: Bool) {
+    private func finishCurrentItem(naturallyFinished: Bool, removeAudio: Bool = true) {
         let finishedItem = currentItem
         if naturallyFinished {
             lastFinishedItemID = finishedItem?.id
@@ -357,7 +365,7 @@ final class PlaybackEngine: NSObject, ObservableObject, AVAudioPlayerDelegate {
         duration = 0
         audioLevel = 0
         state = .idle
-        if finishedItem?.cleanupAfterPlayback == true {
+        if removeAudio, finishedItem?.cleanupAfterPlayback == true {
             try? FileManager.default.removeItem(atPath: finishedItem?.audioPath ?? "")
         }
     }

--- a/app/Sources/SpeakEasy/PlayerProtocol.swift
+++ b/app/Sources/SpeakEasy/PlayerProtocol.swift
@@ -17,6 +17,11 @@ enum QueuePriority: String, Codable {
     case low
 }
 
+enum PlaybackChannel: String, Codable {
+    case interactive
+    case completions
+}
+
 enum PlayerCommand: String, Codable {
     case enqueue
     case pause
@@ -43,6 +48,10 @@ struct PlaybackItem: Codable, Identifiable, Equatable {
     let sourceThreadId: String?
     let cleanupAfterPlayback: Bool?
     let playbackRate: Float?
+    /// Optional keeps older CLI/Deck playback items wire-compatible. A nil
+    /// channel is treated as interactive playback.
+    let channel: PlaybackChannel?
+    let completionActivityID: UUID?
 
     init(
         id: UUID,
@@ -54,7 +63,9 @@ struct PlaybackItem: Codable, Identifiable, Equatable {
         synthesisRateWPM: Int?,
         sourceThreadId: String?,
         cleanupAfterPlayback: Bool? = nil,
-        playbackRate: Float? = nil
+        playbackRate: Float? = nil,
+        channel: PlaybackChannel? = nil,
+        completionActivityID: UUID? = nil
     ) {
         self.id = id
         self.audioPath = audioPath
@@ -66,7 +77,11 @@ struct PlaybackItem: Codable, Identifiable, Equatable {
         self.sourceThreadId = sourceThreadId
         self.cleanupAfterPlayback = cleanupAfterPlayback
         self.playbackRate = playbackRate
+        self.channel = channel
+        self.completionActivityID = completionActivityID
     }
+
+    var effectiveChannel: PlaybackChannel { channel ?? .interactive }
 }
 
 struct PlayerCommandArguments: Codable {

--- a/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
+++ b/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
@@ -176,6 +176,31 @@ function isTerminalRecord(record) {
     typeof payload.turn_id === 'string' && payload.turn_id.length > 0);
 }
 
+/** A narratable completion carries its own durable cursor and must be emitted
+ * before that cursor can be committed. Non-narratable terminal records may
+ * advance the cursor directly. This prevents a crash between two bridge lines
+ * from losing a completion forever. */
+function observationMessages(record, threadId, cursor, provenance) {
+  const completion = parseCompletionRecord(record, threadId);
+  if (completion) {
+    return [{
+      type: 'completion',
+      taskID: completion.taskID,
+      turnID: completion.turnID,
+      response: completion.response,
+      completedAt: completion.completedAt,
+      cursor,
+      provenance,
+    }];
+  }
+  return [{
+    type: 'cursor',
+    taskID: threadId,
+    turnID: record.payload.turn_id,
+    cursor,
+  }];
+}
+
 function frame(message) {
   const body = Buffer.from(JSON.stringify(message), 'utf8');
   if (body.length === 0 || body.length > MAX_FRAME_BYTES) fail('Desktop IPC message is too large.');
@@ -398,7 +423,6 @@ class DesktopIPCClient {
       ));
       return;
     }
-    if (!this.strictObservation && params?.change?.type !== 'snapshot') return;
     if (this.strictObservation && this.ownerClientId && message.sourceClientId !== this.ownerClientId) {
       this.failClosed(Object.assign(
         new Error('Codex Desktop task ownership changed while SpeakEasy was watching.'),
@@ -406,13 +430,10 @@ class DesktopIPCClient {
       ));
       return;
     }
-    if (this.strictObservation && params?.change?.type !== 'snapshot' && this.ownerClientId) {
-      this.failClosed(Object.assign(
-        new Error('Codex Desktop no longer proves ownership of the subscribed task.'),
-        { code: 'task-owner-lost' },
-      ));
-      return;
-    }
+    // Turn activity produces non-snapshot stream updates. They do not change
+    // ownership, so ignore them and keep the read-only follower attached. A
+    // later owner snapshot (or IPC close) remains the authority boundary.
+    if (params?.change?.type !== 'snapshot') return;
     const state = params?.change?.conversationState;
     if (this.strictObservation && this.ownerClientId && (
       state?.id !== this.threadId ||
@@ -572,32 +593,17 @@ async function observeRollout(client, rolloutPath, threadId, requestedOffset, re
           linePosition = lineEnd;
           continue;
         }
-        const payload = record?.payload;
         if (isTerminalRecord(record)) {
           const cursor = lineEnd;
-          const completion = parseCompletionRecord(record, threadId);
-          writeObservation({
-            type: 'cursor',
-            taskID: threadId,
-            turnID: payload.turn_id,
-            cursor,
-          });
-          if (completion) {
-            writeObservation({
-              type: 'completion',
-              taskID: completion.taskID,
-              turnID: completion.turnID,
-              response: completion.response,
-              completedAt: completion.completedAt,
-              cursor,
-              provenance: {
-                owner: 'codex-desktop',
-                hostID: 'local',
-                protocolVersion: STREAM_VERSION,
-                rolloutPath,
-                rolloutIdentity: identity,
-              },
-            });
+          const provenance = {
+            owner: 'codex-desktop',
+            hostID: 'local',
+            protocolVersion: STREAM_VERSION,
+            rolloutPath,
+            rolloutIdentity: identity,
+          };
+          for (const observation of observationMessages(record, threadId, cursor, provenance)) {
+            writeObservation(observation);
           }
         }
         linePosition = lineEnd;
@@ -689,4 +695,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { parseCompletionRecord, isTerminalRecord, assertRolloutPath };
+module.exports = { parseCompletionRecord, isTerminalRecord, observationMessages, assertRolloutPath };

--- a/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
+++ b/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
@@ -6,7 +6,7 @@ const fs = require('node:fs');
 const net = require('node:net');
 const os = require('node:os');
 const path = require('node:path');
-const { randomUUID } = require('node:crypto');
+const { randomUUID, createHash } = require('node:crypto');
 const { execFileSync } = require('node:child_process');
 
 const MAX_FRAME_BYTES = 256 * 1024 * 1024;
@@ -16,6 +16,7 @@ const START_TURN_VERSION = 1;
 const STEER_TURN_VERSION = 1;
 const SNAPSHOT_TIMEOUT_MS = 5_000;
 const TURN_TIMEOUT_MS = 30 * 60_000;
+const OBSERVER_POLL_MS = 150;
 
 function codexHome() {
   return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
@@ -91,6 +92,18 @@ function assertRolloutPath(rolloutPath, threadId) {
   return resolved;
 }
 
+function rolloutIdentity(rolloutPath) {
+  const info = fs.statSync(rolloutPath);
+  const descriptor = fs.openSync(rolloutPath, 'r');
+  const prefix = Buffer.allocUnsafe(Math.min(info.size, 4096));
+  try {
+    if (prefix.length > 0) fs.readSync(descriptor, prefix, 0, prefix.length, 0);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return `${info.dev}:${info.ino}:${createHash('sha256').update(prefix).digest('hex')}`;
+}
+
 function latestActiveTurnId(rolloutPath) {
   const size = fs.statSync(rolloutPath).size;
   const maximumScan = 32 * 1024 * 1024;
@@ -124,6 +137,45 @@ function latestActiveTurnId(rolloutPath) {
   return activeTurnId;
 }
 
+function eventTimestamp(record) {
+  const candidate = record?.timestamp || record?.payload?.timestamp || record?.payload?.completed_at;
+  if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+    return new Date(candidate > 10_000_000_000 ? candidate : candidate * 1000).toISOString();
+  }
+  if (typeof candidate === 'string' && !Number.isNaN(Date.parse(candidate))) {
+    return new Date(candidate).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+/**
+ * Parse only terminal assistant completion records. The rollout path has
+ * already been proven to belong to the exact Desktop-owned task before this
+ * helper is called, so task identity is never inferred from text or titles.
+ */
+function parseCompletionRecord(record, threadId) {
+  if (record?.type !== 'event_msg' || !record.payload) return null;
+  const payload = record.payload;
+  const terminal = ['task_complete', 'turn_complete', 'turn_completed'].includes(payload.type);
+  if (!terminal || typeof payload.turn_id !== 'string' || payload.turn_id.length === 0) return null;
+  const response = String(
+    payload.last_agent_message ?? payload.last_agent_response ?? payload.final_response ?? payload.message ?? ''
+  ).trim();
+  return {
+    taskID: threadId,
+    turnID: payload.turn_id,
+    response,
+    completedAt: eventTimestamp(record),
+  };
+}
+
+function isTerminalRecord(record) {
+  const payload = record?.type === 'event_msg' ? record.payload : null;
+  return Boolean(payload &&
+    ['task_complete', 'turn_complete', 'turn_completed', 'task_failed', 'turn_aborted'].includes(payload.type) &&
+    typeof payload.turn_id === 'string' && payload.turn_id.length > 0);
+}
+
 function frame(message) {
   const body = Buffer.from(JSON.stringify(message), 'utf8');
   if (body.length === 0 || body.length > MAX_FRAME_BYTES) fail('Desktop IPC message is too large.');
@@ -134,8 +186,9 @@ function frame(message) {
 }
 
 class DesktopIPCClient {
-  constructor(threadId) {
+  constructor(threadId, strictObservation = false) {
     this.threadId = threadId;
+    this.strictObservation = strictObservation;
     this.socketPath = path.join(codexHome(), 'ipc', 'ipc.sock');
     this.clientId = 'initializing-client';
     this.ownerClientId = null;
@@ -143,14 +196,16 @@ class DesktopIPCClient {
     this.buffer = Buffer.alloc(0);
     this.pending = new Map();
     this.snapshotWaiter = null;
+    this.failure = null;
+    this.ownerRolloutPath = null;
   }
 
   async connect() {
     assertPrivateCodexSocket(this.socketPath);
     this.socket = net.connect(this.socketPath);
     this.socket.on('data', (chunk) => this.onData(chunk));
-    this.socket.on('error', (error) => this.rejectAll(error));
-    this.socket.on('close', () => this.rejectAll(new Error('Codex Desktop IPC connection closed.')));
+    this.socket.on('error', (error) => this.failClosed(error));
+    this.socket.on('close', () => this.failClosed(new Error('Codex Desktop IPC connection closed.')));
     await new Promise((resolve, reject) => {
       this.socket.once('connect', resolve);
       this.socket.once('error', reject);
@@ -301,7 +356,16 @@ class DesktopIPCClient {
         return;
       }
       if (this.buffer.length < length + 4) return;
-      const message = JSON.parse(this.buffer.subarray(4, length + 4).toString('utf8'));
+      let message;
+      try {
+        message = JSON.parse(this.buffer.subarray(4, length + 4).toString('utf8'));
+      } catch {
+        this.failClosed(Object.assign(
+          new Error('Codex Desktop returned malformed IPC JSON.'),
+          { code: 'protocol-mismatch' },
+        ));
+        return;
+      }
       this.buffer = this.buffer.subarray(length + 4);
       this.onMessage(message);
     }
@@ -319,24 +383,61 @@ class DesktopIPCClient {
     }
     if (message.type !== 'broadcast' || message.method !== 'thread-stream-state-changed') return;
     if (message.version !== STREAM_VERSION) {
-      this.snapshotWaiter?.reject(Object.assign(
+      this.failClosed(Object.assign(
         new Error('Codex Desktop task streaming protocol changed; update SpeakEasy.'),
         { code: 'protocol-mismatch' },
       ));
-      this.snapshotWaiter = null;
       return;
     }
     const { params } = message;
-    if (
-      params?.hostId !== 'local' ||
-      params?.conversationId !== this.threadId ||
-      params?.change?.type !== 'snapshot'
-    ) return;
+    if (params?.conversationId !== this.threadId) return;
+    if (this.strictObservation && params?.hostId !== 'local') {
+      this.failClosed(Object.assign(
+        new Error('Codex Desktop returned a completion stream without local ownership.'),
+        { code: 'task-owner-unavailable' },
+      ));
+      return;
+    }
+    if (!this.strictObservation && params?.change?.type !== 'snapshot') return;
+    if (this.strictObservation && this.ownerClientId && message.sourceClientId !== this.ownerClientId) {
+      this.failClosed(Object.assign(
+        new Error('Codex Desktop task ownership changed while SpeakEasy was watching.'),
+        { code: 'task-owner-lost' },
+      ));
+      return;
+    }
+    if (this.strictObservation && params?.change?.type !== 'snapshot' && this.ownerClientId) {
+      this.failClosed(Object.assign(
+        new Error('Codex Desktop no longer proves ownership of the subscribed task.'),
+        { code: 'task-owner-lost' },
+      ));
+      return;
+    }
+    const state = params?.change?.conversationState;
+    if (this.strictObservation && this.ownerClientId && (
+      state?.id !== this.threadId ||
+      typeof state?.rolloutPath !== 'string' ||
+      state.rolloutPath !== this.ownerRolloutPath
+    )) {
+      this.failClosed(Object.assign(
+        new Error('Codex Desktop changed the exact task rollout while SpeakEasy was watching.'),
+        { code: 'task-owner-lost' },
+      ));
+      return;
+    }
+    if (typeof state?.rolloutPath === 'string') this.ownerRolloutPath = state.rolloutPath;
     this.ownerClientId = message.sourceClientId;
     this.snapshotWaiter?.resolve({
       ownerClientId: message.sourceClientId,
-      state: params.change.conversationState,
+      state,
     });
+  }
+
+  failClosed(error) {
+    if (this.failure) return;
+    this.failure = error;
+    this.rejectAll(error);
+    this.socket?.destroy();
   }
 
   rejectAll(error) {
@@ -413,8 +514,114 @@ async function waitForTurn(rolloutPath, offset, turnId) {
   fail('Timed out waiting for the Codex response.', 'turn-timeout');
 }
 
-async function withClient(threadId, action) {
-  const client = new DesktopIPCClient(threadId);
+function writeObservation(result) {
+  writeResult({ ok: true, ...result });
+}
+
+/**
+ * Read-only, long-lived observation of one already-owned Desktop task. The
+ * first line is a baseline cursor; no existing rollout records are emitted.
+ * Resumed observers start at the durable byte cursor supplied by SpeakEasy.
+ */
+async function observeRollout(client, rolloutPath, threadId, requestedOffset, requestedIdentity) {
+  const initialSize = fs.statSync(rolloutPath).size;
+  const identity = rolloutIdentity(rolloutPath);
+  if (requestedIdentity && requestedIdentity !== identity) {
+    fail('The Codex task rollout identity changed; SpeakEasy will not guess continuity.', 'cursor-mismatch');
+  }
+  let offset;
+  if (requestedOffset === undefined || requestedOffset === null || requestedOffset === '') {
+    offset = initialSize;
+  } else {
+    offset = Number(requestedOffset);
+    if (!Number.isSafeInteger(offset) || offset < 0 || offset > initialSize) {
+      fail('The Codex task rollout cursor cannot be proven continuous.', 'cursor-mismatch');
+    }
+  }
+  writeObservation({ type: 'baseline', taskID: threadId, cursor: offset, rolloutIdentity: identity });
+
+  const descriptor = fs.openSync(rolloutPath, 'r');
+  let pending = '';
+  let pendingStart = offset;
+  let position = offset;
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    fs.closeSync(descriptor);
+  };
+  const readAvailable = () => {
+    const size = fs.fstatSync(descriptor).size;
+    while (size > position) {
+      const chunk = Buffer.allocUnsafe(Math.min(size - position, 1024 * 1024));
+      const count = fs.readSync(descriptor, chunk, 0, chunk.length, position);
+      if (count <= 0) break;
+      position += count;
+      pending += chunk.subarray(0, count).toString('utf8');
+      const lines = pending.split('\n');
+      pending = lines.pop() || '';
+      let linePosition = pendingStart;
+      for (const line of lines) {
+        const lineEnd = linePosition + Buffer.byteLength(line, 'utf8') + 1;
+        if (!line) {
+          linePosition = lineEnd;
+          continue;
+        }
+        let record;
+        try { record = JSON.parse(line); } catch {
+          linePosition = lineEnd;
+          continue;
+        }
+        const payload = record?.payload;
+        if (isTerminalRecord(record)) {
+          const cursor = lineEnd;
+          const completion = parseCompletionRecord(record, threadId);
+          writeObservation({
+            type: 'cursor',
+            taskID: threadId,
+            turnID: payload.turn_id,
+            cursor,
+          });
+          if (completion) {
+            writeObservation({
+              type: 'completion',
+              taskID: completion.taskID,
+              turnID: completion.turnID,
+              response: completion.response,
+              completedAt: completion.completedAt,
+              cursor,
+              provenance: {
+                owner: 'codex-desktop',
+                hostID: 'local',
+                protocolVersion: STREAM_VERSION,
+                rolloutPath,
+                rolloutIdentity: identity,
+              },
+            });
+          }
+        }
+        linePosition = lineEnd;
+      }
+      pendingStart = position - Buffer.byteLength(pending, 'utf8');
+    }
+  };
+
+  try {
+    while (true) {
+      if (client.failure) throw client.failure;
+      if (rolloutIdentity(rolloutPath) !== identity) {
+        fail('The Codex task rollout identity changed while SpeakEasy was watching.', 'cursor-mismatch');
+      }
+      readAvailable();
+      await sleep(OBSERVER_POLL_MS);
+    }
+  } finally {
+    close();
+  }
+}
+
+async function withClient(threadId, action, strictObservation = false) {
+  const client = new DesktopIPCClient(threadId, strictObservation);
   try {
     await client.connect();
     const snapshot = await client.follow();
@@ -430,7 +637,7 @@ async function main() {
     writeResult({ ok: true, tasks: listTasks(argument) });
     return;
   }
-  if ((command === 'validate' || command === 'submit') && argument) {
+  if ((command === 'validate' || command === 'submit' || command === 'observe') && argument) {
     const result = await withClient(argument, async (client, snapshot) => {
       const state = snapshot.state || {};
       const rolloutPath = assertRolloutPath(state.rolloutPath, argument);
@@ -440,6 +647,9 @@ async function main() {
           ok: true,
           task: { id: state.id, title: state.title || 'Untitled task', cwd: state.cwd || '' },
         };
+      }
+      if (command === 'observe') {
+        return await observeRollout(client, rolloutPath, argument, process.argv[4], process.argv[5]);
       }
       const text = (await readStdin()).trim();
       if (!text) fail('The transcript is empty.', 'empty-transcript');
@@ -461,18 +671,22 @@ async function main() {
       }
       const response = await waitForTurn(rolloutPath, offset, turnId);
       return { ok: true, threadId: argument, turnId, delivery, response };
-    });
+    }, command === 'observe');
     writeResult(result);
     return;
   }
-  fail('Usage: codex-desktop-bridge.cjs list [limit] | validate <task-id> | submit <task-id>', 'usage');
+  fail('Usage: codex-desktop-bridge.cjs list [limit] | validate <task-id> | submit <task-id> | observe <task-id> [cursor]', 'usage');
 }
 
-main().catch((error) => {
-  writeResult({
-    ok: false,
-    code: error?.code || 'bridge-failed',
-    error: error instanceof Error ? error.message : String(error),
+if (require.main === module) {
+  main().catch((error) => {
+    writeResult({
+      ok: false,
+      code: error?.code || 'bridge-failed',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exitCode = 1;
   });
-  process.exitCode = 1;
-});
+}
+
+module.exports = { parseCompletionRecord, isTerminalRecord, assertRolloutPath };

--- a/app/Sources/SpeakEasy/Resources/codex-luna-presenter.cjs
+++ b/app/Sources/SpeakEasy/Resources/codex-luna-presenter.cjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+'use strict';
+
+// SpeakEasy's presentation model runs in its own Codex app-server process.
+// Every presentation uses an ephemeral thread, so it cannot create or resume a
+// user-visible Codex task. The parent process receives one JSON object on stdin
+// and this bridge emits one JSON envelope on stdout.
+
+const { spawn } = require('node:child_process');
+const { accessSync, constants } = require('node:fs');
+const { homedir } = require('node:os');
+
+const MODEL = 'gpt-5.6-luna';
+const TIMEOUT_MS = 20_000;
+const SYSTEM_PROMPT = [
+  "You are SpeakEasy's read-only speech presenter.",
+  'Turn a completed Codex response into a concise spoken update.',
+  'Preserve the actual outcome, failures, decisions, and next action. Do not add facts.',
+  'Do not execute tools, inspect files, browse, send messages, or modify the source task.',
+  'Use plain spoken language: at most three short sentences and 80 words.',
+  'Omit markdown, code, raw URLs, commit hashes, and implementation noise unless essential.',
+  'Return only the requested JSON object.',
+].join(' ');
+
+const OUTPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['spokenText'],
+  properties: {
+    spokenText: { type: 'string', minLength: 1, maxLength: 900 },
+  },
+};
+
+function writeEnvelope(envelope) {
+  process.stdout.write(`${JSON.stringify(envelope)}\n`);
+}
+
+function fail(message, code = 'presenter_failed') {
+  writeEnvelope({ ok: false, code, error: String(message || 'Luna presenter failed.') });
+  process.exitCode = 1;
+}
+
+function executable(path) {
+  if (!path) return false;
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveCodex() {
+  const candidates = [
+    process.env.SPEAKEASY_CODEX_BIN,
+    process.env.CODEX_BIN,
+    process.argv[2],
+    '/Applications/ChatGPT.app/Contents/Resources/codex',
+    '/Applications/Codex.app/Contents/Resources/codex',
+    `${homedir()}/.local/bin/codex`,
+    '/opt/homebrew/bin/codex',
+    '/usr/local/bin/codex',
+  ];
+  return candidates.find(executable);
+}
+
+function safeString(value, limit) {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, limit);
+}
+
+function parseInput(raw) {
+  const input = JSON.parse(raw);
+  const taskID = safeString(input.taskID, 128);
+  const turnID = safeString(input.turnID, 128);
+  const taskTitle = safeString(input.taskTitle, 240);
+  const projectPath = safeString(input.projectPath, 1024);
+  const response = safeString(input.response, 80_000);
+  if (!taskID || !turnID || !response) throw new Error('Presenter input is incomplete.');
+  return { taskID, turnID, taskTitle, projectPath, response };
+}
+
+function requestPayload(input) {
+  return JSON.stringify({
+    task: {
+      id: input.taskID,
+      turnId: input.turnID,
+      title: input.taskTitle,
+      projectPath: input.projectPath,
+    },
+    canonicalResponse: input.response,
+  });
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function main() {
+  const codex = resolveCodex();
+  if (!codex) throw Object.assign(new Error('Codex is unavailable for Luna presentation.'), { code: 'codex_unavailable' });
+  const input = parseInput(await readStdin());
+  const child = spawn(codex, ['app-server', '--stdio'], {
+    cwd: '/tmp',
+    env: process.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let nextID = 1;
+  let stdoutBuffer = '';
+  let stderr = '';
+  let threadID;
+  let turnID;
+  let finalText = '';
+  const pending = new Map();
+
+  const stop = () => {
+    if (child.exitCode === null && !child.killed) child.kill('SIGTERM');
+  };
+  const timer = setTimeout(() => {
+    for (const { reject } of pending.values()) reject(new Error('Luna presenter timed out.'));
+    pending.clear();
+    completedReject(new Error('Luna presenter timed out.'));
+    stop();
+  }, TIMEOUT_MS);
+
+  const send = (message) => child.stdin.write(`${JSON.stringify(message)}\n`);
+  const notify = (method, params) => send({ method, ...(params ? { params } : {}) });
+  const request = (method, params) => new Promise((resolve, reject) => {
+    const id = nextID++;
+    pending.set(id, { resolve, reject });
+    send({ id, method, params });
+  });
+
+  let completedResolve;
+  let completedReject;
+  const completed = new Promise((resolve, reject) => {
+    completedResolve = resolve;
+    completedReject = reject;
+  });
+
+  const handleMessage = (message) => {
+    if (Object.prototype.hasOwnProperty.call(message, 'id')
+      && (Object.prototype.hasOwnProperty.call(message, 'result')
+        || Object.prototype.hasOwnProperty.call(message, 'error'))) {
+      const waiter = pending.get(message.id);
+      if (!waiter) return;
+      pending.delete(message.id);
+      if (message.error) waiter.reject(new Error(message.error.message || 'Codex app-server request failed.'));
+      else waiter.resolve(message.result);
+      return;
+    }
+
+    // No presenter tool is supported. Reject any app-server request instead of
+    // letting this presentation-only process acquire an action surface.
+    if (Object.prototype.hasOwnProperty.call(message, 'id') && message.method) {
+      send({ id: message.id, error: { code: -32000, message: 'SpeakEasy presenter tools are disabled.' } });
+      return;
+    }
+
+    if (message.method === 'item/agentMessage/delta'
+      && message.params?.turnId === turnID
+      && typeof message.params?.delta === 'string') {
+      finalText += message.params.delta;
+      return;
+    }
+    if (message.method === 'item/completed'
+      && message.params?.turnId === turnID
+      && message.params?.item?.type === 'agentMessage'
+      && typeof message.params.item.text === 'string') {
+      finalText = message.params.item.text;
+      return;
+    }
+    if (message.method === 'turn/completed' && message.params?.turn?.id === turnID) {
+      const status = message.params.turn.status;
+      if (status === 'completed') completedResolve();
+      else completedReject(new Error(message.params.turn.error?.message || `Luna presenter turn ${status}.`));
+    }
+  };
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    stdoutBuffer += chunk;
+    while (true) {
+      const newline = stdoutBuffer.indexOf('\n');
+      if (newline < 0) break;
+      const line = stdoutBuffer.slice(0, newline).trim();
+      stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      if (!line) continue;
+      try { handleMessage(JSON.parse(line)); } catch { /* ignore non-protocol output */ }
+    }
+  });
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-8_000); });
+  child.once('error', (error) => {
+    for (const { reject } of pending.values()) reject(error);
+    pending.clear();
+    completedReject(error);
+  });
+  child.once('exit', (code) => {
+    const error = new Error(stderr.trim() || `Presenter app-server exited (${code ?? 'signal'}).`);
+    for (const { reject } of pending.values()) reject(error);
+    pending.clear();
+    completedReject(error);
+  });
+
+  try {
+    await request('initialize', {
+      clientInfo: { name: 'speakeasy-presenter', title: 'SpeakEasy Presenter', version: '0.1.0' },
+      capabilities: { experimentalApi: true },
+    });
+    notify('initialized');
+
+    const started = await request('thread/start', {
+      cwd: '/tmp',
+      approvalPolicy: 'never',
+      sandbox: 'read-only',
+      model: MODEL,
+      baseInstructions: SYSTEM_PROMPT,
+      developerInstructions: SYSTEM_PROMPT,
+      ephemeral: true,
+    });
+    threadID = started?.thread?.id;
+    if (!threadID || started?.thread?.ephemeral !== true) {
+      throw new Error('Codex did not establish an ephemeral presenter thread.');
+    }
+
+    const turn = await request('turn/start', {
+      threadId: threadID,
+      cwd: '/tmp',
+      model: MODEL,
+      effort: 'low',
+      approvalPolicy: 'never',
+      sandboxPolicy: { type: 'readOnly', networkAccess: false },
+      input: [{ type: 'text', text: requestPayload(input), text_elements: [] }],
+      outputSchema: OUTPUT_SCHEMA,
+    });
+    turnID = turn?.turn?.id;
+    if (!turnID) throw new Error('Codex did not start a Luna presenter turn.');
+    await completed;
+
+    const parsed = JSON.parse(finalText.trim());
+    const spokenText = safeString(parsed.spokenText, 900);
+    if (!spokenText) throw new Error('Luna returned an empty spoken presentation.');
+    writeEnvelope({
+      ok: true,
+      spokenText,
+      model: MODEL,
+      ephemeral: true,
+      sourceTaskID: input.taskID,
+      sourceTurnID: input.turnID,
+    });
+  } finally {
+    clearTimeout(timer);
+    stop();
+  }
+}
+
+main().catch((error) => fail(error?.message, error?.code));

--- a/app/Sources/SpeakEasy/SystemResponseNarrator.swift
+++ b/app/Sources/SpeakEasy/SystemResponseNarrator.swift
@@ -27,6 +27,41 @@ struct SpeechNarrationConfiguration: Equatable, Sendable {
             rate: rate
         )
     }
+
+    static func configured(from config: ConfigManager, provider: String? = nil) -> Self {
+        switch (provider ?? config.defaultProvider).lowercased() {
+        case "openai":
+            return Self(
+                provider: "openai", voice: config.openaiVoice, model: config.openaiModel,
+                apiKey: config.openaiApiKey, instructions: config.openaiInstructions, rate: config.defaultRate
+            )
+        case "elevenlabs":
+            return Self(
+                provider: "elevenlabs", voice: config.elevenlabsVoiceId, model: config.elevenlabsModelId,
+                apiKey: config.elevenlabsApiKey, instructions: nil, rate: config.defaultRate
+            )
+        case "groq":
+            return Self(
+                provider: "groq", voice: config.groqVoice, model: config.groqModel,
+                apiKey: config.groqApiKey, instructions: nil, rate: config.defaultRate
+            )
+        case "gemini":
+            return Self(
+                provider: "gemini", voice: config.geminiVoice, model: config.geminiModel,
+                apiKey: config.geminiApiKey, instructions: nil, rate: config.defaultRate
+            )
+        case "system":
+            return Self(
+                provider: "system", voice: config.systemVoice, model: nil,
+                apiKey: "", instructions: nil, rate: config.defaultRate
+            )
+        default:
+            return Self(
+                provider: config.defaultProvider, voice: "", model: nil,
+                apiKey: "", instructions: nil, rate: config.defaultRate
+            )
+        }
+    }
 }
 
 enum ConfiguredResponseNarratorError: LocalizedError {

--- a/app/Tests/SpeakEasyTests/CompletionSubscriptionTests.swift
+++ b/app/Tests/SpeakEasyTests/CompletionSubscriptionTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import SpeakEasy
+
+final class CompletionSubscriptionTests: XCTestCase {
+    private let task = ListeningTaskLock(
+        id: "019f99a4-7867-7c23-ac29-0c0eca7da603",
+        title: "Completion task",
+        cwd: "/Users/arach/dev/SpeakEasy"
+    )
+
+    func testSubscriptionStorePersistsCursorAndExactlyOnceSet() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("speakeasy-completions-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = CompletionSubscriptionStore(fileURL: directory.appendingPathComponent("subscriptions.json"))
+        let subscription = CompletionSubscription(
+            task: task,
+            lastObservedTurnID: "turn-2",
+            lastEnqueuedTurnID: "turn-2",
+            cursorOffset: 482,
+            enqueuedTurnIDs: ["\(task.id)::turn-1", "\(task.id)::turn-2"],
+            subscribedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let activity = CompletionActivity(
+            taskID: task.id,
+            turnID: "turn-2",
+            response: "Done",
+            completedAt: Date(timeIntervalSince1970: 1_700_000_010),
+            state: .announced,
+            cursorOffset: 482
+        )
+
+        try store.save(CompletionSubscriptionSnapshot(
+            subscription: subscription,
+            channel: CompletionChannelConfiguration(isMuted: true),
+            activities: [activity]
+        ))
+        let restored = try store.load()
+
+        XCTAssertEqual(restored.subscription, subscription)
+        XCTAssertEqual(restored.subscription?.cursorOffset, 482)
+        XCTAssertTrue(restored.subscription?.enqueuedTurnIDs.contains("\(task.id)::turn-1") == true)
+        XCTAssertEqual(restored.activities.count, 1)
+        XCTAssertEqual(restored.activities.first?.id, activity.id)
+        XCTAssertEqual(restored.activities.first?.dedupeKey, activity.dedupeKey)
+        XCTAssertEqual(restored.activities.first?.state, .announced)
+        XCTAssertTrue(restored.channel.isMuted)
+    }
+
+    func testLegacySubscriptionMigratesWithoutInventingASecondTask() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("speakeasy-completions-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let json = """
+        {
+          "schemaVersion": 1,
+          "subscription": {
+            "task": {"id":"task-1","title":"Title A","cwd":"/tmp/a"},
+            "channelID":"completions",
+            "isEnabled":true,
+            "lastObservedTurnID":"turn-1",
+            "lastEnqueuedTurnID":"turn-1",
+            "subscribedAt":"2026-08-01T12:00:00Z"
+          },
+          "activities": []
+        }
+        """
+        let url = directory.appendingPathComponent("subscriptions.json")
+        try Data(json.utf8).write(to: url)
+
+        let restored = try CompletionSubscriptionStore(fileURL: url).load()
+        XCTAssertEqual(restored.schemaVersion, CompletionSubscriptionSnapshot.currentSchemaVersion)
+        XCTAssertEqual(restored.subscription?.task.id, "task-1")
+        XCTAssertEqual(restored.subscription?.enqueuedTurnIDs, ["task-1::turn-1"])
+        XCTAssertNil(restored.subscription?.cursorOffset)
+    }
+
+    func testDedupeKeyUsesExactTaskAndTurnIdentity() {
+        let first = CompletionSubscription(task: task)
+        let otherTask = ListeningTaskLock(id: "other", title: task.title, cwd: task.cwd)
+        let second = CompletionSubscription(task: otherTask)
+
+        XCTAssertEqual(first.dedupeKey(turnID: "turn-7"), "\(task.id)::turn-7")
+        XCTAssertNotEqual(first.dedupeKey(turnID: "turn-7"), second.dedupeKey(turnID: "turn-7"))
+        XCTAssertNotEqual(first.dedupeKey(turnID: "turn-7"), first.dedupeKey(turnID: "turn-8"))
+    }
+
+    func testBridgeParserAcceptsStructuredCompletionAndRejectsWrongProvenance() throws {
+        let line = """
+        {"ok":true,"type":"completion","taskID":"\(task.id)","turnID":"turn-9","response":"Final answer","completedAt":"2026-08-01T12:00:00Z","cursor":912,"provenance":{"owner":"codex-desktop","hostID":"local","protocolVersion":11,"rolloutPath":"/Users/arach/.codex/sessions/2026/turn-\(task.id).jsonl","rolloutIdentity":"1:2:abc"}}
+        """
+        guard case .completion(let event) = try CodexCompletionBridgeLineParser.parse(line, expectedTaskID: task.id) else {
+            return XCTFail("Expected a completion event")
+        }
+        XCTAssertEqual(event.taskID, task.id)
+        XCTAssertEqual(event.turnID, "turn-9")
+        XCTAssertEqual(event.cursorOffset, 912)
+        XCTAssertEqual(event.provenance.owner, "codex-desktop")
+
+        let unsafe = line.replacingOccurrences(of: "\"owner\":\"codex-desktop\"", with: "\"owner\":\"app-server\"")
+        XCTAssertThrowsError(try CodexCompletionBridgeLineParser.parse(unsafe, expectedTaskID: task.id)) { error in
+            XCTAssertEqual(error as? CodexCompletionBridgeError, .invalidProvenance)
+        }
+    }
+
+    func testBaselineAndCursorMessagesDoNotBecomeNarratableCompletions() throws {
+        let baseline = "{\"ok\":true,\"type\":\"baseline\",\"taskID\":\"\(task.id)\",\"cursor\":200,\"rolloutIdentity\":\"1:2:abc\"}"
+        let cursor = "{\"ok\":true,\"type\":\"cursor\",\"taskID\":\"\(task.id)\",\"turnID\":\"turn-failed\",\"cursor\":260}"
+
+        guard case .baseline(_, let baselineOffset, let rolloutIdentity) = try CodexCompletionBridgeLineParser.parse(baseline, expectedTaskID: task.id) else {
+            return XCTFail("Expected baseline")
+        }
+        guard case .cursor(_, let turnID, let cursorOffset) = try CodexCompletionBridgeLineParser.parse(cursor, expectedTaskID: task.id) else {
+            return XCTFail("Expected cursor")
+        }
+        XCTAssertEqual(baselineOffset, 200)
+        XCTAssertEqual(rolloutIdentity, "1:2:abc")
+        XCTAssertEqual(turnID, "turn-failed")
+        XCTAssertEqual(cursorOffset, 260)
+    }
+
+    func testCompletionPlaybackItemsRemainBehindInteractiveItemsOnTheWire() throws {
+        let activityID = UUID()
+        let completion = PlaybackItem(
+            id: UUID(),
+            audioPath: "/tmp/completion.mp3",
+            title: "Completion task",
+            text: "Done",
+            provider: "system",
+            createdAt: "2026-08-01T12:00:00Z",
+            synthesisRateWPM: 180,
+            sourceThreadId: task.id,
+            channel: .completions,
+            completionActivityID: activityID
+        )
+        let decoded = try JSONDecoder().decode(PlaybackItem.self, from: JSONEncoder().encode(completion))
+
+        XCTAssertEqual(decoded.effectiveChannel, .completions)
+        XCTAssertEqual(decoded.completionActivityID, activityID)
+        XCTAssertEqual(decoded.sourceThreadId, task.id)
+    }
+
+    @MainActor
+    func testCompletionQueueWaitsBehindInteractiveWork() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("speakeasy-playback-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let audioPath = directory.appendingPathComponent("placeholder.mp3").path
+        try Data().write(to: URL(fileURLWithPath: audioPath))
+
+        let engine = PlaybackEngine.shared
+        engine.stop()
+        engine.clearQueue()
+        engine.setInteractiveBusy(true)
+        defer {
+            engine.stop()
+            engine.clearQueue()
+            engine.setInteractiveBusy(false)
+        }
+
+        let completion = PlaybackItem(
+            id: UUID(), audioPath: audioPath, title: "Completion", text: "Done",
+            provider: "system", createdAt: "2026-08-01T12:00:00Z", synthesisRateWPM: 180,
+            sourceThreadId: task.id, channel: .completions
+        )
+        let interactive = PlaybackItem(
+            id: UUID(), audioPath: audioPath, title: "Interactive", text: "Now",
+            provider: "system", createdAt: "2026-08-01T12:00:00Z", synthesisRateWPM: 180
+        )
+        try engine.enqueue(completion, priority: .normal, interrupt: false, autoplay: true)
+        try engine.enqueue(interactive, priority: .high, interrupt: false, autoplay: false)
+
+        XCTAssertEqual(engine.queue.map(\.id), [interactive.id, completion.id])
+        XCTAssertNil(engine.currentItem)
+    }
+
+    @MainActor
+    func testMuteReplayControlsAndUnsubscribeStayIndependentFromListeningState() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("speakeasy-completions-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let controller = CompletionSubscriptionController(
+            store: CompletionSubscriptionStore(fileURL: directory.appendingPathComponent("subscriptions.json"))
+        )
+
+        controller.subscribe(to: task)
+        XCTAssertTrue(controller.isSubscribed(to: task.id))
+        XCTAssertTrue(controller.subscription?.isEnabled == true)
+        XCTAssertEqual(controller.channel.channelID, CompletionChannelConfiguration.id)
+
+        controller.setMuted(true)
+        XCTAssertTrue(controller.channel.isMuted)
+        XCTAssertEqual(controller.state, .muted)
+
+        controller.setMuted(false)
+        XCTAssertFalse(controller.channel.isMuted)
+        controller.setEnabled(false)
+        XCTAssertEqual(controller.state, .off)
+        XCTAssertTrue(controller.isSubscribed(to: task.id))
+
+        controller.unsubscribe()
+        XCTAssertNil(controller.subscription)
+        XCTAssertEqual(controller.state, .off)
+    }
+}

--- a/app/Tests/SpeakEasyTests/CompletionSubscriptionTests.swift
+++ b/app/Tests/SpeakEasyTests/CompletionSubscriptionTests.swift
@@ -168,7 +168,8 @@ final class CompletionSubscriptionTests: XCTestCase {
         )
         let interactive = PlaybackItem(
             id: UUID(), audioPath: audioPath, title: "Interactive", text: "Now",
-            provider: "system", createdAt: "2026-08-01T12:00:00Z", synthesisRateWPM: 180
+            provider: "system", createdAt: "2026-08-01T12:00:00Z", synthesisRateWPM: 180,
+            sourceThreadId: nil
         )
         try engine.enqueue(completion, priority: .normal, interrupt: false, autoplay: true)
         try engine.enqueue(interactive, priority: .high, interrupt: false, autoplay: false)

--- a/app/Tests/SpeakEasyTests/CompletionSubscriptionTests.swift
+++ b/app/Tests/SpeakEasyTests/CompletionSubscriptionTests.swift
@@ -2,6 +2,15 @@ import XCTest
 @testable import SpeakEasy
 
 final class CompletionSubscriptionTests: XCTestCase {
+    func testPackagedResourceResolverFindsTheLunaPresenter() {
+        let presenter = SpeakEasyResources.url(
+            forResource: "codex-luna-presenter",
+            withExtension: "cjs"
+        )
+        XCTAssertNotNil(presenter)
+        XCTAssertTrue(FileManager.default.isReadableFile(atPath: presenter?.path ?? ""))
+    }
+
     private let task = ListeningTaskLock(
         id: "019f99a4-7867-7c23-ac29-0c0eca7da603",
         title: "Completion task",
@@ -135,7 +144,7 @@ final class CompletionSubscriptionTests: XCTestCase {
 
     func testBridgeParserAcceptsStructuredCompletionAndRejectsWrongProvenance() throws {
         let line = """
-        {"ok":true,"type":"completion","taskID":"\(task.id)","turnID":"turn-9","response":"Final answer","completedAt":"2026-08-01T12:00:00Z","cursor":912,"provenance":{"owner":"codex-desktop","hostID":"local","protocolVersion":11,"rolloutPath":"/Users/arach/.codex/sessions/2026/turn-\(task.id).jsonl","rolloutIdentity":"1:2:abc"}}
+        {"ok":true,"type":"completion","taskID":"\(task.id)","turnID":"turn-9","response":"Final answer","completedAt":"2026-08-01T12:00:00.701Z","cursor":912,"provenance":{"owner":"codex-desktop","hostID":"local","protocolVersion":11,"rolloutPath":"/Users/arach/.codex/sessions/2026/turn-\(task.id).jsonl","rolloutIdentity":"1:2:abc"}}
         """
         guard case .completion(let event) = try CodexCompletionBridgeLineParser.parse(line, expectedTaskID: task.id) else {
             return XCTFail("Expected a completion event")

--- a/app/Tests/SpeakEasyTests/CompletionSubscriptionTests.swift
+++ b/app/Tests/SpeakEasyTests/CompletionSubscriptionTests.swift
@@ -28,7 +28,10 @@ final class CompletionSubscriptionTests: XCTestCase {
             response: "Done",
             completedAt: Date(timeIntervalSince1970: 1_700_000_010),
             state: .announced,
-            cursorOffset: 482
+            cursorOffset: 482,
+            spokenText: "The task is done.",
+            presentationSource: .luna,
+            presentationModel: "gpt-5.6-luna"
         )
 
         try store.save(CompletionSubscriptionSnapshot(
@@ -45,6 +48,9 @@ final class CompletionSubscriptionTests: XCTestCase {
         XCTAssertEqual(restored.activities.first?.id, activity.id)
         XCTAssertEqual(restored.activities.first?.dedupeKey, activity.dedupeKey)
         XCTAssertEqual(restored.activities.first?.state, .announced)
+        XCTAssertEqual(restored.activities.first?.spokenText, "The task is done.")
+        XCTAssertEqual(restored.activities.first?.presentationSource, .luna)
+        XCTAssertEqual(restored.activities.first?.presentationModel, "gpt-5.6-luna")
         XCTAssertTrue(restored.channel.isMuted)
     }
 
@@ -85,6 +91,46 @@ final class CompletionSubscriptionTests: XCTestCase {
         XCTAssertEqual(first.dedupeKey(turnID: "turn-7"), "\(task.id)::turn-7")
         XCTAssertNotEqual(first.dedupeKey(turnID: "turn-7"), second.dedupeKey(turnID: "turn-7"))
         XCTAssertNotEqual(first.dedupeKey(turnID: "turn-7"), first.dedupeKey(turnID: "turn-8"))
+    }
+
+    func testObserverPresenterFeatureIsDefaultOffWithEmergencyOverride() {
+        XCTAssertFalse(ObserverPresenterFeature.isEnabled(environment: [:], configured: nil))
+        XCTAssertTrue(ObserverPresenterFeature.isEnabled(environment: [:], configured: true))
+        XCTAssertFalse(ObserverPresenterFeature.isEnabled(
+            environment: [ObserverPresenterFeature.environmentKey: "0"],
+            configured: true
+        ))
+        XCTAssertTrue(ObserverPresenterFeature.isEnabled(
+            environment: [ObserverPresenterFeature.environmentKey: "yes"],
+            configured: false
+        ))
+    }
+
+    func testDeterministicProjectionRemovesSpeechHostileMarkupWithoutInventingASummary() {
+        let response = """
+        ## Completed
+        The observer is installed. See [the task](https://example.com/task).
+
+        ```swift
+        fatalError("This code must not be narrated")
+        ```
+
+        - Tests pass
+        - The full response remains in Codex
+        """
+        let spoken = CompletionSpeechProjector.project(response)
+
+        XCTAssertTrue(spoken.contains("The observer is installed"))
+        XCTAssertTrue(spoken.contains("Tests pass"))
+        XCTAssertFalse(spoken.contains("fatalError"))
+        XCTAssertFalse(spoken.contains("https://"))
+        XCTAssertFalse(spoken.contains("##"))
+    }
+
+    func testDeterministicProjectionBoundsLongSpeechAndPointsBackToCodex() {
+        let spoken = CompletionSpeechProjector.project(String(repeating: "result ", count: 500))
+        XCTAssertLessThanOrEqual(spoken.count, 960)
+        XCTAssertTrue(spoken.hasSuffix("The full response is available in Codex."))
     }
 
     func testBridgeParserAcceptsStructuredCompletionAndRejectsWrongProvenance() throws {
@@ -184,7 +230,8 @@ final class CompletionSubscriptionTests: XCTestCase {
             .appendingPathComponent("speakeasy-completions-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: directory) }
         let controller = CompletionSubscriptionController(
-            store: CompletionSubscriptionStore(fileURL: directory.appendingPathComponent("subscriptions.json"))
+            store: CompletionSubscriptionStore(fileURL: directory.appendingPathComponent("subscriptions.json")),
+            featureEnabled: true
         )
 
         controller.subscribe(to: task)
@@ -203,6 +250,23 @@ final class CompletionSubscriptionTests: XCTestCase {
         XCTAssertTrue(controller.isSubscribed(to: task.id))
 
         controller.unsubscribe()
+        XCTAssertNil(controller.subscription)
+        XCTAssertEqual(controller.state, .off)
+    }
+
+    @MainActor
+    func testFeatureFlagOffPreventsCreatingAHiddenSubscription() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("speakeasy-completions-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let controller = CompletionSubscriptionController(
+            store: CompletionSubscriptionStore(fileURL: directory.appendingPathComponent("subscriptions.json")),
+            featureEnabled: false
+        )
+
+        controller.subscribe(to: task)
+
+        XCTAssertFalse(controller.isFeatureEnabled)
         XCTAssertNil(controller.subscription)
         XCTAssertEqual(controller.state, .off)
     }

--- a/app/Tests/codex-desktop-bridge.test.cjs
+++ b/app/Tests/codex-desktop-bridge.test.cjs
@@ -2,7 +2,11 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { parseCompletionRecord, isTerminalRecord } = require('../Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs');
+const {
+  parseCompletionRecord,
+  isTerminalRecord,
+  observationMessages,
+} = require('../Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs');
 
 const taskID = '019f99a4-7867-7c23-ac29-0c0eca7da603';
 
@@ -32,4 +36,29 @@ test('bridge parser keeps exact task identity independent of response text', () 
   };
   assert.equal(parseCompletionRecord(record, taskID).taskID, taskID);
   assert.equal(parseCompletionRecord(record, 'different-task').taskID, 'different-task');
+});
+
+test('completion observation commits its cursor atomically with the event', () => {
+  const provenance = { owner: 'codex-desktop', rolloutIdentity: 'rollout-1' };
+  const complete = {
+    type: 'event_msg',
+    timestamp: '2026-08-01T12:00:00.000Z',
+    payload: { type: 'task_complete', turn_id: 'turn-3', last_agent_message: 'Done' },
+  };
+  const observations = observationMessages(complete, taskID, 900, provenance);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0].type, 'completion');
+  assert.equal(observations[0].cursor, 900);
+  assert.equal(observations[0].provenance, provenance);
+
+  const failed = {
+    type: 'event_msg',
+    payload: { type: 'task_failed', turn_id: 'turn-4' },
+  };
+  assert.deepEqual(observationMessages(failed, taskID, 950, provenance), [{
+    type: 'cursor',
+    taskID,
+    turnID: 'turn-4',
+    cursor: 950,
+  }]);
 });

--- a/app/Tests/codex-desktop-bridge.test.cjs
+++ b/app/Tests/codex-desktop-bridge.test.cjs
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { parseCompletionRecord, isTerminalRecord } = require('../Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs');
+
+const taskID = '019f99a4-7867-7c23-ac29-0c0eca7da603';
+
+test('bridge parser ignores progress and accepts only terminal final responses', () => {
+  const progress = { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'turn-1', message: 'partial' } };
+  assert.equal(isTerminalRecord(progress), false);
+  assert.equal(parseCompletionRecord(progress, taskID), null);
+
+  const complete = {
+    type: 'event_msg',
+    timestamp: '2026-08-01T12:00:00.000Z',
+    payload: { type: 'task_complete', turn_id: 'turn-1', last_agent_message: 'Final answer' },
+  };
+  assert.equal(isTerminalRecord(complete), true);
+  assert.deepEqual(parseCompletionRecord(complete, taskID), {
+    taskID,
+    turnID: 'turn-1',
+    response: 'Final answer',
+    completedAt: '2026-08-01T12:00:00.000Z',
+  });
+});
+
+test('bridge parser keeps exact task identity independent of response text', () => {
+  const record = {
+    type: 'event_msg',
+    payload: { type: 'turn_completed', turn_id: 'turn-2', final_response: 'Same title' },
+  };
+  assert.equal(parseCompletionRecord(record, taskID).taskID, taskID);
+  assert.equal(parseCompletionRecord(record, 'different-task').taskID, 'different-task');
+});

--- a/app/Tests/codex-luna-presenter.test.cjs
+++ b/app/Tests/codex-luna-presenter.test.cjs
@@ -1,0 +1,97 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { chmod, mkdtemp, writeFile } = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const test = require('node:test');
+
+const bridge = path.resolve(__dirname, '../Sources/SpeakEasy/Resources/codex-luna-presenter.cjs');
+
+async function fakeCodex(directory, ephemeral = true) {
+  const executable = path.join(directory, 'fake-codex.cjs');
+  const source = `#!/usr/bin/env node
+'use strict';
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+rl.on('line', (line) => {
+  const message = JSON.parse(line);
+  if (message.method === 'initialize') {
+    send({ id: message.id, result: { userAgent: 'fake' } });
+  } else if (message.method === 'thread/start') {
+    const p = message.params;
+    if (p.model !== 'gpt-5.6-luna' || p.ephemeral !== true || p.sandbox !== 'read-only' || p.approvalPolicy !== 'never') {
+      send({ id: message.id, error: { message: 'unsafe thread configuration' } });
+    } else {
+      send({ id: message.id, result: { thread: { id: 'presenter-thread', ephemeral: ${ephemeral} } } });
+    }
+  } else if (message.method === 'turn/start') {
+    const p = message.params;
+    if (p.model !== 'gpt-5.6-luna' || p.effort !== 'low' || p.sandboxPolicy?.type !== 'readOnly' || !p.outputSchema) {
+      send({ id: message.id, error: { message: 'unsafe turn configuration' } });
+      return;
+    }
+    const payload = JSON.parse(p.input[0].text);
+    send({ id: message.id, result: { turn: { id: 'presenter-turn' } } });
+    setTimeout(() => {
+      send({ method: 'item/completed', params: { turnId: 'presenter-turn', item: { id: 'answer', type: 'agentMessage', text: JSON.stringify({ spokenText: 'Short spoken update.' }) } } });
+      send({ method: 'turn/completed', params: { turn: { id: 'presenter-turn', status: 'completed' } } });
+      if (payload.task.id !== 'task-1' || payload.task.turnId !== 'turn-1') process.exitCode = 2;
+    }, 5);
+  }
+});
+`;
+  await writeFile(executable, source);
+  await chmod(executable, 0o700);
+  return executable;
+}
+
+function invoke(executable) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [bridge, executable], {
+      env: { ...process.env, SPEAKEASY_CODEX_BIN: executable },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('exit', (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end(JSON.stringify({
+      taskID: 'task-1',
+      turnID: 'turn-1',
+      taskTitle: 'Canonical task',
+      projectPath: '/tmp/project',
+      response: 'The implementation is complete and all tests pass.',
+    }));
+  });
+}
+
+test('uses a separate ephemeral Luna thread with no action surface', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'speakeasy-luna-'));
+  const result = await invoke(await fakeCodex(directory));
+  const envelope = JSON.parse(result.stdout.trim());
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.ephemeral, true);
+  assert.equal(envelope.model, 'gpt-5.6-luna');
+  assert.equal(envelope.sourceTaskID, 'task-1');
+  assert.equal(envelope.sourceTurnID, 'turn-1');
+  assert.equal(envelope.spokenText, 'Short spoken update.');
+});
+
+test('fails closed if the presenter thread is not ephemeral', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'speakeasy-luna-'));
+  const result = await invoke(await fakeCodex(directory, false));
+  const envelope = JSON.parse(result.stdout.trim());
+
+  assert.notEqual(result.code, 0);
+  assert.equal(envelope.ok, false);
+  assert.match(envelope.error, /ephemeral presenter thread/i);
+});

--- a/app/tools/release/common.sh
+++ b/app/tools/release/common.sh
@@ -289,6 +289,7 @@ speakeasy_verify_bundle_layout() {
 
     for resource in \
         "$resources_dir/SpeakEasy_SpeakEasy.bundle/codex-desktop-bridge.cjs" \
+        "$resources_dir/SpeakEasy_SpeakEasy.bundle/codex-luna-presenter.cjs" \
         "$resources_dir/SpeakEasy_SpeakEasy.bundle/Pad/index.html"; do
         if [ ! -s "$resource" ]; then
             echo "SwiftPM runtime resource is missing from Contents/Resources: $resource" >&2

--- a/app/tools/release/verify-dmg.sh
+++ b/app/tools/release/verify-dmg.sh
@@ -45,8 +45,9 @@ HELPER="$APP/Contents/Helpers/speakeasy-runtime"
 CADDY="$APP/Contents/Helpers/caddy"
 PLIST="$APP/Contents/Info.plist"
 CODEX_BRIDGE="$APP/Contents/Resources/SpeakEasy_SpeakEasy.bundle/codex-desktop-bridge.cjs"
+LUNA_PRESENTER="$APP/Contents/Resources/SpeakEasy_SpeakEasy.bundle/codex-luna-presenter.cjs"
 
-for path in "$APP" "$EXECUTABLE" "$HELPER" "$CADDY" "$PLIST" "$CODEX_BRIDGE"; do
+for path in "$APP" "$EXECUTABLE" "$HELPER" "$CADDY" "$PLIST" "$CODEX_BRIDGE" "$LUNA_PRESENTER"; do
     if [ ! -e "$path" ]; then
         echo "Error: Release payload is missing $path" >&2
         exit 1

--- a/config.json.example
+++ b/config.json.example
@@ -31,5 +31,8 @@
   "global": {
     "tempDir": "/tmp",
     "cleanup": true
+  },
+  "features": {
+    "observerPresenter": false
   }
 }

--- a/docs/design/completion-subscriptions.md
+++ b/docs/design/completion-subscriptions.md
@@ -1,6 +1,6 @@
 # Completion subscriptions
 
-Status: proposed implementation brief
+Status: first-version implementation behind a default-off feature flag
 Date: 2026-08-01
 
 ## Product idea
@@ -154,24 +154,52 @@ does not delete the Codex task or its transcript.
 
 ## Speech projection
 
-The full final assistant response remains in Codex. The first slice may use the
-existing deterministic Markdown-to-speech projection before TTS. It should not
-send response text through a hidden conversational agent.
-
-If later responses are summarized for speech, summarization must be an optional
-channel policy with these constraints:
+The full final assistant response remains in Codex. The presenter receives that
+immutable response only after the Desktop-owned observer has proven the exact
+task and turn. It uses GPT-5.6 Luna to produce a short spoken rendering with
+these constraints:
 
 - it receives response text, never Codex routing authority
 - it cannot submit, resume, steer, or mutate a task
 - its output affects narration only, never the Codex transcript
 - failure falls back to deterministic projection
 
+Luna runs in a separate `codex app-server` process. Each presentation thread is
+started with `ephemeral: true`, low reasoning effort, a read-only sandbox, no
+approvals, and no supported dynamic tools. The bridge refuses output unless the
+app server confirms the ephemeral thread and returns the exact source task and
+turn IDs. Presenter sessions therefore do not become tasks, lanes, or resumable
+threads in Codex.
+
+The fallback removes fenced code and Markdown that is hostile to speech, then
+bounds the spoken excerpt and points the listener back to the complete response
+in Codex. It does not generate a second semantic summary.
+
+## Feature flag and rollback
+
+The observer and presenter are one default-off release slice:
+
+```json
+{
+  "features": {
+    "observerPresenter": true
+  }
+}
+```
+
+The setting lives in `~/.config/speakeasy/settings.json` and is read at app
+launch. `SPEAKEASY_OBSERVER_PRESENTER=0` is the emergency kill switch and wins
+over the file; `SPEAKEASY_OBSERVER_PRESENTER=1` enables a development launch
+without rewriting settings. When disabled, the app does not start the observer,
+does not expose subscription controls, and does not start a Luna app server.
+Existing durable subscription state remains inert so rollback is reversible.
+
 ## UI proposal
 
 Add subscription controls to the exact-task surface rather than to the
 microphone control:
 
-- **Announce completions** toggle on the selected task
+- **Present completions** toggle on the selected task
 - **Channel: Completions** picker or disclosure
 - channel mute control in the menu bar player and Deck
 - a small subscription badge on subscribed tasks


### PR DESCRIPTION
## Why this is separate

This is the default-off `0.2.19` observer/presenter slice. It does not place a conversational proxy in the interactive voice path: dictation still enters the exact Codex task, and the full response remains there unchanged.

## What it adds

- one durable subscription to one exact Codex Desktop task
- a read-only Desktop-owned completion observer with a baseline and durable cursor
- completion-plus-cursor atomicity so a restart cannot silently skip a response
- exactly-once activity identity by exact task ID and turn ID
- an independent Completions playback channel that yields to interactive turns
- a separate ephemeral, read-only Luna presenter with no routing authority
- deterministic speech projection when Luna is unavailable or rejects provenance
- a default-off `observerPresenter` feature flag and `SPEAKEASY_OBSERVER_PRESENTER=0` emergency kill switch

## Trust boundary

- Codex Desktop remains the canonical task and transcript owner.
- The observer cannot submit, resume, steer, or mutate a task.
- Normal turn deltas do not invalidate the proven Desktop owner; an owner, host, rollout, protocol, or socket change still fails closed.
- The presenter runs in a separate ephemeral app-server task and affects narration only.
- Presenter output is accepted only with the exact source task and turn IDs.
- Subscriptions do not activate voice lanes or open the microphone.

## Signed acceptance evidence

Run against exact task `019fbd95-b68c-75b3-a3a6-58bc81c85be4` from an installed Developer-ID-signed app:

- the observer executed from `Contents/Resources/SpeakEasy_SpeakEasy.bundle`, not the source tree
- a directly submitted exact-task turn was observed while the observer remained attached
- the response became one durable muted activity with the same task and turn IDs
- restart preserved the cursor and activity count (`1 -> 1`), with no duplicate
- a real ephemeral `gpt-5.6-luna` presenter run returned matching source task and turn provenance
- a signed local `0.2.19` DMG passed the mounted-payload audit with the bridge, Luna presenter, Pad, runtime, and Caddy all inside the bundle

## Verification

- 71 Swift tests
- 64 Bun tests
- TypeScript build
- release-shell syntax checks
- signed app deep codesign verification
- signed local `0.2.19` DMG mounted-payload verification

## Public launch boundary

The code is safe to merge because it remains default-off. Do not publish `0.2.19` as Latest until the remaining clean-device gates in `docs/release/gtm.md` pass: second-Mac/iPad pairing, Apple notarization, and same-commit publication of the DMG, npm package, and Codex plugin.
