### PR TITLE
🔒 Pair direct iPad installs without system trust

### DIFF
--- a/deck/ipad/README.md
+++ b/deck/ipad/README.md
@@ -43,7 +43,12 @@ xcodebuild -project SpeakEasyDeck.xcodeproj -scheme SpeakEasyDeck \
 ```
 
 `build-device.sh` prefers a device whose name contains "iPad"; pin one with
-`SPEAKEASY_DEVICE_ID` (cached in `.device-id.local`).
+`SPEAKEASY_DEVICE_ID` (cached in `.device-id.local`). When a paired HTTPS Deck
+is already running, the script also provisions that exact connection into the
+iPad app: the paired URL and this Mac's public Caddy trust anchor travel over
+the Xcode device channel, then move into this-device-only Keychain storage.
+The app validates only that paired host, so the direct developer install needs
+no certificate profile and remains connected when it is opened normally later.
 
 ## Layout
 

--- a/deck/ipad/Sources/DeckDiscovery.swift
+++ b/deck/ipad/Sources/DeckDiscovery.swift
@@ -1,5 +1,69 @@
 import Foundation
 import Combine
+import Security
+
+/// Developer-installed builds can be provisioned with the exact paired Deck
+/// URL and its private CA anchor at launch. The secret-bearing URL is copied
+/// into this-device-only Keychain storage so tapping the app later reconnects
+/// to the same Mac without a profile install or another Xcode launch.
+enum DeckProvisioning {
+    private static let service = "dev.arach.speakeasy.deck.provisioning"
+    private static let urlAccount = "paired-url-v1"
+    private static let rootAccount = "paired-root-der-v1"
+
+    static func importLaunchEnvironment() {
+        let environment = ProcessInfo.processInfo.environment
+        guard let rawURL = environment["SPEAKEASY_DECK_URL"],
+              let url = URL(string: rawURL),
+              url.scheme == "https",
+              url.host != nil,
+              let root = environment["SPEAKEASY_DECK_ROOT_DER"],
+              Data(base64Encoded: root) != nil else { return }
+        save(rawURL, account: urlAccount)
+        save(root, account: rootAccount)
+    }
+
+    static var pairedURL: URL? {
+        guard let raw = load(account: urlAccount),
+              let url = URL(string: raw),
+              url.scheme == "https",
+              url.host != nil else { return nil }
+        return url
+    }
+
+    static var trustAnchor: SecCertificate? {
+        guard let encoded = load(account: rootAccount),
+              let data = Data(base64Encoded: encoded) else { return nil }
+        return SecCertificateCreateWithData(nil, data as CFData)
+    }
+
+    private static func save(_ value: String, account: String) {
+        let match: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(match as CFDictionary)
+        var item = match
+        item[kSecValueData as String] = Data(value.utf8)
+        item[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        SecItemAdd(item as CFDictionary, nil)
+    }
+
+    private static func load(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}
 
 struct DiscoveredDeck: Identifiable, Hashable {
     let id: String
@@ -33,7 +97,20 @@ final class DeckDiscovery: NSObject, ObservableObject, NetServiceBrowserDelegate
     override init() {
         super.init()
         browser.delegate = self
-        startSearch()
+        DeckProvisioning.importLaunchEnvironment()
+        if let url = DeckProvisioning.pairedURL {
+            let host = url.host ?? "Mac"
+            let deck = DiscoveredDeck(
+                id: "provisioned|\(host)",
+                serviceName: "SpeakEasy Deck (\(host))",
+                url: url
+            )
+            decks = [deck]
+            selectedDeck = deck
+            searching = false
+        } else {
+            startSearch()
+        }
     }
 
     var deckURL: URL? { selectedDeck?.url }

--- a/deck/ipad/Sources/DeckWebView.swift
+++ b/deck/ipad/Sources/DeckWebView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import WebKit
+import Security
+import OSLog
 
 /// The deck's web surface with the native speech bridge attached.
 ///
@@ -10,6 +12,7 @@ import WebKit
 final class DeckWebController: NSObject, ObservableObject, WKNavigationDelegate, WKScriptMessageHandler {
     let webView: WKWebView
     let capture = SpeechCapture()
+    private let logger = Logger(subsystem: "dev.arach.speakeasy.deck", category: "web-surface")
 
     var deckURL: URL? {
         didSet { loadIfNeeded() }
@@ -46,6 +49,38 @@ final class DeckWebController: NSObject, ObservableObject, WKNavigationDelegate,
         // the deck page ships with the server build — never let a stale
         // WKWebView cache hold an old copy
         webView.load(URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData))
+    }
+
+    /// A direct Xcode install carries this Mac's public CA anchor in the app's
+    /// Keychain. Trust remains scoped to this WKWebView and this paired host;
+    /// it never changes the iPad's system trust settings.
+    func webView(
+        _ webView: WKWebView,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let trust = challenge.protectionSpace.serverTrust,
+              let pairedHost = deckURL?.host,
+              challenge.protectionSpace.host.caseInsensitiveCompare(pairedHost) == .orderedSame,
+              let anchor = DeckProvisioning.trustAnchor else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        SecTrustSetAnchorCertificates(trust, [anchor] as CFArray)
+        SecTrustSetAnchorCertificatesOnly(trust, true)
+        var error: CFError?
+        guard SecTrustEvaluateWithError(trust, &error) else {
+            logger.error("Rejected paired Deck certificate: \(error?.localizedDescription ?? "unknown trust error", privacy: .public)")
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        logger.error("Deck navigation failed: \(error.localizedDescription, privacy: .public)")
     }
 
     // JS → native: capture phases from the page's host bridge

--- a/deck/ipad/build-device.sh
+++ b/deck/ipad/build-device.sh
@@ -7,6 +7,8 @@ SCHEME="SpeakEasyDeck"
 DERIVED_DATA="$ROOT/.derived-data"
 DEVICE_CACHE="$ROOT/.device-id.local"
 BUNDLE_ID="dev.arach.speakeasy.deck"
+DISCOVERY_FILE="$HOME/.config/speakeasy/deck-listener.json"
+CADDY_ROOT="$HOME/Library/Application Support/Caddy/pki/authorities/local/root.crt"
 
 resolve_device_id() {
   if [[ -n "${SPEAKEASY_DEVICE_ID:-}" ]]; then
@@ -47,4 +49,36 @@ echo "==> installing $APP_PATH"
 xcrun devicectl device install app --device "$DEVICE_ID" "$APP_PATH"
 
 echo "==> launching"
-xcrun devicectl device process launch --device "$DEVICE_ID" "$BUNDLE_ID"
+if [[ -f "$DISCOVERY_FILE" && -f "$CADDY_ROOT" ]]; then
+  # A developer-installed iPad should be immediately useful. Pass the exact
+  # paired URL plus this Mac's public CA anchor only for the first launch; the
+  # app copies both into this-device-only Keychain storage. Never print the
+  # environment JSON because the paired URL contains the Deck capability.
+  PROVISIONING_ENV="$(python3 - "$DISCOVERY_FILE" "$CADDY_ROOT" <<'PY'
+import base64
+import json
+import pathlib
+import ssl
+import sys
+
+discovery = json.loads(pathlib.Path(sys.argv[1]).read_text())
+pem = pathlib.Path(sys.argv[2]).read_text()
+url = discovery.get("url")
+if not isinstance(url, str) or not url.startswith("https://"):
+    raise SystemExit("running Deck did not publish a paired HTTPS URL")
+der = ssl.PEM_cert_to_DER_cert(pem)
+print(json.dumps({
+    "SPEAKEASY_DECK_URL": url,
+    "SPEAKEASY_DECK_ROOT_DER": base64.b64encode(der).decode(),
+}))
+PY
+)"
+  xcrun devicectl device process launch --terminate-existing \
+    --device "$DEVICE_ID" \
+    --environment-variables "$PROVISIONING_ENV" \
+    "$BUNDLE_ID"
+  echo "==> paired securely with the running Deck (saved on iPad)"
+else
+  xcrun devicectl device process launch --device "$DEVICE_ID" "$BUNDLE_ID"
+  echo "==> launch complete; start 'speakeasy deck' to provision a secure connection"
+fi


### PR DESCRIPTION
## What changed

- Provision the exact paired Deck URL and Mac trust anchor through the device build flow.
- Persist the paired route in this-device-only storage.
- Validate trust only for the paired host while preserving Bonjour discovery as a fallback.

## Why

A directly installed iPad build should reconnect to its Mac without requiring a separate certificate profile or manual URL entry.

## User impact

The app can be installed once, opened normally later, and reconnect securely to the same paired Mac.

## Checks

- Generated the Xcode project with `xcodegen`.
- Built `SpeakEasyDeck` for the iPad Pro 11-inch (M5) iOS 26.2 simulator.

## Stack

This is PR 1 of 3. Canonical task routing and the native hybrid Deck follow as dependent draft PRs.