### PR TITLE
📝 align documented runtime requirements

### DIFF
--- a/docs/cache.mdx
+++ b/docs/cache.mdx
@@ -31,7 +31,7 @@ SpeakEasy includes a sophisticated caching system that:
 
 ### Runtime Requirements
 
-- **Node.js 22.5+** uses built-in `node:sqlite`
+- **Node.js 22.12+** uses built-in `node:sqlite`
 - **Bun 1.0+** uses built-in `bun:sqlite`
 - Older Node versions fall back to `metadata.json` (no SQLite)
 

--- a/docs/sdk.mdx
+++ b/docs/sdk.mdx
@@ -292,7 +292,8 @@ const openai = await speaker.findByProvider('openai');
 await speaker.clearCache();
 ```
 
-Cache uses built-in SQLite on Node.js 22.5+ (`node:sqlite`) or Bun (`bun:sqlite`), with JSON fallback on older Node versions.
+Cache uses built-in SQLite on supported Node.js 22.12+ (`node:sqlite`) or
+Bun 1.0+ (`bun:sqlite`).
 
 ## Error Handling
 

--- a/landing/public/agent.md
+++ b/landing/public/agent.md
@@ -38,7 +38,7 @@ ready and which human-only steps remain. The user—not the agent—approves
 microphone and local-network permissions. Do not bypass Gatekeeper, remove
 quarantine attributes, install a floating `latest` build, or build from source.
 
-## Path B — TTS CLI only (any agent, any host with Node 18+)
+## Path B — TTS CLI only (Node.js 22.12+ or Bun 1.0+)
 
 Install ad hoc, nothing written to the project (preferred):
 


### PR DESCRIPTION
Align the public agent runbook, SDK guide, and cache guide with the supported Node.js 22.12+ or Bun 1.0+ runtime boundary.\n\nVerification: `bun run build` in `landing` (27 static routes).