### PR TITLE
📝 clarify the speech privacy boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,18 @@
 **Speak to the Codex task you are already using. Hear its real answer come back.**
 
 SpeakEasy is a dual-mode voice companion for Codex Desktop on macOS. It
-transcribes an explicit utterance locally, routes the final text to the exact
-Codex task you chose, and narrates that task's real response through a
-controllable native player. The same live task lanes are available from the
+captures an explicit utterance on the surface you are holding, transcribes it
+with Apple Speech or the Mac's local Parakeet model, routes the final text to
+the exact Codex task you chose, and narrates that task's real response through
+a controllable native player. The same live task lanes are available from the
 Mac, a browser, or an iPad on your local network.
 
 - **No shadow conversation:** the full transcript remains in Codex.
 - **No focus guessing:** the exact task ID is the routing authority.
-- **Local speech boundary:** audio is captured and transcribed on your Mac.
+- **Local-network speech boundary:** Parakeet transcription stays on the Mac;
+  the Apple Speech fallback follows Apple's device settings and terms. Browser
+  and iPad fallback recordings travel only to the paired Mac and are deleted
+  after the request.
 - **One self-serve install:** Codex can verify and install the signed,
   Apple-notarized app without a source checkout or developer tools.
 
@@ -22,11 +26,12 @@ Paste this bounded task into Codex Desktop:
 > https://speakeasy.arach.dev/agent.md and follow Path A. Do not build from
 > source or bypass Gatekeeper. Tell me which human-only steps remain.
 
