### PR TITLE
Secure the browser and iPad Deck by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,12 @@ opens **SpeakEasy → Settings → Deck**. Its three-step checklist confirms the
 bundled runtime, finds Codex, and starts the live bridge. The device card and QR
 appear only when the bridge is genuinely ready.
 
-There is no separate server package and Caddy is optional. SpeakEasy finds the
-native Codex binary from the desktop app or the `codex` command in your login
-shell. Re-running `./app/install.sh` is safe; use `--no-open` in automation.
+There is no separate server package or Caddy setup. Release and source builds
+bundle a pinned, checksum-verified Caddy helper so the browser/iPad Deck always
+starts on paired local HTTPS rather than silently losing microphone access on
+plain HTTP. SpeakEasy finds the native Codex binary from the desktop app or the
+`codex` command in your login shell. Re-running `./app/install.sh` is safe; use
+`--no-open` in automation.
 
 Enable **Start the deck with SpeakEasy** after the first successful launch to
 keep it ready whenever the menu-bar app runs.

--- a/app/Resources/ThirdPartyNotices/Caddy-LICENSE.txt
+++ b/app/Resources/ThirdPartyNotices/Caddy-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/app/Sources/SpeakEasy/ConfigModel.swift
+++ b/app/Sources/SpeakEasy/ConfigModel.swift
@@ -511,7 +511,7 @@ class ConfigManager: ObservableObject {
 
     // Deck bridge — the CLI reads these as defaults for `speakeasy deck`
     var deckPair: Bool {
-        get { config.deck?.pair ?? false }
+        get { config.deck?.pair ?? true }
         set {
             ensureDeck()
             config.deck?.pair = newValue

--- a/app/Sources/SpeakEasy/DeckSettingsView.swift
+++ b/app/Sources/SpeakEasy/DeckSettingsView.swift
@@ -42,7 +42,7 @@ struct DeckSettingsView: View {
                     Text("Three checks, then talk to Codex")
                         .font(.headline)
                         .foregroundColor(theme.text)
-                    Text("The app carries the runtime. There are no server packages, URLs, or Caddy steps to configure.")
+                    Text("The app carries the runtime and secure bridge. There are no server packages or Caddy steps to configure.")
                         .font(.caption)
                         .foregroundColor(theme.textSecondary)
                 }

--- a/app/tools/release/common.sh
+++ b/app/tools/release/common.sh
@@ -19,6 +19,111 @@ speakeasy_default_version() {
     fi
 }
 
+speakeasy_caddy_version() {
+    echo "2.11.4"
+}
+
+speakeasy_verify_caddy_binary() {
+    local candidate="$1"
+    local expected_version="$2"
+    local actual_version
+
+    if [ ! -x "$candidate" ]; then
+        echo "Caddy is missing or not executable: $candidate" >&2
+        return 1
+    fi
+
+    actual_version="$("$candidate" version 2>/dev/null | awk '{ print $1 }')"
+    if [ "$actual_version" != "v$expected_version" ]; then
+        echo "Caddy $expected_version is required, found ${actual_version:-unknown}: $candidate" >&2
+        return 1
+    fi
+
+    if ! file "$candidate" | grep -q 'arm64'; then
+        echo "Caddy must contain an arm64 executable: $candidate" >&2
+        return 1
+    fi
+}
+
+# Resolve a reproducible arm64 Caddy helper for the release bundle. An explicit
+# path wins; otherwise use a matching PATH binary or fetch the pinned official
+# GitHub release and verify it against the publisher's checksum manifest.
+speakeasy_prepare_caddy() {
+    local app_root="$1"
+    local version="$(speakeasy_caddy_version)"
+    local override="${SPEAKEASY_CADDY_PATH:-}"
+    local candidate=""
+    local tools_dir="$app_root/.build/tools"
+    local cached
+    local archive_name
+    local release_url
+    local temp_dir
+    local checksum
+
+    version="${version#v}"
+    cached="$tools_dir/caddy-$version"
+    archive_name="caddy_${version}_mac_arm64.tar.gz"
+    release_url="https://github.com/caddyserver/caddy/releases/download/v${version}"
+
+    if [ -n "$override" ]; then
+        if ! speakeasy_verify_caddy_binary "$override" "$version"; then
+            echo "SPEAKEASY_CADDY_PATH must point to the pinned release helper." >&2
+            return 1
+        fi
+        echo "$override"
+        return 0
+    fi
+
+    candidate="$(command -v caddy 2>/dev/null || true)"
+    if [ -n "$candidate" ] && speakeasy_verify_caddy_binary "$candidate" "$version" >/dev/null 2>&1; then
+        echo "$candidate"
+        return 0
+    fi
+
+    if speakeasy_verify_caddy_binary "$cached" "$version" >/dev/null 2>&1; then
+        echo "$cached"
+        return 0
+    fi
+
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "curl is required to fetch the pinned Caddy helper." >&2
+        return 1
+    fi
+
+    mkdir -p "$tools_dir"
+    temp_dir="$(mktemp -d)"
+    echo "Fetching pinned Caddy v$version for the secure Deck..." >&2
+    if ! curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+        "$release_url/$archive_name" -o "$temp_dir/$archive_name" \
+        || ! curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+        "$release_url/caddy_${version}_checksums.txt" -o "$temp_dir/checksums.txt"; then
+        rm -rf "$temp_dir"
+        echo "Could not download the pinned Caddy release." >&2
+        return 1
+    fi
+
+    checksum="$(awk -v archive="$archive_name" '$2 == archive { print $1; exit }' "$temp_dir/checksums.txt")"
+    if [ -z "$checksum" ] || ! (cd "$temp_dir" && printf '%s  %s\n' "$checksum" "$archive_name" | shasum -a 256 -c - >/dev/null); then
+        rm -rf "$temp_dir"
+        echo "Caddy archive checksum verification failed." >&2
+        return 1
+    fi
+
+    if ! tar -xzf "$temp_dir/$archive_name" -C "$temp_dir" caddy; then
+        rm -rf "$temp_dir"
+        echo "Could not extract the Caddy release helper." >&2
+        return 1
+    fi
+    chmod +x "$temp_dir/caddy"
+    if ! speakeasy_verify_caddy_binary "$temp_dir/caddy" "$version"; then
+        rm -rf "$temp_dir"
+        return 1
+    fi
+    mv "$temp_dir/caddy" "$cached"
+    rm -rf "$temp_dir"
+    echo "$cached"
+}
+
 speakeasy_build_deck_runtime() {
     local app_root="$1"
     local repo_root
@@ -118,6 +223,7 @@ speakeasy_verify_bundle_layout() {
     local bundle_path="$1"
     local executable="$bundle_path/Contents/MacOS/SpeakEasy"
     local deck_runtime="$bundle_path/Contents/Helpers/speakeasy-runtime"
+    local caddy_helper="$bundle_path/Contents/Helpers/caddy"
     local frameworks_dir="$bundle_path/Contents/Frameworks"
     local resources_dir="$bundle_path/Contents/Resources"
     local info_plist="$bundle_path/Contents/Info.plist"
@@ -134,8 +240,18 @@ speakeasy_verify_bundle_layout() {
         return 1
     fi
 
+    if ! speakeasy_verify_caddy_binary "$caddy_helper" "$(speakeasy_caddy_version)"; then
+        echo "Bundled secure Deck helper is invalid: $caddy_helper" >&2
+        return 1
+    fi
+
     if [ ! -s "$resources_dir/Deck/index.html" ]; then
         echo "Bundled deck surface is missing: Contents/Resources/Deck/index.html" >&2
+        return 1
+    fi
+
+    if [ ! -s "$resources_dir/ThirdPartyNotices/Caddy-LICENSE.txt" ]; then
+        echo "Bundled Caddy license notice is missing." >&2
         return 1
     fi
 
@@ -207,6 +323,8 @@ speakeasy_bundle_app() {
     local build_dir="$app_root/.build/release"
     local executable_path="$bundle_path/Contents/MacOS/SpeakEasy"
     local helper_path="$bundle_path/Contents/Helpers/speakeasy-runtime"
+    local caddy_path="$bundle_path/Contents/Helpers/caddy"
+    local caddy_source
     local repo_root
     repo_root="$(speakeasy_repo_root)"
 
@@ -225,6 +343,10 @@ speakeasy_bundle_app() {
     cp "$build_dir/speakeasy-runtime" "$helper_path"
     chmod +x "$helper_path"
 
+    caddy_source="$(speakeasy_prepare_caddy "$app_root")"
+    cp -L "$caddy_source" "$caddy_path"
+    chmod +x "$caddy_path"
+
     echo "Bundling HudsonKit frameworks..."
     speakeasy_bundle_swiftpm_frameworks \
         "$executable_path" \
@@ -242,6 +364,10 @@ speakeasy_bundle_app() {
     ditto "$repo_root/deck/variants" "$bundle_path/Contents/Resources/Deck/variants"
 
     cp "$app_root/Resources/Info.plist" "$bundle_path/Contents/"
+
+    if [ -d "$app_root/Resources/ThirdPartyNotices" ]; then
+        ditto "$app_root/Resources/ThirdPartyNotices" "$bundle_path/Contents/Resources/ThirdPartyNotices"
+    fi
 
     if [ -f "$app_root/Resources/hud-preview-sample.aiff" ]; then
         cp "$app_root/Resources/hud-preview-sample.aiff" "$bundle_path/Contents/Resources/"

--- a/app/tools/release/sign-bundle.sh
+++ b/app/tools/release/sign-bundle.sh
@@ -91,6 +91,7 @@ sign_bundle_with_identity() {
     local label="$2"
     local executable="$BUNDLE_PATH/Contents/MacOS/SpeakEasy"
     local deck_runtime="$BUNDLE_PATH/Contents/Helpers/speakeasy-runtime"
+    local caddy_helper="$BUNDLE_PATH/Contents/Helpers/caddy"
     local framework_path
 
     echo "==> Signing ($label)..."
@@ -103,6 +104,7 @@ sign_bundle_with_identity() {
     done
 
     sign_path "$deck_runtime" "$identity" 0
+    sign_path "$caddy_helper" "$identity" 0
     sign_path "$executable" "$identity" 1
 
     local bundle_args=(--force --options runtime --timestamp --sign "$identity" --identifier "$BUNDLE_ID")

--- a/app/tools/release/verify-dmg.sh
+++ b/app/tools/release/verify-dmg.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
 DMG_PATH="${1:-}"
 EXPECTED_VERSION="${2:-}"
 EXPECT_NOTARIZED="${SPEAKEASY_EXPECT_NOTARIZED:-1}"
@@ -38,9 +42,10 @@ hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$MOUNT_POINT" -quiet
 APP="$MOUNT_POINT/SpeakEasy.app"
 EXECUTABLE="$APP/Contents/MacOS/SpeakEasy"
 HELPER="$APP/Contents/Helpers/speakeasy-runtime"
+CADDY="$APP/Contents/Helpers/caddy"
 PLIST="$APP/Contents/Info.plist"
 
-for path in "$APP" "$EXECUTABLE" "$HELPER" "$PLIST"; do
+for path in "$APP" "$EXECUTABLE" "$HELPER" "$CADDY" "$PLIST"; do
     if [ ! -e "$path" ]; then
         echo "Error: Release payload is missing $path" >&2
         exit 1
@@ -65,6 +70,7 @@ fi
 
 APP_ARCHS="$(lipo -archs "$EXECUTABLE")"
 HELPER_ARCHS="$(lipo -archs "$HELPER")"
+CADDY_ARCHS="$(lipo -archs "$CADDY")"
 case " $APP_ARCHS " in
     *" arm64 "*) ;;
     *) echo "Error: SpeakEasy executable is missing arm64: $APP_ARCHS" >&2; exit 1 ;;
@@ -73,6 +79,12 @@ case " $HELPER_ARCHS " in
     *" arm64 "*) ;;
     *) echo "Error: Deck runtime is missing arm64: $HELPER_ARCHS" >&2; exit 1 ;;
 esac
+case " $CADDY_ARCHS " in
+    *" arm64 "*) ;;
+    *) echo "Error: Caddy helper is missing arm64: $CADDY_ARCHS" >&2; exit 1 ;;
+esac
+
+speakeasy_verify_caddy_binary "$CADDY" "$(speakeasy_caddy_version)"
 
 if otool -L "$EXECUTABLE" | awk 'NR > 1 { print $1 }' | grep -Ev '^(@rpath/|/System/Library/|/usr/lib/)' | grep -q .; then
     echo "Error: App contains a non-portable dynamic-library reference:" >&2
@@ -80,4 +92,4 @@ if otool -L "$EXECUTABLE" | awk 'NR > 1 { print $1 }' | grep -Ev '^(@rpath/|/Sys
     exit 1
 fi
 
-echo "    Payload accepted: SpeakEasy $ACTUAL_VERSION · app $APP_ARCHS · runtime $HELPER_ARCHS"
+echo "    Payload accepted: SpeakEasy $ACTUAL_VERSION · app $APP_ARCHS · runtime $HELPER_ARCHS · Caddy $CADDY_ARCHS"

--- a/config.json.example
+++ b/config.json.example
@@ -31,5 +31,9 @@
   "global": {
     "tempDir": "/tmp",
     "cleanup": true
+  },
+  "deck": {
+    "pair": true,
+    "autoStart": false
   }
 }

--- a/deck/README.md
+++ b/deck/README.md
@@ -25,21 +25,26 @@ The installer opens the Deck settings checklist after it verifies and installs
 the bundled runtime. A device link appears only after Codex and the live data
 plane are ready, so a half-configured bridge is never presented as success.
 
-That serves the live deck on the local network (via Caddy when installed, the fully live built-in server otherwise),
-advertises **speak.\<your-mac\>.local** over Bonjour, and prints a QR code. It uses 43211 for a
-normal user install (or port 80 only when the process is permitted to bind it). On the iPad (same Wi-Fi):
+That serves the live deck on the local network through SpeakEasy's bundled
+Caddy helper, advertises **speak.\<your-mac\>.local** over Bonjour, and prints a
+paired HTTPS QR code. It uses 43211 for the certificate bootstrap endpoint and
+443 for the secure Deck. On the iPad (same Wi-Fi):
 
-1. Scan the code or open the printed URL (e.g. `http://speak.air.local`) in Safari.
-2. Share → **Add to Home Screen** for the full-screen deck.
-3. Pick a look: `?theme=paper|ember|flight`, or a variant like `?variant=oxide`.
+1. Open the printed trust link once, install the local profile, and enable it in
+   **Settings → General → About → Certificate Trust Settings**.
+2. Scan the code or open the printed URL (for example,
+   `https://speak.air.local#k=…`) in Safari.
+3. Share → **Add to Home Screen** for the full-screen deck.
 
-Options: `--port <n>`, `--host <name>` (default `speak.<device>.local`), `--no-qr`, `--no-caddy`,
-`--no-mdns`. The public server proxies the loopback runtime under same-origin `/ws`, `/api`, and
-`/audio` routes: hold-to-speak runs the real phase machine with real synthesis on the Mac, and
-`speakeasy "text"` from any shell mirrors into the open deck. Caddy is only the optional local-HTTPS
-upgrade; it is not required for live lanes. Without the runtime the page falls back to demo state. Is it running?
-`curl http://localhost:<port>/healthz` on the printed port. Prefer your own server?
-`caddy run` in this directory uses the shipped `Caddyfile`.
+Options: `--port <n>`, `--host <name>` (default `speak.<device>.local`),
+`--pair|--no-pair`, `--no-qr`, and `--no-mdns`. Pairing and TLS default on. The
+public server proxies the loopback runtime under same-origin `/ws`, `/api`, and
+`/audio` routes: hold-to-speak runs the real phase machine with real synthesis
+on the Mac, and `speakeasy "text"` from any shell mirrors into the open deck.
+Without the runtime the page falls back to demo state. `--no-tls --no-caddy`
+exists only for explicit local development; a normal start fails closed instead
+of presenting an insecure device link. Is it running? Use
+`curl http://localhost:<port>/healthz` on the printed bootstrap port.
 
 Run SpeakEasy on more Macs to add machines. Each advertises its own `SpeakEasy Deck (<host>)`
 Bonjour service; the native iPad shell lists them in a machine menu and remembers the last choice.

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -137,8 +137,8 @@ that answers questions about the whole system from a live status digest.
 # Start the deck (43211+ for normal users; port 80 only when permitted)
 speakeasy deck
 
-# Pin a port and require a pairing token from devices
-speakeasy deck --port 43211 --pair
+# Pin the certificate-bootstrap port (pairing and HTTPS stay on by default)
+speakeasy deck --port 43211
 
 # Full option set
 speakeasy deck [--port <n>] [--host <name>] [--pair|--no-pair] [--no-qr] [--no-caddy] [--no-mdns] [--no-tls]
@@ -151,7 +151,7 @@ them from its Deck section, and CLI flags always win over config:
 {
   "deck": {
     "port": 43211,
-    "pair": false,
+    "pair": true,
     "autoStart": true
   }
 }
@@ -165,10 +165,12 @@ connected devices, lane bindings, trace), manages lanes directly (each lane's
 menu binds a recent codex thread or resets to a fresh session — the same
 `lane.assign` intent the deck's own picker sends), and owns the bridge:
 start/stop/restart, auto-start, pairing, port, and a scannable device link. A
-release app includes both the runtime and Deck assets; Caddy is optional and
-adds local HTTPS, while the built-in server carries the same live WebSocket and
-HTTP control paths with no extra install. It discovers the running deck through
-`~/.config/speakeasy/deck-listener.json`, so it works no matter how the deck
+release app includes the runtime, Deck assets, and a pinned Caddy helper, so the
+device path uses paired local HTTPS with no separate server install. A normal
+start fails closed rather than downgrade the microphone path to HTTP. The
+built-in HTTP server remains available only through the explicit development
+flags `--no-tls --no-caddy`. The app discovers the running deck through
+`~/.config/speakeasy/deck-listener.json`, so it works no matter how the Deck
 was started.
 
 ## Complete Examples

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -68,7 +68,7 @@ SpeakEasy uses a hierarchical configuration system with the following precedence
   },
   "deck": {
     "port": 43211,
-    "pair": false
+    "pair": true
   }
 }
 ```
@@ -80,7 +80,7 @@ Optional defaults for `speakeasy deck` (CLI flags always win):
 | Key | Type | Effect |
 |---|---|---|
 | `deck.port` | number | Preferred deck port. Falls back to auto (43211+ for normal users; port 80 only when permitted) when busy — unlike `--port`, which must be bindable. |
-| `deck.pair` | boolean | Require the persistent pairing token from devices, like `--pair`. Override per-run with `--no-pair`. |
+| `deck.pair` | boolean | Require the persistent pairing token from devices. Defaults to `true`; override per-run with `--no-pair` only on a trusted development network. |
 | `deck.autoStart` | boolean | Start the bundled Deck when the SpeakEasy menu-bar app launches. Enable this after the first guided setup succeeds. |
 
 The Mac settings app edits these from its Deck section, which also shows live

--- a/docs/release/gtm.md
+++ b/docs/release/gtm.md
@@ -28,10 +28,13 @@ or silently replacing the existing `v0.2.18` tag or assets.
 The launch order is:
 
 1. merge and deploy the core onboarding PR;
-2. prove `0.2.18` on a clean second Mac and browser/iPad device path;
+2. use `0.2.18` for core Mac proof only; its browser/PWA path predates the
+   bundled-TLS and pairing-default fix;
 3. validate observer/presenter in a signed `0.2.19` candidate;
-4. publish every `0.2.19` artifact from the same commit;
-5. run the clean-machine gate again against the public assets;
+4. verify the candidate bundles pinned Caddy, defaults pairing on, and fails
+   closed rather than downgrade a requested HTTPS launch;
+5. publish every `0.2.19` artifact from the same commit and run the full
+   clean-machine plus browser/iPad gate against those public assets;
 6. promote `0.2.19` to **Latest** and announce it.
 
 ## Product truth
@@ -145,6 +148,7 @@ narration across your Mac and iPad without creating a shadow conversation.
 | Signed/notarized `0.2.18` DMG | Public prerelease | Keep immutable; use as core proof candidate |
 | Pinned release installer and checksum | Public prerelease | Run from clean second Mac |
 | Native onboarding and Deck | In `0.2.18` prerelease | Complete human permission and device-path checks |
+| Secure browser/PWA transport | Implemented for `0.2.19` | Verify bundled Caddy, paired HTTPS, and mic access on a clean Mac/device |
 | Observer/presenter | Implemented, tested, default-off in draft PR #14 | Real Codex/Luna/signed-app acceptance; ship in `0.2.19` |
 | npm package | Public `latest` is `0.2.16` | Publish `0.2.19` from launch commit |
 | Codex plugin runtime | Bundled runtime reports `0.2.17` | Rebuild/package from `0.2.19`; rerun bundle audit |

--- a/docs/release/self-serve-mac-test.md
+++ b/docs/release/self-serve-mac-test.md
@@ -36,6 +36,8 @@ Pass criteria:
   quarantine bypass, or right-click workaround.
 - SpeakEasy appears in the menu bar.
 - The app does not request Bun, Xcode, Node, a repository, or a terminal step.
+- The app bundle contains its signed Caddy helper; no Homebrew or separate
+  server install is requested.
 - Codex clearly separates completed machine checks from the microphone and
   local-network prompts that require the user.
 
@@ -55,6 +57,8 @@ Pass criteria:
 - A failure leaves an actionable message and **Open log** button.
 - The device URL is not shown until the runtime snapshot answers.
 - Restarting SpeakEasy does not create duplicate Deck or Caddy processes.
+- Pairing is on before the first start, and startup fails with an actionable
+  error instead of publishing an HTTP device link when HTTPS cannot start.
 
 ## Exercise one real voice turn
 
@@ -83,6 +87,9 @@ Pass criteria:
 Pass criteria:
 
 - the device sees the same live lane and activity state as the Mac app;
+- the device URL is `https://`, contains a pairing token in its fragment, and
+  hold-to-speak can obtain microphone permission in the secure context;
+- an unpaired copy of the URL cannot read snapshot, audio, or WebSocket data;
 - dictation and responses remain synchronized with the real Codex task;
 - reconnecting the page resumes the same lane rather than creating a new one.
 

--- a/src/cli/deck.ts
+++ b/src/cli/deck.ts
@@ -262,7 +262,16 @@ interface DeckHandle {
   exited: Promise<number | null>;
 }
 
-function findCaddy(): string | null {
+/** Prefer the release-bundled Caddy beside the compiled runtime, then fall
+ * back to PATH for source/development runs. */
+export function findCaddy(runtimeExecutable = process.execPath): string | null {
+  const bundled = path.join(path.dirname(runtimeExecutable), 'caddy');
+  try {
+    const stat = lstatSync(bundled);
+    if (stat.isFile() && (stat.mode & 0o111) !== 0) return bundled;
+  } catch {
+    // Not running from the signed app bundle; try the developer's PATH.
+  }
   const res = spawnSync('which', ['caddy'], { encoding: 'utf8' });
   return res.status === 0 ? res.stdout.trim() : null;
 }
@@ -451,8 +460,8 @@ function proxyDataRequest(req: IncomingMessage, res: ServerResponse, live: LiveP
   req.pipe(upstream);
 }
 
-/** Zero-dependency server and same-origin live-runtime proxy. Caddy remains an
- * optional HTTPS upgrade, not an installation requirement. */
+/** Zero-dependency server and same-origin live-runtime proxy. This is an
+ * explicit development fallback (`--no-tls`), not the production LAN path. */
 export async function startNodeServer(root: string, port: number, live: LiveProxy | null): Promise<DeckHandle> {
   const proxyWss = new WebSocketServer({ noServer: true });
   const server = createServer(async (req, res) => {
@@ -564,15 +573,15 @@ export async function startNodeServer(root: string, port: number, live: LiveProx
 
 /** Bridge defaults from ~/.config/speakeasy/settings.json — the settings app's
  * Deck tab writes these; CLI flags always win over config. */
-function deckConfigDefaults(): { port: number | null; pair: boolean } {
+export function deckConfigDefaults(configFile = CONFIG_FILE): { port: number | null; pair: boolean } {
   try {
-    const raw = JSON.parse(readFileSync(CONFIG_FILE, 'utf8')) as {
+    const raw = JSON.parse(readFileSync(configFile, 'utf8')) as {
       deck?: { port?: unknown; pair?: unknown };
     };
     const port = typeof raw.deck?.port === 'number' && raw.deck.port > 0 && raw.deck.port <= 65535 ? raw.deck.port : null;
-    return { port, pair: raw.deck?.pair === true };
+    return { port, pair: raw.deck?.pair !== false };
   } catch {
-    return { port: null, pair: false };
+    return { port: null, pair: true };
   }
 }
 
@@ -680,16 +689,25 @@ export async function runDeck(argv: string[]): Promise<void> {
   const { qr, host, mdns } = args;
   const caddy = args.caddy ? findCaddy() : null;
 
-  // HTTPS on :443 with Caddy's local CA when we can — browsers only grant mic
-  // (hold-to-speak) in a secure context. Independent of the HTTP port.
-  // Caddy can carry the platform-specific permission needed for 443 even when
-  // the embedded Node/Bun data plane must stay on an unprivileged port.
-  const tlsHost = args.tls && caddy && (await portAvailable(443, true)) ? host : null;
+  // HTTPS is a production invariant for browser/iPad voice: browsers only
+  // grant mic access in a secure context. Never silently downgrade a requested
+  // TLS launch to HTTP. `--no-tls` is the explicit local-development escape.
+  if (args.tls && !caddy) {
+    console.error('❌ Secure Deck startup requires the bundled Caddy helper.');
+    console.error('   Reinstall SpeakEasy, or use --no-tls --no-caddy for local development only.');
+    process.exit(1);
+  }
+  if (args.tls && !(await portAvailable(443, true))) {
+    console.error('❌ Secure Deck startup could not claim HTTPS port 443.');
+    console.error('   Stop the service using port 443, then start the Deck again.');
+    process.exit(1);
+  }
+  const tlsHost = args.tls ? host : null;
   const caCert = tlsHost ? (caddyRootCert(true) ?? null) : null;
 
   // The data plane runs loopback-only on port+1ish; Caddy proxies /ws and
-  // /api/* to it same-origin. Open on the local network by default; --pair
-  // gates both routes behind the persistent capability token.
+  // /api/* to it same-origin. Pairing is on by default and gates both routes
+  // behind a persistent capability token; --no-pair is an explicit override.
   const token = args.pair ? deckToken(args.rotateToken) : null;
   let dataPort: number | null = null;
   for (let candidate = port + 1; candidate <= Math.min(port + 5, 65535); candidate++) {
@@ -707,6 +725,11 @@ export async function runDeck(argv: string[]): Promise<void> {
   } catch (error) {
     if (!caddy) {
       console.error('❌ Could not start the deck server:', (error as Error).message);
+      process.exit(1);
+    }
+    if (args.tls) {
+      console.error('❌ Secure Deck startup failed:', (error as Error).message);
+      console.error('   SpeakEasy did not fall back to insecure HTTP.');
       process.exit(1);
     }
     console.error(`  ⚠️  Caddy failed (${(error as Error).message}) — falling back to the built-in live server.`);
@@ -746,7 +769,8 @@ export async function runDeck(argv: string[]): Promise<void> {
     : bonjour
       ? hostUrl(bonjour, port)
       : `http://${lan ?? 'your-macs-ip'}:${port}`);
-  // pair mode: the capability token travels in the URL fragment — never on the wire
+  // Pair mode bootstraps from a URL fragment (omitted from the initial request),
+  // then sends the capability only inside same-origin HTTPS API/WS requests.
   const padUrl = dataPlane && token ? `${padUrlBase}#k=${token}` : padUrlBase;
 
   // the settings app discovers the deck through this file — the canonical URL

--- a/tests/deck-server.test.ts
+++ b/tests/deck-server.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, expect, test } from 'bun:test';
 import { createServer } from 'node:http';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { WebSocket, WebSocketServer } from 'ws';
 
-import { acquireDeckProcessLock, portAvailable, startNodeServer } from '../src/cli/deck';
+import { acquireDeckProcessLock, deckConfigDefaults, findCaddy, portAvailable, startNodeServer } from '../src/cli/deck';
 
 const cleanups: Array<() => Promise<void> | void> = [];
 
@@ -114,4 +114,29 @@ test('deck process lock rejects a second owner and releases safely', async () =>
   const third = acquireDeckProcessLock(lockFile);
   expect(third.acquired).toBe(true);
   third.release();
+});
+
+test('release runtime resolves the bundled Caddy helper before PATH', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'speakeasy-deck-caddy-test-'));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  const runtime = path.join(root, 'speakeasy-runtime');
+  const caddy = path.join(root, 'caddy');
+  await writeFile(runtime, 'runtime');
+  await writeFile(caddy, '#!/bin/sh\nexit 0\n');
+  await chmod(caddy, 0o755);
+
+  expect(findCaddy(runtime)).toBe(caddy);
+});
+
+test('pairing defaults on and preserves an explicit opt-out', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'speakeasy-deck-config-test-'));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  const missing = path.join(root, 'missing.json');
+  expect(deckConfigDefaults(missing)).toEqual({ port: null, pair: true });
+
+  const config = path.join(root, 'settings.json');
+  await writeFile(config, JSON.stringify({ deck: { port: 43211 } }));
+  expect(deckConfigDefaults(config)).toEqual({ port: 43211, pair: true });
+  await writeFile(config, JSON.stringify({ deck: { pair: false } }));
+  expect(deckConfigDefaults(config)).toEqual({ port: null, pair: false });
 });


### PR DESCRIPTION
## Summary
- bundle pinned Caddy 2.11.4 from its official release with checksum verification and license notice
- sign and audit the nested helper in app/DMG release workflows
- resolve the bundled helper before PATH, default pairing on, and fail closed instead of silently downgrading requested TLS
- align setup, CLI, GTM, and clean-machine guidance with the paired HTTPS contract

## Validation
- `bun test` (59 pass)
- `bun run build`
- `swift test` (57 pass)
- `bash -n app/tools/release/common.sh app/tools/release/sign-bundle.sh app/tools/release/verify-dmg.sh`
- built, Developer-ID signed, installed, and relaunched `/Applications/SpeakEasy.app`
- bundled Caddy reports `v2.11.4`; HTTPS health check passes on `:443`
- live discovery is HTTPS + paired; unpaired `/api/snapshot` returns 403 and paired returns 200
