### PR TITLE
Pin release helper integrity and correct preview claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Paste this bounded task into Codex Desktop:
 > https://speakeasy.arach.dev/agent.md and follow Path A. Do not build from
 > source or bypass Gatekeeper. Tell me which human-only steps remain.
 
-The current `0.2.18` build is an immutable self-serve core preview. It remains
-a GitHub prerelease permanently; the first public **Latest** train is `0.2.19`
-after the clean second-Mac, device-path, and observer/presenter gates pass.
+The current `0.2.18` build is an immutable self-serve **Mac core** preview. Do
+not use it to evaluate the browser/iPad path. It remains a GitHub prerelease
+permanently; the first public **Latest** train is `0.2.19` after the clean
+second-Mac, paired-HTTPS device, and observer/presenter gates pass.
 See [SpeakEasy for Codex](https://speakeasy.arach.dev/codex/) for the product
 loop and [`docs/release/self-serve-mac-test.md`](docs/release/self-serve-mac-test.md)
 for the clean-machine proof.

--- a/app/Sources/SpeakEasy/CodexThreadRouter.swift
+++ b/app/Sources/SpeakEasy/CodexThreadRouter.swift
@@ -196,7 +196,7 @@ actor CodexThreadRouter {
            FileManager.default.isReadableFile(atPath: override) {
             return URL(fileURLWithPath: override)
         }
-        return Bundle.module.url(forResource: "codex-desktop-bridge", withExtension: "cjs")
+        return SpeakEasyResources.url(forResource: "codex-desktop-bridge", withExtension: "cjs")
     }
 
     private static func resolveJavaScriptRuntime() -> URL? {

--- a/app/Sources/SpeakEasy/SpeakEasyPadHost.swift
+++ b/app/Sources/SpeakEasy/SpeakEasyPadHost.swift
@@ -189,7 +189,7 @@ final class SpeakEasyPadLANRuntime {
         if let override = ProcessInfo.processInfo.environment["SPEAKEASY_PAD_WEB_ROOT"] {
             return URL(fileURLWithPath: override, isDirectory: true)
         }
-        return Bundle.module.resourceURL?.appendingPathComponent("Pad", isDirectory: true)
+        return SpeakEasyResources.resourceURL?.appendingPathComponent("Pad", isDirectory: true)
     }
 
     private static func makeLiveCoordinator() -> SpeakEasyPadRemoteCoordinator {

--- a/app/Sources/SpeakEasy/SpeakEasyResources.swift
+++ b/app/Sources/SpeakEasy/SpeakEasyResources.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// SwiftPM's generated accessor for an executable looks beside the executable
+/// bundle and then falls back to an absolute `.build` path. SpeakEasy wraps the
+/// executable in a hand-built macOS app, where resources correctly live in
+/// `Contents/Resources`. Resolve that release location first so a clean Mac
+/// never depends on the developer checkout embedded at compile time.
+enum SpeakEasyResources {
+    private static let bundleName = "SpeakEasy_SpeakEasy"
+
+    static var bundle: Bundle? {
+        if let resourceURL = Bundle.main.resourceURL,
+           let packaged = Bundle(
+                url: resourceURL.appendingPathComponent("\(bundleName).bundle", isDirectory: true)
+           ) {
+            return packaged
+        }
+        return Bundle.module
+    }
+
+    static func url(forResource name: String, withExtension extensionName: String?) -> URL? {
+        bundle?.url(forResource: name, withExtension: extensionName)
+    }
+
+    static var resourceURL: URL? { bundle?.resourceURL }
+}

--- a/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
+++ b/app/Tests/SpeakEasyTests/PlayerProtocolTests.swift
@@ -445,6 +445,15 @@ final class PlayerProtocolTests: XCTestCase {
         XCTAssertNil(CodexTaskLink.url(threadId: ""))
     }
 
+    func testPackagedResourceResolverFindsTheCodexBridge() {
+        let bridge = SpeakEasyResources.url(
+            forResource: "codex-desktop-bridge",
+            withExtension: "cjs"
+        )
+        XCTAssertNotNil(bridge)
+        XCTAssertTrue(FileManager.default.isReadableFile(atPath: bridge?.path ?? ""))
+    }
+
     @MainActor
     func testPlayerSettingsClampToSupportedRanges() {
         let engine = PlaybackEngine.shared

--- a/app/tools/release/common.sh
+++ b/app/tools/release/common.sh
@@ -23,7 +23,28 @@ speakeasy_caddy_version() {
     echo "2.11.4"
 }
 
-speakeasy_verify_caddy_binary() {
+speakeasy_caddy_archive_sha256() {
+    echo "9efb0af2d6cf09cfb5053c0e51721b9b3d4956d346234f39368d943d25a3c9a7"
+}
+
+speakeasy_caddy_binary_sha256() {
+    echo "e9ebf99dfd4b72259debe1830c83e86c63fb89a88e28b4e7c5e78a35fa76c92d"
+}
+
+speakeasy_verify_sha256() {
+    local file_path="$1"
+    local expected="$2"
+    local label="$3"
+    local actual
+
+    actual="$(shasum -a 256 "$file_path" | awk '{ print $1 }')"
+    if [ "$actual" != "$expected" ]; then
+        echo "$label SHA-256 mismatch: expected $expected, found $actual" >&2
+        return 1
+    fi
+}
+
+speakeasy_verify_caddy_identity() {
     local candidate="$1"
     local expected_version="$2"
     local actual_version
@@ -45,9 +66,21 @@ speakeasy_verify_caddy_binary() {
     fi
 }
 
+speakeasy_verify_caddy_source() {
+    local candidate="$1"
+    local expected_version="$2"
+
+    speakeasy_verify_caddy_identity "$candidate" "$expected_version"
+    speakeasy_verify_sha256 \
+        "$candidate" \
+        "$(speakeasy_caddy_binary_sha256)" \
+        "Caddy $expected_version binary"
+}
+
 # Resolve a reproducible arm64 Caddy helper for the release bundle. An explicit
 # path wins; otherwise use a matching PATH binary or fetch the pinned official
-# GitHub release and verify it against the publisher's checksum manifest.
+# GitHub release and verify both the archive and extracted binary against
+# immutable SHA-256 digests pinned in this source tree.
 speakeasy_prepare_caddy() {
     local app_root="$1"
     local version="$(speakeasy_caddy_version)"
@@ -58,7 +91,6 @@ speakeasy_prepare_caddy() {
     local archive_name
     local release_url
     local temp_dir
-    local checksum
 
     version="${version#v}"
     cached="$tools_dir/caddy-$version"
@@ -66,7 +98,7 @@ speakeasy_prepare_caddy() {
     release_url="https://github.com/caddyserver/caddy/releases/download/v${version}"
 
     if [ -n "$override" ]; then
-        if ! speakeasy_verify_caddy_binary "$override" "$version"; then
+        if ! speakeasy_verify_caddy_source "$override" "$version"; then
             echo "SPEAKEASY_CADDY_PATH must point to the pinned release helper." >&2
             return 1
         fi
@@ -75,12 +107,12 @@ speakeasy_prepare_caddy() {
     fi
 
     candidate="$(command -v caddy 2>/dev/null || true)"
-    if [ -n "$candidate" ] && speakeasy_verify_caddy_binary "$candidate" "$version" >/dev/null 2>&1; then
+    if [ -n "$candidate" ] && speakeasy_verify_caddy_source "$candidate" "$version" >/dev/null 2>&1; then
         echo "$candidate"
         return 0
     fi
 
-    if speakeasy_verify_caddy_binary "$cached" "$version" >/dev/null 2>&1; then
+    if speakeasy_verify_caddy_source "$cached" "$version" >/dev/null 2>&1; then
         echo "$cached"
         return 0
     fi
@@ -94,16 +126,16 @@ speakeasy_prepare_caddy() {
     temp_dir="$(mktemp -d)"
     echo "Fetching pinned Caddy v$version for the secure Deck..." >&2
     if ! curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
-        "$release_url/$archive_name" -o "$temp_dir/$archive_name" \
-        || ! curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
-        "$release_url/caddy_${version}_checksums.txt" -o "$temp_dir/checksums.txt"; then
+        "$release_url/$archive_name" -o "$temp_dir/$archive_name"; then
         rm -rf "$temp_dir"
         echo "Could not download the pinned Caddy release." >&2
         return 1
     fi
 
-    checksum="$(awk -v archive="$archive_name" '$2 == archive { print $1; exit }' "$temp_dir/checksums.txt")"
-    if [ -z "$checksum" ] || ! (cd "$temp_dir" && printf '%s  %s\n' "$checksum" "$archive_name" | shasum -a 256 -c - >/dev/null); then
+    if ! speakeasy_verify_sha256 \
+        "$temp_dir/$archive_name" \
+        "$(speakeasy_caddy_archive_sha256)" \
+        "Caddy $version archive"; then
         rm -rf "$temp_dir"
         echo "Caddy archive checksum verification failed." >&2
         return 1
@@ -115,7 +147,7 @@ speakeasy_prepare_caddy() {
         return 1
     fi
     chmod +x "$temp_dir/caddy"
-    if ! speakeasy_verify_caddy_binary "$temp_dir/caddy" "$version"; then
+    if ! speakeasy_verify_caddy_source "$temp_dir/caddy" "$version"; then
         rm -rf "$temp_dir"
         return 1
     fi
@@ -240,7 +272,7 @@ speakeasy_verify_bundle_layout() {
         return 1
     fi
 
-    if ! speakeasy_verify_caddy_binary "$caddy_helper" "$(speakeasy_caddy_version)"; then
+    if ! speakeasy_verify_caddy_source "$caddy_helper" "$(speakeasy_caddy_version)"; then
         echo "Bundled secure Deck helper is invalid: $caddy_helper" >&2
         return 1
     fi
@@ -254,6 +286,15 @@ speakeasy_verify_bundle_layout() {
         echo "Bundled Caddy license notice is missing." >&2
         return 1
     fi
+
+    for resource in \
+        "$resources_dir/SpeakEasy_SpeakEasy.bundle/codex-desktop-bridge.cjs" \
+        "$resources_dir/SpeakEasy_SpeakEasy.bundle/Pad/index.html"; do
+        if [ ! -s "$resource" ]; then
+            echo "SwiftPM runtime resource is missing from Contents/Resources: $resource" >&2
+            return 1
+        fi
+    done
 
     if find "$bundle_path/Contents/MacOS" -maxdepth 1 -type d -name '*.framework' -print -quit \
         | grep -q .; then

--- a/app/tools/release/verify-dmg.sh
+++ b/app/tools/release/verify-dmg.sh
@@ -44,8 +44,9 @@ EXECUTABLE="$APP/Contents/MacOS/SpeakEasy"
 HELPER="$APP/Contents/Helpers/speakeasy-runtime"
 CADDY="$APP/Contents/Helpers/caddy"
 PLIST="$APP/Contents/Info.plist"
+CODEX_BRIDGE="$APP/Contents/Resources/SpeakEasy_SpeakEasy.bundle/codex-desktop-bridge.cjs"
 
-for path in "$APP" "$EXECUTABLE" "$HELPER" "$CADDY" "$PLIST"; do
+for path in "$APP" "$EXECUTABLE" "$HELPER" "$CADDY" "$PLIST" "$CODEX_BRIDGE"; do
     if [ ! -e "$path" ]; then
         echo "Error: Release payload is missing $path" >&2
         exit 1
@@ -84,7 +85,8 @@ case " $CADDY_ARCHS " in
     *) echo "Error: Caddy helper is missing arm64: $CADDY_ARCHS" >&2; exit 1 ;;
 esac
 
-speakeasy_verify_caddy_binary "$CADDY" "$(speakeasy_caddy_version)"
+speakeasy_verify_caddy_identity "$CADDY" "$(speakeasy_caddy_version)"
+codesign --verify --strict --verbose=2 "$CADDY"
 
 if otool -L "$EXECUTABLE" | awk 'NR > 1 { print $1 }' | grep -Ev '^(@rpath/|/System/Library/|/usr/lib/)' | grep -q .; then
     echo "Error: App contains a non-portable dynamic-library reference:" >&2

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -72,10 +72,10 @@ fails closed instead of selecting another task.
 
 ## Release status
 
-The signed `0.2.18` build is a self-serve preview. It remains a prerelease
-until the clean second-Mac and device-path acceptance gate passes. The native
-iPad shell is a developer preview; the browser/PWA is the supported companion
-surface for the first public release.
+The signed `0.2.18` build is an immutable Mac core preview; it is not the
+supported browser/iPad build. The paired-HTTPS browser/PWA path begins with the
+signed `0.2.19` candidate after its clean second-Mac and real-device gate. The
+native iPad shell remains a developer preview.
 
 See [the GTM control plan](https://github.com/arach/SpeakEasy/blob/master/docs/release/gtm.md)
 for the launch sequence and

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -24,6 +24,11 @@ Paste this bounded task into Codex Desktop:
 > https://speakeasy.arach.dev/agent.md and follow Path A. Do not build from
 > source or bypass Gatekeeper. Tell me which human-only steps remain.
 
+`0.2.18` is the immutable Mac core preview. Use it to prove exact-task
+dictation and narration on that Mac; do not use it to evaluate the browser/iPad
+path. The first supported paired-HTTPS device build is the signed `0.2.19`
+candidate described in the launch plan.
+
 Codex downloads and inspects the pinned installer. The installer verifies the
 published checksum, Gatekeeper acceptance, Developer ID team, bundle identity,
 and exact app version before replacing `/Applications/SpeakEasy.app`. It then
@@ -40,9 +45,10 @@ SpeakEasy checkout.
 4. Confirm the dictation appears once in that same Codex task.
 5. Hear the task's real response and try replay, speed, or volume.
 
-Open the shown device link on another Mac or iPad to use the same live lanes.
-For the first public release, the browser/PWA is the supported device path; the
-native iPad shell remains a developer preview.
+With `0.2.19` or current source, install and trust the one-time local CA from the
+shown bootstrap link, then open the paired HTTPS device link on another Mac or
+iPad. For the first public release, the browser/PWA is the supported device
+path; the native iPad shell remains a developer preview.
 
 See [Listening mode](listening-mode.mdx) for routing and privacy details.
 

--- a/docs/release/self-serve-mac-test.md
+++ b/docs/release/self-serve-mac-test.md
@@ -76,13 +76,18 @@ Pass criteria:
 - narration comes from the configured system/OpenAI/ElevenLabs voice;
 - replay, stop, speed, and volume operate on the returned audio.
 
-## Exercise the device path
+## Exercise the device path (`0.2.19` only)
 
-1. Open the QR/device link from another Mac on the same Wi-Fi.
-2. Select the same lane and confirm its project, branch, and recent activity.
-3. Complete another hold-to-speak turn.
-4. If using an iPad, install and trust the local Caddy certificate once, then
-   add the Deck to the Home Screen.
+Do not run this section against `0.2.18`; its device path predates the bundled
+TLS and pairing-default fix.
+
+1. From the Mac's Deck settings, copy the one-time certificate trust link.
+2. On the iPad, open that HTTP bootstrap link, install the local Caddy profile,
+   then enable **Caddy Local Authority** in **Settings → General → About →
+   Certificate Trust Settings**.
+3. Only after trust is enabled, scan or open the paired HTTPS Deck link.
+4. Select the same lane and confirm its project, branch, and recent activity.
+5. Complete another hold-to-speak turn, then add the Deck to the Home Screen.
 
 Pass criteria:
 

--- a/landing/app/codex/page.tsx
+++ b/landing/app/codex/page.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/button"
 import CodexInstallPrompt from "@/components/codex-install-prompt"
 import SiteFooter from "@/components/site-footer"
 import SiteNav from "@/components/site-nav"
-import { releaseDownloadUrl, releaseRequirements, releaseVersion } from "@/lib/release"
+import { launchVersion, releaseDownloadUrl, releaseRequirements, releaseVersion } from "@/lib/release"
 
 export const metadata: Metadata = {
   title: "SpeakEasy for Codex",
@@ -44,7 +44,7 @@ export default function CodexPage() {
         <div className="relative mx-auto grid max-w-6xl items-center gap-14 lg:grid-cols-[1fr_0.92fr]">
           <div>
             <Badge variant="outline" className="rounded-xl border-emerald-200 bg-white/80 text-emerald-700">
-              SpeakEasy {releaseVersion} · dual mode
+              SpeakEasy {launchVersion} launch candidate · dual mode
             </Badge>
             <h1 className="mt-6 font-display text-5xl font-extralight leading-[0.98] tracking-tight text-slate-900 sm:text-6xl md:text-7xl">
               One voice.
@@ -205,7 +205,7 @@ export default function CodexPage() {
           <article className="rounded-3xl border border-emerald-200/70 bg-emerald-50/45 p-8 shadow-lg shadow-emerald-900/5">
             <div className="flex items-center justify-between gap-4">
               <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-amber-100 text-amber-700"><Mic2 className="h-5 w-5" /></div>
-              <Badge variant="outline" className="rounded-xl border border-emerald-200 bg-white/70 text-emerald-700">Included in {releaseVersion}</Badge>
+              <Badge variant="outline" className="rounded-xl border border-emerald-200 bg-white/70 text-emerald-700">Mac in {releaseVersion} · secure devices in {launchVersion}</Badge>
             </div>
             <h2 className="mt-7 font-display text-3xl font-medium text-slate-900">Listen · local ASR</h2>
             <p className="mt-3 text-sm leading-6 text-slate-600">

--- a/landing/components/agent-voice-section.tsx
+++ b/landing/components/agent-voice-section.tsx
@@ -4,9 +4,10 @@ import { useState } from "react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Check, Copy, ExternalLink, MonitorSpeaker, Terminal } from "lucide-react"
+import { releaseVersion } from "@/lib/release"
 
 const agentPrompt = `Read https://speakeasy.arach.dev/agent.md and follow it.`
-const codexPrompt = `Install SpeakEasy 0.2.18 on this Mac. Read https://speakeasy.arach.dev/agent.md and follow Path A. Do not build from source or bypass Gatekeeper. Tell me which human-only steps remain.`
+const codexPrompt = `Install SpeakEasy ${releaseVersion} on this Mac. Read https://speakeasy.arach.dev/agent.md and follow Path A. Do not build from source or bypass Gatekeeper. Tell me which human-only steps remain.`
 
 function CopyPrompt({
   payload,
@@ -87,7 +88,7 @@ export default function AgentVoiceSection() {
               </span>
             </h2>
             <p className="font-text text-lg text-slate-600 max-w-2xl mx-auto font-light">
-              You don't wire anything up — your coding agent does. Copy a prompt, paste it in, then listen from the deck on your iPad.
+              You don't wire anything up — your coding agent does. The current signed preview proves the Mac loop; paired browser and iPad setup joins the signed 0.2.19 candidate.
             </p>
           </div>
 

--- a/landing/components/codex-install-prompt.tsx
+++ b/landing/components/codex-install-prompt.tsx
@@ -30,12 +30,12 @@ export default function CodexInstallPrompt() {
     <section id="codex-install" className="overflow-hidden rounded-3xl border border-slate-200/80 bg-white shadow-xl shadow-slate-900/5">
       <header className="border-b border-slate-100 px-5 py-5 sm:px-7 sm:py-6">
         <div className="flex items-center gap-2">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-700">Codex install</span>
+          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-700">Codex install · Mac core preview</span>
           <span className="font-mono text-[10px] text-slate-400">v{releaseVersion}</span>
         </div>
         <h3 className="mt-2 font-display text-2xl font-medium tracking-tight text-slate-900">Paste once.</h3>
         <p className="mt-1.5 max-w-xl text-sm leading-6 text-slate-500">
-          Codex downloads the pinned installer, inspects it, verifies every trust boundary, replaces the app safely, finishes setup, and launches SpeakEasy.
+          Codex downloads the pinned Mac preview, inspects it, verifies every trust boundary, replaces the app safely, finishes setup, and launches SpeakEasy. Use the signed 0.2.19 candidate for browser or iPad testing.
         </p>
       </header>
 

--- a/landing/components/download-section.tsx
+++ b/landing/components/download-section.tsx
@@ -29,11 +29,11 @@ export default function DownloadSection() {
             <h2 className="mt-6 max-w-3xl font-display text-5xl font-extralight leading-[0.98] tracking-tight sm:text-6xl">
               Download the complete
               <span className="block bg-gradient-to-r from-emerald-300 to-blue-300 bg-clip-text text-transparent">
-                Codex voice loop.
+                Mac core preview.
               </span>
             </h2>
             <p className="mt-6 max-w-2xl text-lg font-light leading-8 text-white/58">
-              No repository, Bun, Xcode, or server setup. Give Codex one bounded installation task; it verifies and opens the notarized app, then tells you exactly which human permissions remain.
+              No repository, Bun, Xcode, or server setup. Give Codex one bounded installation task; it verifies and opens the notarized app, then tells you exactly which human permissions remain. The paired browser/iPad build begins with 0.2.19.
             </p>
 
             <div className="mt-9 flex flex-col gap-3 sm:flex-row">

--- a/landing/lib/release.ts
+++ b/landing/lib/release.ts
@@ -1,4 +1,5 @@
 export const releaseVersion = "0.2.18"
+export const launchVersion = "0.2.19"
 
 const releaseRoot = `https://github.com/arach/SpeakEasy/releases/download/v${releaseVersion}`
 

--- a/landing/public/agent.md
+++ b/landing/public/agent.md
@@ -8,9 +8,11 @@
 
 ## Path A — full Codex voice loop (recommended on Apple silicon Macs)
 
-Use this when the user asks to install the native app, use dictation, connect an
-iPad/browser Deck, or speak with a real Codex task. Release `0.2.18` requires an
-Apple silicon Mac running macOS 14 or newer.
+Use this when the user asks to install the native app, use Mac dictation, or
+speak with a real Codex task. Release `0.2.18` is an immutable core preview for
+an Apple silicon Mac running macOS 14 or newer. **Do not present its browser or
+iPad Deck as the supported device path.** That path begins with `0.2.19`, whose
+bundled paired-HTTPS transport must pass the public clean-device gate first.
 
 Download the pinned installer to a temporary file. **Inspect it before running;
 do not pipe a network response directly into a shell.**
@@ -34,9 +36,10 @@ The installer must pass all of these before it changes `/Applications`:
 - exact app version `0.2.18`.
 
 It then opens **SpeakEasy Settings → Deck**. Report which checklist rows are
-ready and which human-only steps remain. The user—not the agent—approves
-microphone and local-network permissions. Do not bypass Gatekeeper, remove
-quarantine attributes, install a floating `latest` build, or build from source.
+ready and which human-only steps remain, but keep the `0.2.18` acceptance run on
+the Mac. The user—not the agent—approves microphone and local-network
+permissions. Do not bypass Gatekeeper, remove quarantine attributes, install a
+floating `latest` build, or build from source.
 
 ## Path B — TTS CLI only (Node.js 22.12+ or Bun 1.0+)
 
@@ -86,16 +89,17 @@ session so it scans the skill, and follow the SKILL.md. Use Path A for the
 full dual-mode app instead of relying on the older CLI app bootstrap.
 (`speakeasy plugin claude` installs the same skill for Claude Code.)
 
-## The deck (only when the user asks)
+## The Deck (developer/source use until 0.2.19)
 
 ```bash
 npx @arach/speakeasy deck
 ```
 
-Leave the process running. It serves the SpeakEasy control surface on the local
-network and prints a QR code — the user scans it with an iPad and pins the page
-to their Home Screen. Ctrl+C stops the server. Themes ride in the URL:
-`?theme=paper|ember|flight`.
+Do not use the `0.2.18` packaged app for this path. In current source or the
+signed `0.2.19` candidate, leave the process running. It serves the paired
+HTTPS control surface on the local network and prints the certificate-bootstrap
+link plus QR code. Trust the local CA on the iPad first, then scan the HTTPS QR
+and pin the page to the Home Screen. Ctrl+C stops the server.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary
- pin immutable SHA-256 values for the official Caddy archive and extracted arm64 helper
- verify every source candidate, including PATH, override, and cached binaries, before signing
- resolve SwiftPM resources from `Contents/Resources` so clean installs never fall through to an embedded developer `.build` path
- separate the immutable 0.2.18 Mac core preview from the 0.2.19 paired browser/iPad launch in public onboarding
- put iPad certificate trust before the first HTTPS Deck connection

## Validation
- fresh official Caddy download verified against pinned archive and binary SHA-256 values
- `bun test` (59 pass)
- `bun run build`
- `swift test` (58 pass)
- landing `bun run build` (27 pages)
- built, Developer-ID signed, installed, and relaunched the app
- clean app layout has packaged bridge under `Contents/Resources`, no unsealed root resources, and passes deep strict codesign
- live Deck discovery remains paired HTTPS