-The current `0.2.18` build is a self-serve preview. It stays a GitHub
-prerelease until the clean second-Mac and device-path acceptance run passes.
+The current `0.2.18` build is an immutable self-serve core preview. It remains
+a GitHub prerelease permanently; the first public **Latest** train is `0.2.19`
+after the clean second-Mac, device-path, and observer/presenter gates pass.
 See [SpeakEasy for Codex](https://speakeasy.arach.dev/codex/) for the product
 loop and [`docs/release/self-serve-mac-test.md`](docs/release/self-serve-mac-test.md)
-for the promotion gate.
+for the clean-machine proof.
 
 The TypeScript library and CLI remain available for applications and agent
 hooks that need provider-independent TTS. Jump to [Library and CLI](#library-and-cli)

--- a/docs/release/gtm.md
+++ b/docs/release/gtm.md
@@ -102,8 +102,12 @@ narration across your Mac and iPad without creating a shadow conversation.
    folder, or recency, is the routing authority.
 2. **The transcript stays whole.** Dictations and real responses remain in the
    same Codex task; SpeakEasy owns voice and playback, not a second chat.
-3. **Local by design.** Audio capture and ASR stay on the Mac. The device Deck
-   is a control surface for that Mac, not a hosted agent.
+3. **Local-network by design.** Parakeet transcription stays on the Mac; the
+   Apple Speech fallback follows Apple's device capabilities, settings, and
+   terms. A browser records on that device and sends a bounded file over
+   paired local HTTPS to the Mac's Parakeet model. The native iPad shell can
+   use Apple Speech first and uploads its private fallback recording to that
+   same Mac. No Arach speech server sits in the path.
 4. **Codex installs the companion.** A bounded Codex task can inspect the
    installer and verify checksum, Gatekeeper, Developer ID, and exact version.
 5. **Completions are opt-in and quiet.** The observer is read-only; the
@@ -136,12 +140,12 @@ narration across your Mac and iPad without creating a shadow conversation.
 
 | Asset | State | Required action |
 | --- | --- | --- |
-| Dual-mode website and `/codex/` | Built and tested on PR branch; not public | Merge onboarding PR and verify Pages deployment |
-| Agent-readable installer guide | Present at `landing/public/agent.md` | Verify public 200 response after deployment |
+| Dual-mode website and `/codex/` | Live publicly from merged PR #13 | Keep the product and pinned release story aligned |
+| Agent-readable installer guide | Live publicly at `/agent.md` | Update only with the exact release train |
 | Signed/notarized `0.2.18` DMG | Public prerelease | Keep immutable; use as core proof candidate |
 | Pinned release installer and checksum | Public prerelease | Run from clean second Mac |
 | Native onboarding and Deck | In `0.2.18` prerelease | Complete human permission and device-path checks |
-| Observer/presenter | Implemented, tested, default-off on follow-on branch | Real Codex/Luna/signed-app acceptance; ship in `0.2.19` |
+| Observer/presenter | Implemented, tested, default-off in draft PR #14 | Real Codex/Luna/signed-app acceptance; ship in `0.2.19` |
 | npm package | Public `latest` is `0.2.16` | Publish `0.2.19` from launch commit |
 | Codex plugin runtime | Bundled runtime reports `0.2.17` | Rebuild/package from `0.2.19`; rerun bundle audit |
 | OpenAI plugin listing | Submission materials exist | User completes publisher verification and Apps Management Write |
@@ -189,6 +193,10 @@ All public `0.2.19` artifacts must be produced from one commit:
 - `package.json` and npm tarball;
 - bundled plugin runtime and submission ZIP;
 - release notes and documented requirements.
+
+Publish and verify the GitHub assets, npm package, and plugin bundle before
+promoting `0.2.19` to **Latest**. Installation from each public artifact must
+be part of the gate; successful local builds are not enough.
 
 Do not update or move `v0.2.18`. If a `0.2.19` candidate fails, fix forward to
 a new candidate or version rather than replacing an artifact people may have

--- a/landing/app/privacy/page.tsx
+++ b/landing/app/privacy/page.tsx
@@ -3,15 +3,15 @@ import { LegalPage } from "@/components/legal-page"
 
 export const metadata: Metadata = {
   title: "Privacy Policy - SpeakEasy",
-  description: "How SpeakEasy handles text, audio, provider credentials, and website analytics.",
+  description: "How SpeakEasy handles microphone capture, transcription, narration, provider credentials, and website analytics.",
 }
 
 export default function PrivacyPage() {
   return (
     <LegalPage
       title="Privacy Policy"
-      summary="SpeakEasy is a local-first text-to-speech tool. This policy describes the data the app and plugin use to create and play speech."
-      updated="July 24, 2026"
+      summary="SpeakEasy is a local-network voice companion and text-to-speech tool. This policy describes how its Mac, browser, and iPad surfaces handle microphone audio, transcripts, narration, and credentials."
+      updated="August 2, 2026"
     >
       <section>
         <h2>What SpeakEasy processes</h2>
@@ -19,6 +19,57 @@ export default function PrivacyPage() {
           SpeakEasy processes the text you choose to narrate, audio generated from that text, player
           state, and local configuration such as your preferred provider and voice. Its playback queue,
           cache, and history are stored on your Mac.
+        </p>
+      </section>
+
+      <section>
+        <h2>Microphone capture and transcription</h2>
+        <p>
+          SpeakEasy opens a microphone only after you explicitly start a voice turn and stops when
+          you finish or cancel it. A voice turn can begin on the Mac, in the paired browser Deck, or
+          in the native iPad developer preview.
+        </p>
+        <p>
+          On the Mac, SpeakEasy prefers its bundled Parakeet model, which performs transcription on
+          that Mac. It can use Apple Speech while Parakeet warms or as a fallback. SpeakEasy requests
+          on-device Apple recognition when the operating system reports support; otherwise Apple&apos;s
+          handling is governed by the Mac&apos;s capabilities, settings, and Apple&apos;s privacy terms.
+          Audio is not sent to Arach.
+        </p>
+        <p>
+          The browser Deck records on the browser device, then sends a bounded audio file over the
+          paired local-network HTTPS connection to the selected Mac. The native iPad shell first
+          tries Apple Speech; Apple&apos;s handling of that request is governed by the device&apos;s
+          capabilities, settings, and Apple&apos;s privacy terms. If Apple Speech is unavailable or does
+          not return a final transcript, the shell sends its fallback recording to the paired Mac
+          for Parakeet transcription.
+        </p>
+        <p>
+          Mac-side upload directories are owner-only and recordings are mode <code>0600</code>. The
+          temporary upload is deleted immediately after the transcription request finishes, whether
+          it succeeds or fails. The native iPad shell also deletes its temporary recording after the
+          Apple Speech or Mac fallback path completes. SpeakEasy does not retain voice-turn audio as
+          narration history or upload it to an Arach server.
+        </p>
+      </section>
+
+      <section>
+        <h2>Local-network Deck</h2>
+        <p>
+          The Deck connects directly to a Mac on the same local network. Paired sessions use a
+          temporary secret and local HTTPS. The Deck exchanges task display state, explicit control
+          commands, transcripts, narration state, and—only for device microphone turns—the bounded
+          recording described above. SpeakEasy does not relay this traffic through an Arach service.
+        </p>
+      </section>
+
+      <section>
+        <h2>Codex tasks and transcripts</h2>
+        <p>
+          When you send a voice turn, SpeakEasy submits the final transcript to the exact Codex
+          Desktop task you selected. The transcript, Codex response, tool activity, and task history
+          remain in Codex and are governed by your Codex account, application, and retention settings.
+          SpeakEasy does not create an Arach-hosted copy of that conversation.
         </p>
       </section>
 
@@ -43,11 +94,13 @@ export default function PrivacyPage() {
       <section>
         <h2>Retention and deletion</h2>
         <p>
-          Arach does not retain your narration text, generated audio, queue, history, or provider
-          credentials on an Arach server. Local settings remain in <code>~/.config/speakeasy</code>
-          until you edit or remove them. Cached audio remains until its configured time-to-live or
-          size policy removes it, or until you clear it manually. Local narration history remains
-          until you remove it. Audio files saved to a path you selected remain until you delete them.
+          Arach does not retain your microphone audio, transcripts, narration text, generated audio,
+          queue, history, or provider credentials on an Arach server. Voice-turn recordings are
+          temporary and are deleted as described above. Local settings remain in
+          <code>~/.config/speakeasy</code> until you edit or remove them. Cached narration audio
+          remains until its configured time-to-live or size policy removes it, or until you clear it
+          manually. Local narration history remains until you remove it. Audio files saved to a path
+          you selected remain until you delete them.
         </p>
         <p>
           You can clear the CLI cache with <code>speakeasy --clear-cache</code>, remove local history
@@ -61,8 +114,9 @@ export default function PrivacyPage() {
         <h2>Collection by SpeakEasy</h2>
         <p>
           The SpeakEasy app, CLI, and plugin do not operate an Arach account service and do not send
-          narration text, generated audio, queue contents, or provider credentials to Arach. App
-          installation checks GitHub Releases to download the signed macOS application.
+          microphone audio, transcripts, narration text, generated audio, queue contents, or
+          provider credentials to Arach. App installation checks GitHub Releases to download the
+          signed macOS application.
         </p>
       </section>
 
@@ -81,6 +135,8 @@ export default function PrivacyPage() {
       <section>
         <h2>Your choices</h2>
         <ul>
+          <li>Use only the Mac microphone path to keep capture and transcription on the Mac.</li>
+          <li>Use the browser or iPad Deck only on a local network you trust.</li>
           <li>Use the macOS system provider to keep speech synthesis on-device.</li>
           <li>Remove cached audio, history, or configuration from your local SpeakEasy directories.</li>
           <li>Revoke provider credentials with the provider that issued them.</li>


### PR DESCRIPTION
## What changed\n\n- corrects the launch story: 0.2.18 remains an immutable core prerelease and 0.2.19 is the first Latest train\n- updates the GTM status now that the dual-mode site is public\n- documents Mac Parakeet, Apple Speech, paired browser/iPad audio transfer, private temporary files, deletion, and Codex transcript custody\n- makes npm and plugin artifact verification an explicit pre-promotion gate\n\n## Verification\n\n- `bun run build` in `landing` — 27 static routes