### PR TITLE
🏗️ Route Deck turns through canonical Codex tasks

### DIFF
--- a/app/Sources/SpeakEasy/DeckBridgeController.swift
+++ b/app/Sources/SpeakEasy/DeckBridgeController.swift
@@ -288,7 +288,7 @@ final class DeckBridgeController: ObservableObject {
         postIntent(["name": "catalog.refresh"])
     }
 
-    /// Bind a worker lane (0-8) to a thread, or to a fresh session when nil.
+    /// Bind a worker lane (0-8) to a task, or clear its assignment when nil.
     /// The overview lane is deck-owned and never assignable.
     func assign(lane: Int, threadId: String?) {
         guard (0..<9).contains(lane) else { return }

--- a/app/Sources/SpeakEasy/DeckSettingsView.swift
+++ b/app/Sources/SpeakEasy/DeckSettingsView.swift
@@ -222,7 +222,7 @@ struct DeckSettingsView: View {
         }
     }
 
-    /// Per-lane mapper: fresh session or any recent codex thread — the same
+    /// Per-lane mapper: unassigned or any recent Codex task — the same
     /// lane.assign intent the deck's own picker sends.
     private func laneMenu(
         lane: DeckBridgeController.Lane,
@@ -230,7 +230,7 @@ struct DeckSettingsView: View {
         catalog: [DeckBridgeController.CatalogThread]
     ) -> some View {
         Menu {
-            Button("Fresh session") { bridge.assign(lane: index, threadId: nil) }
+            Button("Clear assignment") { bridge.assign(lane: index, threadId: nil) }
             if catalog.isEmpty {
                 Button("Load recent threads…") { bridge.refreshCatalog() }
             } else {

--- a/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
+++ b/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
@@ -14,12 +14,27 @@ const FOLLOW_VERSION = 1;
 const STREAM_VERSION = 11;
 const START_TURN_VERSION = 1;
 const STEER_TURN_VERSION = 1;
-const SNAPSHOT_TIMEOUT_MS = 5_000;
+// Canonical Desktop snapshots include the task history currently held by the
+// owning window. Long-running tasks can legitimately be tens of megabytes; on
+// Node, receiving and parsing that private IPC frame can take longer than five
+// seconds even while the owner is healthy. Keep the wait bounded, but size the
+// default for real tasks instead of treating a large canonical history as a
+// missing owner.
+const DEFAULT_SNAPSHOT_TIMEOUT_MS = 30_000;
+const MIN_SNAPSHOT_TIMEOUT_MS = 5_000;
+const MAX_SNAPSHOT_TIMEOUT_MS = 120_000;
 const TURN_TIMEOUT_MS = 30 * 60_000;
 const OBSERVER_POLL_MS = 150;
 
 function codexHome() {
   return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+}
+
+function snapshotTimeoutMs(value = process.env.SPEAKEASY_CODEX_OWNER_TIMEOUT_MS) {
+  if (value === undefined || value === null || value === '') return DEFAULT_SNAPSHOT_TIMEOUT_MS;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SNAPSHOT_TIMEOUT_MS;
+  return Math.max(MIN_SNAPSHOT_TIMEOUT_MS, Math.min(Math.trunc(parsed), MAX_SNAPSHOT_TIMEOUT_MS));
 }
 
 function writeResult(result) {
@@ -223,6 +238,7 @@ class DesktopIPCClient {
     this.snapshotWaiter = null;
     this.failure = null;
     this.ownerRolloutPath = null;
+    this.snapshotTimeoutMs = snapshotTimeoutMs();
   }
 
   async connect() {
@@ -238,7 +254,7 @@ class DesktopIPCClient {
     const initialized = await this.request('initialize', { clientType: 'speakeasy' }, {
       allowUninitialized: true,
       version: 0,
-      timeoutMs: SNAPSHOT_TIMEOUT_MS,
+      timeoutMs: MIN_SNAPSHOT_TIMEOUT_MS,
     });
     if (initialized.resultType !== 'success' || typeof initialized.result?.clientId !== 'string') {
       fail('Codex Desktop rejected the SpeakEasy bridge.', 'desktop-unavailable');
@@ -254,7 +270,7 @@ class DesktopIPCClient {
           new Error('Open the locked task in Codex Desktop, then try the hotkey again.'),
           { code: 'task-owner-unavailable' },
         ));
-      }, SNAPSHOT_TIMEOUT_MS);
+      }, this.snapshotTimeoutMs);
       this.snapshotWaiter = {
         resolve: (snapshot) => {
           clearTimeout(timer);
@@ -695,4 +711,10 @@ if (require.main === module) {
   });
 }
 
-module.exports = { parseCompletionRecord, isTerminalRecord, observationMessages, assertRolloutPath };
+module.exports = {
+  parseCompletionRecord,
+  isTerminalRecord,
+  observationMessages,
+  assertRolloutPath,
+  snapshotTimeoutMs,
+};

--- a/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
+++ b/app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const net = require('node:net');
 const os = require('node:os');
 const path = require('node:path');
+const readline = require('node:readline');
 const { randomUUID, createHash } = require('node:crypto');
 const { execFileSync } = require('node:child_process');
 
@@ -20,7 +21,7 @@ const STEER_TURN_VERSION = 1;
 // seconds even while the owner is healthy. Keep the wait bounded, but size the
 // default for real tasks instead of treating a large canonical history as a
 // missing owner.
-const DEFAULT_SNAPSHOT_TIMEOUT_MS = 30_000;
+const DEFAULT_SNAPSHOT_TIMEOUT_MS = 120_000;
 const MIN_SNAPSHOT_TIMEOUT_MS = 5_000;
 const MAX_SNAPSHOT_TIMEOUT_MS = 120_000;
 const TURN_TIMEOUT_MS = 30 * 60_000;
@@ -35,6 +36,22 @@ function snapshotTimeoutMs(value = process.env.SPEAKEASY_CODEX_OWNER_TIMEOUT_MS)
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SNAPSHOT_TIMEOUT_MS;
   return Math.max(MIN_SNAPSHOT_TIMEOUT_MS, Math.min(Math.trunc(parsed), MAX_SNAPSHOT_TIMEOUT_MS));
+}
+
+/** Keep only routing and steering metadata after a potentially very large
+ * Desktop snapshot has proven ownership. Long task histories can be hundreds
+ * of megabytes; a warm bridge must not retain a duplicate transcript merely
+ * to remember the owner client and rollout path. */
+function compactConversationState(state) {
+  if (!state || typeof state !== 'object') return {};
+  return {
+    id: state.id,
+    title: state.title,
+    cwd: state.cwd,
+    rolloutPath: state.rolloutPath,
+    latestCollaborationMode: state.latestCollaborationMode,
+    threadRuntimeStatus: state.threadRuntimeStatus,
+  };
 }
 
 function writeResult(result) {
@@ -232,6 +249,7 @@ class DesktopIPCClient {
     this.socketPath = path.join(codexHome(), 'ipc', 'ipc.sock');
     this.clientId = 'initializing-client';
     this.ownerClientId = null;
+    this.ownerState = null;
     this.socket = null;
     this.buffer = Buffer.alloc(0);
     this.pending = new Map();
@@ -450,7 +468,7 @@ class DesktopIPCClient {
     // ownership, so ignore them and keep the read-only follower attached. A
     // later owner snapshot (or IPC close) remains the authority boundary.
     if (params?.change?.type !== 'snapshot') return;
-    const state = params?.change?.conversationState;
+    const state = compactConversationState(params?.change?.conversationState);
     if (this.strictObservation && this.ownerClientId && (
       state?.id !== this.threadId ||
       typeof state?.rolloutPath !== 'string' ||
@@ -464,6 +482,7 @@ class DesktopIPCClient {
     }
     if (typeof state?.rolloutPath === 'string') this.ownerRolloutPath = state.rolloutPath;
     this.ownerClientId = message.sourceClientId;
+    this.ownerState = state;
     this.snapshotWaiter?.resolve({
       ownerClientId: message.sourceClientId,
       state,
@@ -653,17 +672,102 @@ async function withClient(threadId, action, strictObservation = false) {
   }
 }
 
+function validateOwnedSnapshot(snapshot, threadId) {
+  const state = snapshot?.state || {};
+  const rolloutPath = assertRolloutPath(state.rolloutPath, threadId);
+  if (state.id !== threadId) fail('Codex Desktop returned the wrong task.', 'task-mismatch');
+  return { state, rolloutPath };
+}
+
+/** Submit against an already-following Desktop owner. The active turn is read
+ * from the canonical rollout rather than from the initial snapshot so a warm
+ * channel remains correct as the task moves between idle and working. */
+async function submitOwnedTurn(client, snapshot, threadId, text) {
+  const transcript = String(text || '').trim();
+  if (!transcript) fail('The transcript is empty.', 'empty-transcript');
+  const currentSnapshot = client.ownerClientId && client.ownerState
+    ? { ownerClientId: client.ownerClientId, state: client.ownerState }
+    : snapshot;
+  const { state, rolloutPath } = validateOwnedSnapshot(currentSnapshot, threadId);
+  const offset = fs.statSync(rolloutPath).size;
+  const activeTurnId = latestActiveTurnId(rolloutPath);
+  let turnId;
+  let delivery;
+  if (activeTurnId) {
+    await client.steerTurn(transcript, currentSnapshot.ownerClientId, state);
+    turnId = activeTurnId;
+    delivery = 'steered-active-turn';
+  } else {
+    turnId = await client.startTurn(transcript, currentSnapshot.ownerClientId);
+    delivery = 'started-turn';
+  }
+  const response = await waitForTurn(rolloutPath, offset, turnId);
+  return { ok: true, threadId, turnId, delivery, response };
+}
+
+/** Persistent stdio protocol used by the Deck runtime. Owner discovery and the
+ * expensive canonical snapshot happen once; subsequent dictations reuse the
+ * exact same proven Desktop channel. Requests are deliberately serialized so
+ * one response can never be attributed to another capture. */
+async function serveTask(threadId) {
+  const client = new DesktopIPCClient(threadId);
+  try {
+    await client.connect();
+    const snapshot = await client.follow();
+    const { state } = validateOwnedSnapshot(snapshot, threadId);
+    writeResult({
+      ok: true,
+      type: 'ready',
+      threadId,
+      task: { id: state.id, title: state.title || 'Untitled task', cwd: state.cwd || '' },
+    });
+
+    const lines = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+    for await (const line of lines) {
+      if (!line.trim()) continue;
+      let request;
+      try {
+        request = JSON.parse(line);
+      } catch {
+        writeResult({ ok: false, code: 'protocol-mismatch', error: 'Unreadable warm bridge request.' });
+        continue;
+      }
+      const requestId = typeof request.requestId === 'string' ? request.requestId : null;
+      if (request.type !== 'submit' || !requestId) {
+        writeResult({ ok: false, requestId, code: 'protocol-mismatch', error: 'Invalid warm bridge request.' });
+        continue;
+      }
+      try {
+        const result = await submitOwnedTurn(client, snapshot, threadId, request.text);
+        writeResult({ requestId, ...result });
+      } catch (error) {
+        writeResult({
+          ok: false,
+          requestId,
+          code: error?.code || 'bridge-failed',
+          error: error instanceof Error ? error.message : String(error),
+        });
+        if (client.failure) throw client.failure;
+      }
+    }
+  } finally {
+    client.close();
+  }
+}
+
 async function main() {
   const [command, argument] = process.argv.slice(2);
   if (command === 'list') {
     writeResult({ ok: true, tasks: listTasks(argument) });
     return;
   }
+  if (command === 'serve' && argument) {
+    await serveTask(argument);
+    return;
+  }
   if ((command === 'validate' || command === 'submit' || command === 'observe') && argument) {
     const result = await withClient(argument, async (client, snapshot) => {
-      const state = snapshot.state || {};
-      const rolloutPath = assertRolloutPath(state.rolloutPath, argument);
-      if (state.id !== argument) fail('Codex Desktop returned the wrong task.', 'task-mismatch');
+      const { state, rolloutPath } = validateOwnedSnapshot(snapshot, argument);
       if (command === 'validate') {
         return {
           ok: true,
@@ -673,31 +777,12 @@ async function main() {
       if (command === 'observe') {
         return await observeRollout(client, rolloutPath, argument, process.argv[4], process.argv[5]);
       }
-      const text = (await readStdin()).trim();
-      if (!text) fail('The transcript is empty.', 'empty-transcript');
-      const offset = fs.statSync(rolloutPath).size;
-      const taskIsActive = state?.threadRuntimeStatus?.type === 'active';
-      const activeTurnId = taskIsActive ? latestActiveTurnId(rolloutPath) : null;
-      if (taskIsActive && !activeTurnId) {
-        fail('Codex Desktop reports an active task without a correlatable turn.', 'protocol-mismatch');
-      }
-      let turnId;
-      let delivery;
-      if (activeTurnId) {
-        await client.steerTurn(text, snapshot.ownerClientId, state);
-        turnId = activeTurnId;
-        delivery = 'steered-active-turn';
-      } else {
-        turnId = await client.startTurn(text, snapshot.ownerClientId);
-        delivery = 'started-turn';
-      }
-      const response = await waitForTurn(rolloutPath, offset, turnId);
-      return { ok: true, threadId: argument, turnId, delivery, response };
+      return await submitOwnedTurn(client, snapshot, argument, await readStdin());
     }, command === 'observe');
     writeResult(result);
     return;
   }
-  fail('Usage: codex-desktop-bridge.cjs list [limit] | validate <task-id> | submit <task-id> | observe <task-id> [cursor]', 'usage');
+  fail('Usage: codex-desktop-bridge.cjs list [limit] | validate <task-id> | submit <task-id> | serve <task-id> | observe <task-id> [cursor]', 'usage');
 }
 
 if (require.main === module) {
@@ -717,4 +802,5 @@ module.exports = {
   observationMessages,
   assertRolloutPath,
   snapshotTimeoutMs,
+  compactConversationState,
 };

--- a/app/Tests/codex-desktop-bridge.test.cjs
+++ b/app/Tests/codex-desktop-bridge.test.cjs
@@ -7,6 +7,7 @@ const {
   isTerminalRecord,
   observationMessages,
   snapshotTimeoutMs,
+  compactConversationState,
 } = require('../Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs');
 
 const taskID = '019f99a4-7867-7c23-ac29-0c0eca7da603';
@@ -65,9 +66,32 @@ test('completion observation commits its cursor atomically with the event', () =
 });
 
 test('owner discovery allows large canonical task snapshots without becoming unbounded', () => {
-  assert.equal(snapshotTimeoutMs(), 30_000);
-  assert.equal(snapshotTimeoutMs('not-a-number'), 30_000);
+  assert.equal(snapshotTimeoutMs(), 120_000);
+  assert.equal(snapshotTimeoutMs('not-a-number'), 120_000);
   assert.equal(snapshotTimeoutMs('1000'), 5_000);
   assert.equal(snapshotTimeoutMs('45000'), 45_000);
   assert.equal(snapshotTimeoutMs('999999'), 120_000);
+});
+
+test('warm owner state drops the canonical transcript after proving identity', () => {
+  const compact = compactConversationState({
+    id: taskID,
+    title: 'Long-running task',
+    cwd: '/tmp/project',
+    rolloutPath: `/tmp/${taskID}.jsonl`,
+    latestCollaborationMode: { mode: 'default' },
+    threadRuntimeStatus: { type: 'idle' },
+    messages: Array.from({ length: 1_000 }, () => ({ text: 'large history' })),
+    turns: ['not retained'],
+  });
+  assert.deepEqual(compact, {
+    id: taskID,
+    title: 'Long-running task',
+    cwd: '/tmp/project',
+    rolloutPath: `/tmp/${taskID}.jsonl`,
+    latestCollaborationMode: { mode: 'default' },
+    threadRuntimeStatus: { type: 'idle' },
+  });
+  assert.equal('messages' in compact, false);
+  assert.equal('turns' in compact, false);
 });

--- a/app/Tests/codex-desktop-bridge.test.cjs
+++ b/app/Tests/codex-desktop-bridge.test.cjs
@@ -6,6 +6,7 @@ const {
   parseCompletionRecord,
   isTerminalRecord,
   observationMessages,
+  snapshotTimeoutMs,
 } = require('../Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs');
 
 const taskID = '019f99a4-7867-7c23-ac29-0c0eca7da603';
@@ -61,4 +62,12 @@ test('completion observation commits its cursor atomically with the event', () =
     turnID: 'turn-4',
     cursor: 950,
   }]);
+});
+
+test('owner discovery allows large canonical task snapshots without becoming unbounded', () => {
+  assert.equal(snapshotTimeoutMs(), 30_000);
+  assert.equal(snapshotTimeoutMs('not-a-number'), 30_000);
+  assert.equal(snapshotTimeoutMs('1000'), 5_000);
+  assert.equal(snapshotTimeoutMs('45000'), 45_000);
+  assert.equal(snapshotTimeoutMs('999999'), 120_000);
 });

--- a/deck/README.md
+++ b/deck/README.md
@@ -55,8 +55,8 @@ Choose **Set lanes** from the deck header on the website or in the iPad app. The
 workspace keeps all nine pads visible and groups recent tasks under the same project labels and
 user-facing titles shown by the Codex app. Search matches task titles, projects, previews, paths,
 and full thread IDs; for example, a renamed Codex task such as `spk-web` appears as `spk-web`, not
-as the rollout prompt that originally created it. Choosing a task moves its binding to that pad
-without deleting or modifying the Codex task. **Clear assignment** leaves the pad unassigned;
+as the rollout prompt that originally created it. Choosing a task moves its binding to that pad,
+makes that pad the active conversation target, and does not modify the Codex task. **Clear assignment** leaves the pad unassigned;
 speaking to it will not create a shadow task. Assign an existing Codex task before using the pad.
 
 ## Boot options

--- a/deck/README.md
+++ b/deck/README.md
@@ -56,8 +56,8 @@ workspace keeps all nine pads visible and groups recent tasks under the same pro
 user-facing titles shown by the Codex app. Search matches task titles, projects, previews, paths,
 and full thread IDs; for example, a renamed Codex task such as `spk-web` appears as `spk-web`, not
 as the rollout prompt that originally created it. Choosing a task moves its binding to that pad
-without deleting or modifying the Codex task. **Fresh session** clears the pad so its next spoken
-request starts a new Codex task.
+without deleting or modifying the Codex task. **Clear assignment** leaves the pad unassigned;
+speaking to it will not create a shadow task. Assign an existing Codex task before using the pad.
 
 ## Boot options
 

--- a/deck/index.html
+++ b/deck/index.html
@@ -1823,22 +1823,15 @@ const ACTIONS = {
   setupassign: a => {
     if (S.setupPending) return;
     const index = S.setupLane;
-    const current = S.lanes && S.lanes[index] && S.lanes[index].threadId;
-    if (a && current === a) {
-      S.setupNotice = 'PAD ' + String(index + 1).padStart(2, '0') + ' ALREADY CONTINUES THIS TASK';
-      S.setupTone = 'ok';
-      paint();
-      return;
-    }
     const task = a ? (S.catalog || []).find(t => t.id === a) : null;
     const label = task ? task.snippet : 'Unassigned';
     S.setupPending = true;
     S.setupNotice = 'SETTING PAD ' + String(index + 1).padStart(2, '0') + '…';
     S.setupTone = 'ok';
-    const sent = sendIntent('lane.assign', { index: index, threadId: a || null }, ack => {
+    const sent = sendIntent('lane.assign', { index: index, threadId: a || null, activate: !!a }, ack => {
       S.setupPending = false;
       S.setupNotice = ack.ok
-        ? 'PAD ' + String(index + 1).padStart(2, '0') + ' → ' + label
+        ? 'PAD ' + String(index + 1).padStart(2, '0') + (a ? ' ACTIVE → ' : ' → ') + label
         : (ack.error || 'The lane could not be changed.');
       S.setupTone = ack.ok ? 'ok' : 'error';
       paint();

--- a/deck/index.html
+++ b/deck/index.html
@@ -1342,7 +1342,7 @@ function view() {
     setupLaneRows: setupLaneRows,
     setupQuery: S.setupQuery,
     setupCurrentThread: setupCurrentThread,
-    setupCurrent: setupCurrentLane && setupCurrentThread ? setupCurrentLane.title : 'Fresh session on first ask',
+    setupCurrent: setupCurrentLane && setupCurrentThread ? setupCurrentLane.title : 'Unassigned — choose a Codex task',
     setupPending: S.setupPending,
     setupNotice: S.setupNotice,
     setupTone: S.setupTone,
@@ -1647,8 +1647,8 @@ function tpl(v) {
             '</div>' +
             '<div class="se-scroll se-setup-results">' +
               '<button type="button" data-act="setupassign" data-arg="" ' + (v.setupPending ? 'disabled ' : '') + 'style="min-height:62px;text-align:left;border:1.5px dashed var(--se-accent-edge);border-radius:10px;background:var(--se-chip-bg);padding:11px 14px;cursor:' + (v.setupPending ? 'wait' : 'pointer') + ';opacity:' + (v.setupPending ? '.55' : '1') + ';">' +
-                '<span style="display:block;font:600 10px var(--se-mono);letter-spacing:0.14em;color:var(--se-accent-ink);">+ FRESH SESSION</span>' +
-                '<span style="display:block;margin-top:5px;font:400 9.5px var(--se-sans);color:var(--se-ink-3);">Start a clean Codex task when you first speak to this pad.</span>' +
+                '<span style="display:block;font:600 10px var(--se-mono);letter-spacing:0.14em;color:var(--se-accent-ink);">CLEAR ASSIGNMENT</span>' +
+                '<span style="display:block;margin-top:5px;font:400 9.5px var(--se-sans);color:var(--se-ink-3);">Leave this pad unassigned. Speaking will not create a shadow task.</span>' +
               '</button>' +
               v.catalogRows.map(t =>
                 t.kind === 'more'
@@ -1831,7 +1831,7 @@ const ACTIONS = {
       return;
     }
     const task = a ? (S.catalog || []).find(t => t.id === a) : null;
-    const label = task ? task.snippet : 'Fresh session on first ask';
+    const label = task ? task.snippet : 'Unassigned';
     S.setupPending = true;
     S.setupNotice = 'SETTING PAD ' + String(index + 1).padStart(2, '0') + '…';
     S.setupTone = 'ok';

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -5,6 +5,9 @@ description: Project structure and design decisions
 
 # Architecture
 
+> The task-scoped Deck, observer, presenter, and Scout framework boundaries are
+> specified in [SpeakEasy conversation topology](design/conversation-topology.md).
+
 ## Overview
 
 SpeakEasy is a unified text-to-speech library that abstracts multiple TTS providers behind a common interface. It runs on macOS and uses native audio playback.

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -162,7 +162,7 @@ A config `port` is a preference (falls back to auto when busy); an explicit
 
 The Deck section of the Mac settings app shows live status (running host/port,
 connected devices, lane bindings, trace), manages lanes directly (each lane's
-menu binds a recent codex thread or resets to a fresh session — the same
+menu binds a recent Codex task or clears the pad's assignment — the same
 `lane.assign` intent the deck's own picker sends), and owns the bridge:
 start/stop/restart, auto-start, pairing, port, and a scannable device link. A
 release app includes the runtime, Deck assets, and a pinned Caddy helper, so the
@@ -172,6 +172,14 @@ built-in HTTP server remains available only through the explicit development
 flags `--no-tls --no-caddy`. The app discovers the running deck through
 `~/.config/speakeasy/deck-listener.json`, so it works no matter how the Deck
 was started.
+
+Bound lanes use the private, fail-closed Codex Desktop-owner bridge rather than
+the Deck's overview model. An unassigned worker pad refuses the turn instead of
+creating a shadow task. The Luna overview/observer path is read-only or outbound
+presentation only: it never receives the user's lane transcript, and the direct
+route never falls back to Scout or a fresh app-server task. Scout can help define
+and implement the observer/narrator/orchestrator topology, but it is not a broker
+or peer identity in the canonical conversation data plane.
 
 ## Complete Examples
 

--- a/docs/design/conversation-topology.md
+++ b/docs/design/conversation-topology.md
@@ -1,0 +1,135 @@
+# SpeakEasy conversation topology
+
+## Decision
+
+SpeakEasy is a remote input/output surface for one canonical Codex task. A
+worker pad behaves like a keyboard, microphone, display, and speaker with lane
+memory. It does not create a second conversation and it does not send the
+operator's turn through the Scout broker.
+
+Scout may define and implement the local role topology—potentially through
+`agent-sessions` primitives—but those roles are runtime components, not Scout
+peer identities. There is no `ask`, broker receipt, agent alias, or Scout
+conversation between the operator and Codex.
+
+## Ownership spheres
+
+| Sphere | Owns | Must not own |
+|---|---|---|
+| Deck device | Capture, ASR finalization, lane selection, playback controls | Task history or task execution |
+| Canonical Codex task | Full user transcript, reasoning, tools, final response | Device presentation policy |
+| Observer | Read-only task state, completion events, progress-derived metadata | User-turn dispatch or canonical transcript mutation |
+| Presenter / narrator | Redaction, compression, speech shaping, TTS queue | Task execution or authoritative answers |
+| Orchestrator (optional) | Role lifecycle, cancellation, backpressure, correlations | Rewriting or rerouting operator turns |
+| Scout framework | Contracts, topology helpers, lifecycle implementation, diagnostics | The canonical conversation data plane |
+
+The roles are scoped by the canonical task id, not by a broker identity:
+
+```text
+TaskScope(codexTaskId)
+  ├─ CanonicalTurnTransport  (write authority)
+  ├─ TaskObserver            (read authority)
+  ├─ Presenter               (derived-output authority)
+  └─ Narrator                (audio-output authority)
+```
+
+## Loops
+
+### 1. Interaction loop — lossless and direct
+
+```text
+microphone → ASR final → exact task-id check → Codex task owner
+```
+
+The ASR final is submitted verbatim as a native user turn. The transport must
+return the same task id plus a correlatable turn id. If exact ownership cannot
+be proven, the turn fails visibly. It never falls back to a fresh app-server
+task, a Scout message, or a summary produced by another model.
+
+### 2. Observation loop — read-only
+
+```text
+Codex task events → task-scoped cursor → normalized observations
+```
+
+The observer can derive state such as `working`, `needs_input`, `completed`,
+recent tools, or the latest final response. Its cursor is durable and tied to
+the exact task rollout identity. It cannot insert messages into the task.
+
+### 3. Presentation loop — disposable derivation
+
+```text
+normalized observation → redact / compress / speech-shape → TTS
+```
+
+A cheap, fast model such as Luna may be used here. Its output is presentation,
+not conversation history. The full canonical response remains visible in
+Codex; the spoken form can omit code, paths, repetitive logs, or long detail.
+Derived prompts and results live in a separate, hidden runtime store and may be
+deleted without affecting the task.
+
+### 4. Orchestration loop — control plane only
+
+The optional orchestrator starts and stops observer/presenter components,
+propagates cancellation, applies queue policy, and records correlations. It can
+recommend actions but cannot dispatch a canonical user turn. This keeps a
+future multi-role topology from becoming a hidden conversational hop.
+
+## Minimal contracts
+
+```ts
+type CanonicalTurn = {
+  taskId: string;
+  transcript: string;
+  source: 'speakeasy-deck';
+  captureId: string;
+};
+
+type CanonicalReceipt = {
+  taskId: string;        // must exactly equal CanonicalTurn.taskId
+  turnId: string;
+  delivery: 'started-turn' | 'steered-active-turn';
+};
+
+type TaskObservation = {
+  taskId: string;
+  turnId?: string;
+  cursor: string;
+  kind: 'working' | 'needs_input' | 'completed' | 'failed';
+  payload: unknown;
+};
+
+type Presentation = {
+  taskId: string;
+  turnId?: string;
+  text: string;
+  provenance: 'canonical' | 'derived';
+};
+```
+
+Every derived event retains `taskId` and, when available, `turnId`. Correlation
+is explicit; roles do not infer identity from titles, snippets, or response
+text.
+
+## Hard invariants
+
+1. One operator turn produces at most one canonical Codex user message.
+2. Worker pads require an explicit task assignment.
+3. The canonical route has no Scout broker hop and no model rewrite.
+4. Observer and presenter state is per task and hidden from task history.
+5. Derived output can be wrong or discarded without corrupting the task.
+6. Stopping Scout, the observer, or the presenter cannot prevent direct turn
+   submission; only loss of the exact Codex task owner can do that.
+7. Every fallback is presentation-only. There is no fallback destination for a
+   canonical user turn.
+
+## What Scout can own
+
+Scout can provide the reusable implementation package for `TaskScope`, role
+registration, cancellation, event schemas, cursors, local tracing, and feature
+flags. `agent-sessions` can host a hidden presenter or overview role in a
+separate app-server instance. None of those components needs or receives a
+Scout broker identity, and none appears as a peer in agent-to-agent messaging.
+
+This makes the division precise: **Scout owns the topology pattern; Codex owns
+the conversation; SpeakEasy owns the device experience.**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "!dist/test.*",
     "deck/index.html",
     "deck/themes.json",
-    "deck/variants"
+    "deck/variants",
+    "app/Sources/SpeakEasy/Resources/codex-desktop-bridge.cjs"
   ],
   "exports": {
     ".": "./dist/index.js"

--- a/src/cli/codex-desktop-submit.test.ts
+++ b/src/cli/codex-desktop-submit.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { resolveCodexDesktopBridge, submitCodexDesktopTurn } from './codex-desktop-submit';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { force: true, recursive: true });
+});
+
+function fakeBridge(source: string): string {
+  const directory = mkdtempSync(path.join(tmpdir(), 'speakeasy-desktop-bridge-test-'));
+  temporaryDirectories.push(directory);
+  const file = path.join(directory, 'bridge.cjs');
+  writeFileSync(file, source);
+  chmodSync(file, 0o700);
+  return file;
+}
+
+describe('Codex Desktop submission', () => {
+  test('resolves an explicit packaged bridge before any fallback', () => {
+    const bridge = fakeBridge('');
+    expect(resolveCodexDesktopBridge(bridge)).toBe(bridge);
+  });
+
+  test('returns only a response proven to belong to the exact task', async () => {
+    const threadId = '019fa9c1-9113-74d2-86a6-9607f89f1953';
+    const bridge = fakeBridge(`
+      const threadId = process.argv[3];
+      let input = '';
+      process.stdin.on('data', (chunk) => { input += chunk; });
+      process.stdin.on('end', () => {
+        process.stdout.write(JSON.stringify({
+          ok: true,
+          threadId,
+          turnId: 'turn-1',
+          delivery: 'started-turn',
+          response: 'Canonical reply to: ' + input,
+        }) + '\\n');
+      });
+    `);
+
+    const result = await submitCodexDesktopTurn(threadId, 'exact transcript', {
+      bridgePath: bridge,
+      runtimePath: process.execPath,
+      timeoutMs: 2_000,
+    });
+
+    expect(result).toEqual({
+      threadId,
+      turnId: 'turn-1',
+      delivery: 'started-turn',
+      response: 'Canonical reply to: exact transcript',
+    });
+  });
+
+  test('fails closed when the bridge reports a different task', async () => {
+    const bridge = fakeBridge(`
+      process.stdin.resume();
+      process.stdin.on('end', () => process.stdout.write(JSON.stringify({
+        ok: true,
+        threadId: 'shadow-task',
+        turnId: 'turn-2',
+        delivery: 'started-turn',
+        response: 'Wrong destination',
+      }) + '\\n'));
+    `);
+
+    await expect(submitCodexDesktopTurn('canonical-task', 'hello', {
+      bridgePath: bridge,
+      runtimePath: process.execPath,
+      timeoutMs: 2_000,
+    })).rejects.toThrow('wrong task');
+  });
+
+  test('cancels an in-flight bridge instead of leaving a hidden turn runner', async () => {
+    const bridge = fakeBridge('setInterval(() => {}, 1000); process.stdin.resume();');
+    const controller = new AbortController();
+    const pending = submitCodexDesktopTurn('canonical-task', 'hello', {
+      bridgePath: bridge,
+      runtimePath: process.execPath,
+      timeoutMs: 5_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(pending).rejects.toThrow('cancelled');
+  });
+});

--- a/src/cli/codex-desktop-submit.test.ts
+++ b/src/cli/codex-desktop-submit.test.ts
@@ -3,7 +3,11 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { resolveCodexDesktopBridge, submitCodexDesktopTurn } from './codex-desktop-submit';
+import {
+  CodexDesktopSession,
+  resolveCodexDesktopBridge,
+  submitCodexDesktopTurn,
+} from './codex-desktop-submit';
 
 const temporaryDirectories: string[] = [];
 
@@ -87,5 +91,60 @@ describe('Codex Desktop submission', () => {
     });
     controller.abort();
     await expect(pending).rejects.toThrow('cancelled');
+  });
+
+  test('reuses one proven Desktop owner across rapid sequential turns', async () => {
+    const threadId = 'canonical-task';
+    const bridge = fakeBridge(`
+      const readline = require('node:readline');
+      const threadId = process.argv[3];
+      let count = 0;
+      process.stdout.write(JSON.stringify({ ok: true, type: 'ready', threadId }) + '\\n');
+      const lines = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+      lines.on('line', (line) => {
+        const request = JSON.parse(line);
+        count += 1;
+        process.stdout.write(JSON.stringify({
+          ok: true,
+          requestId: request.requestId,
+          threadId,
+          turnId: 'turn-' + count,
+          delivery: 'started-turn',
+          response: 'warm-' + count + ': ' + request.text,
+        }) + '\\n');
+      });
+    `);
+    const session = new CodexDesktopSession(threadId, {
+      bridgePath: bridge,
+      runtimePath: process.execPath,
+      readyTimeoutMs: 2_000,
+    });
+
+    await session.warm();
+    const first = await session.turn('one', { timeoutMs: 2_000 });
+    const second = await session.turn('two', { timeoutMs: 2_000 });
+
+    expect(first).toMatchObject({ turnId: 'turn-1', response: 'warm-1: one' });
+    expect(second).toMatchObject({ turnId: 'turn-2', response: 'warm-2: two' });
+    session.close();
+  });
+
+  test('warm channel fails closed when Desktop proves another task', async () => {
+    const bridge = fakeBridge(`
+      process.stdout.write(JSON.stringify({
+        ok: true,
+        type: 'ready',
+        threadId: 'shadow-task',
+      }) + '\\n');
+      setInterval(() => {}, 1000);
+    `);
+    const session = new CodexDesktopSession('canonical-task', {
+      bridgePath: bridge,
+      runtimePath: process.execPath,
+      readyTimeoutMs: 2_000,
+    });
+
+    await expect(session.warm()).rejects.toThrow('wrong task');
+    session.close();
   });
 });

--- a/src/cli/codex-desktop-submit.ts
+++ b/src/cli/codex-desktop-submit.ts
@@ -1,0 +1,173 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_TIMEOUT_MS = 185_000;
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+export type CodexDesktopDelivery = 'started-turn' | 'steered-active-turn';
+
+export interface CodexDesktopTurnResult {
+  response: string;
+  delivery: CodexDesktopDelivery;
+  threadId: string;
+  turnId: string;
+}
+
+interface BridgeEnvelope {
+  ok?: boolean;
+  code?: string;
+  error?: string;
+  response?: string;
+  delivery?: string;
+  threadId?: string;
+  turnId?: string;
+}
+
+interface SubmitOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  bridgePath?: string;
+  runtimePath?: string;
+}
+
+/**
+ * The bridge ships in both the npm package and the native macOS app. Prefer an
+ * explicit development override, then the copy beside this package, then the
+ * installed app. Missing bridge code is an installation error, never a reason
+ * to start a second Codex app-server.
+ */
+export function resolveCodexDesktopBridge(
+  override = process.env.SPEAKEASY_CODEX_BRIDGE_PATH,
+): string {
+  const candidates = [
+    override?.trim(),
+    path.resolve(__dirname, '..', '..', 'app', 'Sources', 'SpeakEasy', 'Resources', 'codex-desktop-bridge.cjs'),
+    '/Applications/SpeakEasy.app/Contents/Resources/SpeakEasy_SpeakEasy.bundle/codex-desktop-bridge.cjs',
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  const bridge = candidates.find((candidate) => existsSync(candidate));
+  if (!bridge) {
+    throw new Error('The Codex Desktop bridge is not installed. Update SpeakEasy, then try again.');
+  }
+  return bridge;
+}
+
+function parseBridgeResult(stdout: string, expectedThreadId: string): CodexDesktopTurnResult {
+  const line = stdout.trim().split('\n').filter(Boolean).at(-1);
+  if (!line) throw new Error('Codex Desktop returned no bridge result.');
+
+  let result: BridgeEnvelope;
+  try {
+    result = JSON.parse(line) as BridgeEnvelope;
+  } catch {
+    throw new Error('Codex Desktop returned an unreadable bridge result.');
+  }
+
+  if (!result.ok) {
+    throw new Error(result.error?.trim() || `Codex Desktop bridge failed (${result.code || 'unknown error'}).`);
+  }
+  if (result.threadId !== expectedThreadId) {
+    throw new Error('Codex Desktop returned the wrong task; the turn was not accepted.');
+  }
+  if (result.delivery !== 'started-turn' && result.delivery !== 'steered-active-turn') {
+    throw new Error('Codex Desktop did not confirm how the turn was delivered.');
+  }
+  const response = result.response?.trim();
+  const turnId = result.turnId?.trim();
+  if (!response || !turnId) {
+    throw new Error('Codex Desktop completed without a correlatable response.');
+  }
+
+  return {
+    response,
+    delivery: result.delivery,
+    threadId: result.threadId,
+    turnId,
+  };
+}
+
+function stop(child: ChildProcessWithoutNullStreams): void {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  const hardStop = setTimeout(() => child.kill('SIGKILL'), 1_000);
+  hardStop.unref();
+}
+
+/**
+ * Submit one exact user transcript to an already-bound Codex Desktop task.
+ * The bridge chooses start-vs-steer from the Desktop owner's live state and
+ * returns only after the matching canonical turn completes.
+ */
+export function submitCodexDesktopTurn(
+  threadId: string,
+  text: string,
+  options: SubmitOptions = {},
+): Promise<CodexDesktopTurnResult> {
+  const exactThreadId = threadId.trim();
+  const transcript = text.trim();
+  if (!exactThreadId) return Promise.reject(new Error('The lane has no exact Codex task ID.'));
+  if (!transcript) return Promise.reject(new Error('The transcript is empty.'));
+  if (options.signal?.aborted) return Promise.reject(new Error('The Codex turn was cancelled.'));
+
+  const bridgePath = options.bridgePath ?? resolveCodexDesktopBridge();
+  const runtimePath = options.runtimePath ?? process.execPath;
+  const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(runtimePath, [bridgePath, 'submit', exactThreadId], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: process.env,
+    });
+    let stdout = Buffer.alloc(0);
+    let stderr = Buffer.alloc(0);
+    let settled = false;
+
+    const finish = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener('abort', onAbort);
+      callback();
+    };
+    const fail = (error: Error): void => finish(() => reject(error));
+    const append = (current: Buffer, chunk: Buffer): Buffer => {
+      if (current.length + chunk.length > MAX_OUTPUT_BYTES) {
+        stop(child);
+        fail(new Error('Codex Desktop bridge output exceeded its safety limit.'));
+        return current;
+      }
+      return Buffer.concat([current, chunk]);
+    };
+    const onAbort = (): void => {
+      stop(child);
+      fail(new Error('The Codex turn was cancelled.'));
+    };
+    const timer = setTimeout(() => {
+      stop(child);
+      fail(new Error(`Timed out waiting for the exact Codex task after ${timeoutMs}ms.`));
+    }, timeoutMs);
+    timer.unref();
+
+    child.stdout.on('data', (chunk: Buffer) => { stdout = append(stdout, chunk); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr = append(stderr, chunk); });
+    child.on('error', (error) => fail(error));
+    child.on('close', (code) => {
+      if (settled) return;
+      try {
+        const parsed = parseBridgeResult(stdout.toString('utf8'), exactThreadId);
+        if (code !== 0) {
+          const detail = stderr.toString('utf8').trim();
+          throw new Error(detail || 'Codex Desktop rejected the turn.');
+        }
+        finish(() => resolve(parsed));
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+    child.stdin.on('error', (error) => fail(error));
+    child.stdin.end(transcript);
+  });
+}

--- a/src/cli/codex-desktop-submit.ts
+++ b/src/cli/codex-desktop-submit.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
@@ -22,13 +23,21 @@ interface BridgeEnvelope {
   delivery?: string;
   threadId?: string;
   turnId?: string;
+  type?: string;
+  requestId?: string | null;
 }
 
-interface SubmitOptions {
+export interface SubmitOptions {
   signal?: AbortSignal;
   timeoutMs?: number;
   bridgePath?: string;
   runtimePath?: string;
+}
+
+export interface CodexDesktopSessionOptions {
+  bridgePath?: string;
+  runtimePath?: string;
+  readyTimeoutMs?: number;
 }
 
 /**
@@ -53,17 +62,7 @@ export function resolveCodexDesktopBridge(
   return bridge;
 }
 
-function parseBridgeResult(stdout: string, expectedThreadId: string): CodexDesktopTurnResult {
-  const line = stdout.trim().split('\n').filter(Boolean).at(-1);
-  if (!line) throw new Error('Codex Desktop returned no bridge result.');
-
-  let result: BridgeEnvelope;
-  try {
-    result = JSON.parse(line) as BridgeEnvelope;
-  } catch {
-    throw new Error('Codex Desktop returned an unreadable bridge result.');
-  }
-
+function parseBridgeEnvelope(result: BridgeEnvelope, expectedThreadId: string): CodexDesktopTurnResult {
   if (!result.ok) {
     throw new Error(result.error?.trim() || `Codex Desktop bridge failed (${result.code || 'unknown error'}).`);
   }
@@ -87,11 +86,197 @@ function parseBridgeResult(stdout: string, expectedThreadId: string): CodexDeskt
   };
 }
 
+function parseBridgeResult(stdout: string, expectedThreadId: string): CodexDesktopTurnResult {
+  const line = stdout.trim().split('\n').filter(Boolean).at(-1);
+  if (!line) throw new Error('Codex Desktop returned no bridge result.');
+
+  let result: BridgeEnvelope;
+  try {
+    result = JSON.parse(line) as BridgeEnvelope;
+  } catch {
+    throw new Error('Codex Desktop returned an unreadable bridge result.');
+  }
+  return parseBridgeEnvelope(result, expectedThreadId);
+}
+
 function stop(child: ChildProcessWithoutNullStreams): void {
   if (child.exitCode !== null || child.signalCode !== null) return;
   child.kill('SIGTERM');
   const hardStop = setTimeout(() => child.kill('SIGKILL'), 1_000);
   hardStop.unref();
+}
+
+interface PendingWarmTurn {
+  resolve: (result: CodexDesktopTurnResult) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+/** A warm, exact-task Desktop channel for latency-sensitive surfaces such as
+ * the iPad Deck. The expensive owner snapshot is proven once per selected
+ * task; every subsequent transcript remains a native, correlatable Codex turn
+ * over that same Desktop-owned IPC connection. */
+export class CodexDesktopSession {
+  readonly threadId: string;
+
+  private readonly bridgePath: string;
+  private readonly runtimePath: string;
+  private readonly readyTimeoutMs: number;
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private readyPromise: Promise<void> | null = null;
+  private readyResolve: (() => void) | null = null;
+  private readyReject: ((error: Error) => void) | null = null;
+  private readyTimer: NodeJS.Timeout | null = null;
+  private stdout = '';
+  private stderr = '';
+  private pending = new Map<string, PendingWarmTurn>();
+  private disposed = false;
+
+  constructor(threadId: string, options: CodexDesktopSessionOptions = {}) {
+    const exactThreadId = threadId.trim();
+    if (!exactThreadId) throw new Error('The lane has no exact Codex task ID.');
+    this.threadId = exactThreadId;
+    this.bridgePath = options.bridgePath ?? resolveCodexDesktopBridge();
+    this.runtimePath = options.runtimePath ?? process.execPath;
+    this.readyTimeoutMs = Math.max(5_000, options.readyTimeoutMs ?? 125_000);
+  }
+
+  /** Resolve after Codex Desktop has proven the exact task owner. Calls share
+   * one in-flight handshake and later calls are immediate. */
+  warm(): Promise<void> {
+    if (this.disposed) return Promise.reject(new Error('The Codex Desktop session is closed.'));
+    if (this.readyPromise) return this.readyPromise;
+
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      this.readyResolve = resolve;
+      this.readyReject = reject;
+    });
+    const child = spawn(this.runtimePath, [this.bridgePath, 'serve', this.threadId], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: process.env,
+    });
+    this.child = child;
+    this.stdout = '';
+    this.stderr = '';
+    this.readyTimer = setTimeout(() => {
+      this.reset(new Error(`Timed out warming the exact Codex task after ${this.readyTimeoutMs}ms.`), child);
+    }, this.readyTimeoutMs);
+    this.readyTimer.unref();
+
+    child.stdout.on('data', (chunk: Buffer) => this.consumeStdout(chunk, child));
+    child.stderr.on('data', (chunk: Buffer) => {
+      this.stderr = (this.stderr + chunk.toString('utf8')).slice(-64 * 1024);
+    });
+    child.stdin.on('error', (error) => this.reset(error, child));
+    child.on('error', (error) => this.reset(error, child));
+    child.on('close', (code) => {
+      if (this.child !== child) return;
+      const detail = this.stderr.trim();
+      this.reset(new Error(detail || `Codex Desktop warm bridge exited (${code ?? 'signal'}).`), child);
+    });
+    return this.readyPromise;
+  }
+
+  async turn(text: string, options: Pick<SubmitOptions, 'signal' | 'timeoutMs'> = {}): Promise<CodexDesktopTurnResult> {
+    const transcript = text.trim();
+    if (!transcript) throw new Error('The transcript is empty.');
+    if (options.signal?.aborted) throw new Error('The Codex turn was cancelled.');
+    await this.warm();
+    const child = this.child;
+    if (!child?.stdin.writable) throw new Error('Codex Desktop warm bridge is unavailable.');
+    if (this.pending.size > 0) throw new Error('A canonical Codex turn is already in flight.');
+
+    const requestId = randomUUID();
+    const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    return new Promise<CodexDesktopTurnResult>((resolve, reject) => {
+      const onAbort = () => this.reset(new Error('The Codex turn was cancelled.'), child);
+      const timer = setTimeout(() => {
+        this.reset(new Error(`Timed out waiting for the exact Codex task after ${timeoutMs}ms.`), child);
+      }, timeoutMs);
+      timer.unref();
+      const pending: PendingWarmTurn = { resolve, reject, timer, signal: options.signal, onAbort };
+      this.pending.set(requestId, pending);
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+      child.stdin.write(`${JSON.stringify({ type: 'submit', requestId, text: transcript })}\n`);
+    });
+  }
+
+  close(): void {
+    this.disposed = true;
+    this.reset(new Error('The Codex Desktop session was closed.'), this.child);
+  }
+
+  private consumeStdout(chunk: Buffer, child: ChildProcessWithoutNullStreams): void {
+    if (this.child !== child) return;
+    this.stdout += chunk.toString('utf8');
+    if (Buffer.byteLength(this.stdout, 'utf8') > MAX_OUTPUT_BYTES) {
+      this.reset(new Error('Codex Desktop bridge output exceeded its safety limit.'), child);
+      return;
+    }
+    const lines = this.stdout.split('\n');
+    this.stdout = lines.pop() ?? '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let envelope: BridgeEnvelope;
+      try {
+        envelope = JSON.parse(line) as BridgeEnvelope;
+      } catch {
+        this.reset(new Error('Codex Desktop returned an unreadable bridge result.'), child);
+        return;
+      }
+      if (envelope.type === 'ready') {
+        if (!envelope.ok || envelope.threadId !== this.threadId) {
+          this.reset(new Error(envelope.error || 'Codex Desktop warmed the wrong task.'), child);
+          return;
+        }
+        if (this.readyTimer) clearTimeout(this.readyTimer);
+        this.readyTimer = null;
+        const resolve = this.readyResolve;
+        this.readyResolve = null;
+        this.readyReject = null;
+        resolve?.();
+        continue;
+      }
+      if (this.readyResolve && envelope.ok === false && !envelope.requestId) {
+        this.reset(new Error(envelope.error || 'Codex Desktop could not warm the exact task.'), child);
+        return;
+      }
+      const requestId = envelope.requestId;
+      if (!requestId) continue;
+      const pending = this.pending.get(requestId);
+      if (!pending) continue;
+      this.pending.delete(requestId);
+      clearTimeout(pending.timer);
+      if (pending.onAbort) pending.signal?.removeEventListener('abort', pending.onAbort);
+      try {
+        pending.resolve(parseBridgeEnvelope(envelope, this.threadId));
+      } catch (error) {
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  }
+
+  private reset(error: Error, child: ChildProcessWithoutNullStreams | null): void {
+    if (child && this.child !== child) return;
+    const active = this.child;
+    this.child = null;
+    if (this.readyTimer) clearTimeout(this.readyTimer);
+    this.readyTimer = null;
+    const rejectReady = this.readyReject;
+    this.readyResolve = null;
+    this.readyReject = null;
+    this.readyPromise = null;
+    rejectReady?.(error);
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      if (pending.onAbort) pending.signal?.removeEventListener('abort', pending.onAbort);
+      pending.reject(error);
+    }
+    this.pending.clear();
+    if (active) stop(active);
+  }
 }
 
 /**

--- a/src/cli/deck-runtime-navigation.test.ts
+++ b/src/cli/deck-runtime-navigation.test.ts
@@ -15,7 +15,7 @@ function runtimeInternals(runtime: DeckRuntime): RuntimeInternals {
 
 describe('Deck canonical IPC lifecycle', () => {
   test('lane navigation preserves an in-flight canonical waiter and playback', async () => {
-    const runtime = new DeckRuntime({ warmCatalog: false });
+    const runtime = new DeckRuntime({ warmCatalog: false, warmCanonical: false });
     const internal = runtimeInternals(runtime);
     const controller = new AbortController();
     internal.busy = true;
@@ -37,7 +37,7 @@ describe('Deck canonical IPC lifecycle', () => {
   });
 
   test('stop silences transport without dropping the canonical result', async () => {
-    const runtime = new DeckRuntime({ warmCatalog: false });
+    const runtime = new DeckRuntime({ warmCatalog: false, warmCanonical: false });
     const internal = runtimeInternals(runtime);
     const controller = new AbortController();
     internal.busy = true;
@@ -57,7 +57,7 @@ describe('Deck canonical IPC lifecycle', () => {
   });
 
   test('a second capture is rejected without cancelling the current turn', async () => {
-    const runtime = new DeckRuntime({ warmCatalog: false });
+    const runtime = new DeckRuntime({ warmCatalog: false, warmCanonical: false });
     const internal = runtimeInternals(runtime);
     const controller = new AbortController();
     internal.busy = true;

--- a/src/cli/deck-runtime-navigation.test.ts
+++ b/src/cli/deck-runtime-navigation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+
+import { DeckRuntime } from './deck-runtime';
+
+type RuntimeInternals = {
+  busy: boolean;
+  canonicalTurnAbort: AbortController | null;
+  gen: number;
+  playing: string | null;
+};
+
+function runtimeInternals(runtime: DeckRuntime): RuntimeInternals {
+  return runtime as unknown as RuntimeInternals;
+}
+
+describe('Deck canonical IPC lifecycle', () => {
+  test('lane navigation preserves an in-flight canonical waiter and playback', async () => {
+    const runtime = new DeckRuntime({ warmCatalog: false });
+    const internal = runtimeInternals(runtime);
+    const controller = new AbortController();
+    internal.busy = true;
+    internal.canonicalTurnAbort = controller;
+    internal.gen = 41;
+    internal.playing = '0:0';
+
+    const result = await runtime.apply({ name: 'lane.select', index: 2 });
+
+    expect(result.ok).toBe(true);
+    expect(runtime.snapshot().lane).toBe(2);
+    expect(internal.gen).toBe(41);
+    expect(controller.signal.aborted).toBe(false);
+    expect(runtime.snapshot().playing).toBe('0:0');
+
+    internal.busy = false;
+    internal.canonicalTurnAbort = null;
+    runtime.destroy();
+  });
+
+  test('stop silences transport without dropping the canonical result', async () => {
+    const runtime = new DeckRuntime({ warmCatalog: false });
+    const internal = runtimeInternals(runtime);
+    const controller = new AbortController();
+    internal.busy = true;
+    internal.canonicalTurnAbort = controller;
+    internal.gen = 7;
+
+    const result = await runtime.apply({ name: 'playback.stop' });
+
+    expect(result.ok).toBe(true);
+    expect(internal.gen).toBe(7);
+    expect(controller.signal.aborted).toBe(false);
+    expect(runtime.snapshot().confirm).toBe('AUDIO STOPPED · TASK CONTINUES');
+
+    internal.busy = false;
+    internal.canonicalTurnAbort = null;
+    runtime.destroy();
+  });
+
+  test('a second capture is rejected without cancelling the current turn', async () => {
+    const runtime = new DeckRuntime({ warmCatalog: false });
+    const internal = runtimeInternals(runtime);
+    const controller = new AbortController();
+    internal.busy = true;
+    internal.canonicalTurnAbort = controller;
+    internal.gen = 13;
+
+    const result = await runtime.apply({ name: 'capture.start' });
+
+    expect(result).toMatchObject({ ok: false, error: 'response already in flight' });
+    expect(internal.gen).toBe(13);
+    expect(controller.signal.aborted).toBe(false);
+    expect(runtime.snapshot().listening).toBe(false);
+
+    internal.busy = false;
+    internal.canonicalTurnAbort = null;
+    runtime.destroy();
+  });
+});

--- a/src/cli/deck-runtime-route.test.ts
+++ b/src/cli/deck-runtime-route.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveDeckTurnRoute } from './deck-runtime';
+
+describe('Deck turn authority', () => {
+  test('routes a bound worker pad to its exact canonical Codex task', () => {
+    expect(resolveDeckTurnRoute(2, '  task-123  ')).toEqual({
+      kind: 'canonical',
+      taskId: 'task-123',
+    });
+  });
+
+  test('refuses an unassigned worker pad instead of creating a session', () => {
+    expect(resolveDeckTurnRoute(2)).toEqual({ kind: 'unassigned' });
+    expect(resolveDeckTurnRoute(2, '   ')).toEqual({ kind: 'unassigned' });
+  });
+
+  test('reserves the hidden model transport for the overview role', () => {
+    expect(resolveDeckTurnRoute(9, 'ignored-worker-task')).toEqual({ kind: 'overview' });
+  });
+});

--- a/src/cli/deck-runtime-route.test.ts
+++ b/src/cli/deck-runtime-route.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { resolveDeckTurnRoute } from './deck-runtime';
+import { parseIntent, resolveDeckTurnRoute } from './deck-runtime';
 
 describe('Deck turn authority', () => {
   test('routes a bound worker pad to its exact canonical Codex task', () => {
@@ -17,5 +17,19 @@ describe('Deck turn authority', () => {
 
   test('reserves the hidden model transport for the overview role', () => {
     expect(resolveDeckTurnRoute(9, 'ignored-worker-task')).toEqual({ kind: 'overview' });
+  });
+
+  test('accepts an atomic assign-and-activate intent from the Deck picker', () => {
+    expect(parseIntent({
+      name: 'lane.assign',
+      index: 0,
+      threadId: 'task-123',
+      activate: true,
+    }).intent).toEqual({
+      name: 'lane.assign',
+      index: 0,
+      threadId: 'task-123',
+      activate: true,
+    });
   });
 });

--- a/src/cli/deck-runtime.ts
+++ b/src/cli/deck-runtime.ts
@@ -121,6 +121,11 @@ export interface DeckSnapshot {
   clients: number;
 }
 
+export interface DeckRuntimeOptions {
+  /** Skip the eager Codex catalog read in isolated runtime tests. */
+  warmCatalog?: boolean;
+}
+
 const intentSchema = z.discriminatedUnion('name', [
   // max 9: lanes 0-8 plus the deck-owned overview lane (MASTER_IX below —
   // a literal here because the schema initializes before the constants)
@@ -393,8 +398,11 @@ export class DeckRuntime extends EventEmitter {
   private ticker: NodeJS.Timeout | null = null;
   private busy = false;
   private destroyed = false;
-  /** bumped on stop/cancel — pending response work checks it before every phase */
+  /** Bumped for each accepted capture and teardown; async phases retain only
+   * the generation that created them. */
   private gen = 0;
+  /** A transport stop silences the current reply without detaching from Codex. */
+  private suppressAutoplayForGeneration: number | null = null;
   private player: ChildProcess | null = null;
   private playerRate = 1;
   private synthDir = mkdtempSync(path.join(tmpdir(), 'speakeasy-deck-synth-'));
@@ -406,12 +414,12 @@ export class DeckRuntime extends EventEmitter {
     return this.synthDir;
   }
 
-  constructor() {
+  constructor(options: DeckRuntimeOptions = {}) {
     super();
     this.restoreLaneBindings();
     // Warm the exact Codex task catalog before the user opens lane setup. The
     // explicit refresh action reuses this in-flight request if it is still busy.
-    void this.refreshThreadCatalog();
+    if (options.warmCatalog !== false) void this.refreshThreadCatalog();
   }
 
   /** Copy identity from the exact Codex catalog record used for the binding.
@@ -687,15 +695,17 @@ export class DeckRuntime extends EventEmitter {
     return this.lanes[ix]?.name.toLowerCase() ?? `lane ${ix + 1}`;
   }
 
-  /** Change the conversation target and cancel work/audio owned by the old one. */
+  /** Change only what the operator is viewing and targeting next.
+   *
+   * Canonical work and playback belong to their origin lane, not to the
+   * currently visible lane. Navigation must therefore never abort the Codex
+   * waiter, bump its generation, or stop its audio. */
   private selectLane(index: number): void {
-    this.gen++;
-    this.cancelAgentWork();
     this.laneIx = index;
-    this.stopPlayer();
-    this.clearPlayback();
     const label = index === MASTER_IX ? 'OVERVIEW' : `LANE ${String(index + 1).padStart(2, '0')}`;
-    this.setPhase(this.phase, `READY · ${label}`);
+    const state = this.lanes[index]?.state;
+    const status = state === 'working' ? 'WORKING' : state === 'speaking' ? 'SPEAKING' : 'READY';
+    this.setPhase(this.phase, `${status} · ${label}`);
     this.log('LANE SELECTED', index === MASTER_IX ? 'overview' : `lane ${index + 1}`);
     this.changed();
   }
@@ -830,13 +840,16 @@ export class DeckRuntime extends EventEmitter {
         this.changed();
         return { ok: true, rev: this.rev };
       case 'playback.stop':
-        this.gen++; // cancel any pending response work
-        this.cancelAgentWork();
+        // Transport control is intentionally not task control. Aborting the
+        // bridge here would leave Codex running while silently dropping its
+        // result from the Deck. Preserve the canonical waiter and merely keep
+        // this response from autoplaying when it lands.
+        if (this.busy) this.suppressAutoplayForGeneration = this.gen;
         this.stopPlayer();
         this.clearPlayback();
         this.listening = false;
-        this.setPhase('idle', 'CANCELLED');
-        this.log('PLAYBACK STOPPED', 'buffer cleared');
+        this.setPhase('idle', this.busy ? 'AUDIO STOPPED · TASK CONTINUES' : 'AUDIO STOPPED');
+        this.log('PLAYBACK STOPPED', this.busy ? 'audio cleared · canonical task continues' : 'buffer cleared');
         this.changed();
         return { ok: true, rev: this.rev };
       case 'playback.replay': {
@@ -859,8 +872,11 @@ export class DeckRuntime extends EventEmitter {
         return { ok: false, rev: this.rev, error: 'no replayable reply' };
       }
       case 'capture.start':
+        // Until one bridge can correlate multiple steering requests to a
+        // single terminal Codex turn, fail explicitly instead of detaching the
+        // response already in flight. The operator can still browse all lanes.
+        if (this.busy) return { ok: false, rev: this.rev, error: 'response already in flight' };
         this.gen++;
-        this.cancelAgentWork();
         this.stopPlayer();
         this.clearPlayback();
         this.listening = true;
@@ -979,13 +995,13 @@ export class DeckRuntime extends EventEmitter {
     const alive = () => this.gen === gen;
     this.setLaneState(lane, 'working');
     try {
-      this.setPhase('transcribing', 'TRANSCRIBING');
+      this.setPhase('transcribing', `TRANSCRIBING · LANE ${String(lane + 1).padStart(2, '0')}`);
       this.changed();
       await wait(600);
       if (!alive()) return;
 
       this.pushMessage(lane, { role: 'you', text: command, dur: estimateDuration(command) });
-      this.setPhase('submitting', 'SUBMITTING');
+      this.setPhase('submitting', `SUBMITTING · LANE ${String(lane + 1).padStart(2, '0')}`);
       this.log('AGENT ASKED', `${this.laneLabel(lane)} · ${command.slice(0, 40)}`);
       this.changed();
 
@@ -996,7 +1012,7 @@ export class DeckRuntime extends EventEmitter {
       this.pushMessage(lane, msg);
       const id = `${lane}:${this.threads[lane].length - 1}`;
 
-      this.setPhase('preparingSpeech', 'PREPARING SPEECH');
+      this.setPhase('preparingSpeech', `PREPARING SPEECH · LANE ${String(lane + 1).padStart(2, '0')}`);
       this.log('AGENT REPLY', `${msg.dur.toFixed(0)}s queued`);
       this.changed();
 
@@ -1012,18 +1028,18 @@ export class DeckRuntime extends EventEmitter {
       if (!file) {
         // synthesis failed — show the reply without audio, never fake playback
         msg.mirrored = true;
-        this.setPhase('idle', 'READY');
+        this.setPhase('idle', `READY · LANE ${String(lane + 1).padStart(2, '0')}`);
         this.log('NO AUDIO', 'synthesis unavailable · text-only reply');
         this.changed();
         return;
       }
       msg.file = file;
       msg.audioUrl = `/audio/${path.basename(file)}`;
-      if (this.autoplay) {
+      if (this.autoplay && this.suppressAutoplayForGeneration !== gen) {
         this.playing = id;
         this.paused = false;
         this.pos = 0;
-        this.setPhase('speaking', 'SPEAKING');
+        this.setPhase('speaking', `SPEAKING · LANE ${String(lane + 1).padStart(2, '0')}`);
         this.setLaneState(lane, 'speaking');
         this.ensureTicker();
         this.changed();
@@ -1031,11 +1047,12 @@ export class DeckRuntime extends EventEmitter {
         // when nobody is watching
         if (this.liveClients() === 0) this.playFile(file);
       } else {
-        this.setPhase('idle', 'READY');
+        this.setPhase('idle', `READY · LANE ${String(lane + 1).padStart(2, '0')}`);
         this.changed();
       }
     } finally {
       this.busy = false;
+      if (this.suppressAutoplayForGeneration === gen) this.suppressAutoplayForGeneration = null;
       if (this.lanes[lane]?.state !== 'speaking' && this.setLaneState(lane, 'idle')) this.changed();
     }
   }
@@ -1110,7 +1127,8 @@ export class DeckRuntime extends EventEmitter {
     }
   }
 
-  /** Interrupt any in-flight lane turn — called on stop, lane change, new capture, destroy. */
+  /** Detach from in-flight work during runtime teardown only. User-facing
+   * navigation and transport controls must preserve canonical task delivery. */
   private cancelAgentWork(): void {
     this.canonicalTurnAbort?.abort();
     this.canonicalTurnAbort = null;

--- a/src/cli/deck-runtime.ts
+++ b/src/cli/deck-runtime.ts
@@ -10,6 +10,7 @@ import {
   type DeckAgentClient,
   type DeckAgentClientOptions,
 } from './deck-agent-client.js';
+import { submitCodexDesktopTurn } from './codex-desktop-submit.js';
 import { displayCodexThreadTitle, listCodexThreadReferences } from './codex-thread-catalog.js';
 
 /** execFile as a promise, capturing stdout, with a hard timeout. */
@@ -163,6 +164,18 @@ const LANES_FILE = path.join(homedir(), '.config', 'speakeasy', 'deck-lanes.json
 const CODEX_SESSIONS_DIR = path.join(homedir(), '.codex', 'sessions');
 const CATALOG_LIMIT = 25;
 
+export type DeckTurnRoute =
+  | { kind: 'canonical'; taskId: string }
+  | { kind: 'unassigned' }
+  | { kind: 'overview' };
+
+/** Resolve authority before a transcript can touch any model transport. */
+export function resolveDeckTurnRoute(laneIx: number, taskId?: string): DeckTurnRoute {
+  if (laneIx === MASTER_IX) return { kind: 'overview' };
+  const exactTaskId = taskId?.trim();
+  return exactTaskId ? { kind: 'canonical', taskId: exactTaskId } : { kind: 'unassigned' };
+}
+
 /** Read at most `bytes` from the head of a file. */
 function readHead(file: string, bytes: number): string {
   const fd = openSync(file, 'r');
@@ -277,9 +290,9 @@ function scanCodexThreadsFallback(): DeckThreadInfo[] | null {
   return out;
 }
 
-/** Per-lane session reuse keys, persisted so a cycled (reset) lane keeps its
- * fresh session across deck restarts instead of resurrecting the base one.
- * Only deck-owned keys are honored — legacy scout session ids are ignored. */
+/** Per-lane binding keys. The files beneath these keys persist only the exact
+ * Codex task assigned to each worker pad; they are not worker-agent identities.
+ * Only Deck-owned keys are honored — legacy Scout session ids are ignored. */
 function loadLaneKeys(): string[] {
   const base = Array.from({ length: LANE_COUNT }, (_, i) => `speakeasy-deck-lane-${i}`);
   try {
@@ -293,11 +306,6 @@ function loadLaneKeys(): string[] {
   }
 }
 
-/** Session-level instructions for every lane's codex session. */
-const VOICE_SYSTEM_PROMPT =
-  'You are a voice responder for a spoken interface. Do not use tools, do not read or write files, do not access the network. ' +
-  'Answer from general knowledge only, in one or two spoken-style sentences, plain words, no lists, no code.';
-
 /** Session-level instructions for the overview lane: the digest is its eyes. */
 const OVERVIEW_SYSTEM_PROMPT =
   'You are the overview officer of a voice-command deck with nine lanes, each a live codex thread. ' +
@@ -306,8 +314,7 @@ const OVERVIEW_SYSTEM_PROMPT =
   'Do not use tools, do not read or write files, do not access the network. ' +
   'Plain spoken words, no lists, no code: one or two sentences for a status question, a few plain sentences for a summary.';
 
-/** Options for the lane session factory — model/effort select a cheaper,
- * faster brain for the overview lane while workers keep the default. */
+/** Options for the overview session factory. Worker pads never create one. */
 type LaneClientOptions = DeckAgentClientOptions;
 type LaneAgentClient = DeckAgentClient;
 
@@ -346,7 +353,7 @@ export class DeckRuntime extends EventEmitter {
     ...Array.from({ length: LANE_COUNT }, (_, i) => ({
       num: String(i + 1).padStart(2, '0'),
       name: `LANE ${i + 1}`,
-      title: 'new codex session on first ask',
+      title: 'assign a Codex task before speaking',
       state: 'idle' as const,
     })),
     {
@@ -356,10 +363,12 @@ export class DeckRuntime extends EventEmitter {
       state: 'idle' as const,
     },
   ];
-  /** per-lane session reuse keys — cycling a lane bumps its key to reset the session */
+  /** per-lane binding keys — clearing a lane rotates the persisted assignment */
   private laneKeys: string[] = loadLaneKeys();
-  /** warm session clients, created lazily on each lane's first question */
+  /** The single hidden overview client. Worker conversations never use it. */
   private laneClients = new Map<number, { key: string; client: LaneAgentClient }>();
+  /** One direct turn currently owned by the Codex Desktop bridge. */
+  private canonicalTurnAbort: AbortController | null = null;
   private threads: DeckMessage[][] = Array.from({ length: LANE_COUNT + 1 }, () => []);
   private playing: string | null = null;
   private paused = false;
@@ -459,8 +468,8 @@ export class DeckRuntime extends EventEmitter {
     return this.catalogRefresh;
   }
 
-  /** Rebuild lane labels for persisted thread bindings — the adapter resumes
-   * the thread on its own; this restores what the pad SAYS it is bound to.
+  /** Rebuild lane labels for persisted task bindings. The direct Desktop
+   * bridge uses the exact task id; this restores what the pad says it targets.
    * Restores honor the one-thread-one-lane invariant too: legacy state from
    * before dedupe can double-bind a thread, and the first lane keeps it. */
   private restoreLaneBindings(): void {
@@ -471,14 +480,14 @@ export class DeckRuntime extends EventEmitter {
       try {
         threadId = readFileSync(path.join(laneRuntimeDir(key), 'codex-thread-id.txt'), 'utf8').trim();
       } catch {
-        return; // unseeded lane — fresh session
+        return; // unseeded lane — unassigned
       }
       if (!threadId) return;
       if (claimed.has(threadId)) {
-        // double binding from an older build — rotate to a fresh key
+        // double binding from an older build — rotate to an unassigned key
         this.laneKeys[i] = `speakeasy-deck-lane-${i}-${Date.now().toString(36)}`;
         rotated = true;
-        this.log('LANE DEDUPED', `lane ${i + 1} → fresh session (thread already bound)`);
+        this.log('LANE DEDUPED', `lane ${i + 1} → unassigned (task already bound)`);
         return;
       }
       claimed.add(threadId);
@@ -527,13 +536,11 @@ export class DeckRuntime extends EventEmitter {
 
   // ── lanes ────────────────────────────────────────────────────────────────
 
-  /** The lane's warm codex session client, created on first use. Sessions are
-   * owned by the deck via @openscout/agent-sessions — the adapter persists the
-   * codex thread id under the reuse key, so a lane resumes its exact thread
-   * across deck restarts with no broker involvement. */
+  /** The Deck-owned overview session. Worker pads are input/output peripherals
+   * for explicit Codex tasks and must never create an app-server session. */
   private async laneClient(ix: number): Promise<LaneAgentClient> {
-    // the overview lane has a fixed, deck-owned key — it is never remapped
-    const key = ix === MASTER_IX ? MASTER_REUSE_KEY : this.laneKeys[ix];
+    if (ix !== MASTER_IX) throw new Error('Assign a Codex task to this lane before speaking.');
+    const key = MASTER_REUSE_KEY;
     const existing = this.laneClients.get(ix);
     if (existing && existing.key === key) return existing.client;
     if (existing) {
@@ -545,15 +552,13 @@ export class DeckRuntime extends EventEmitter {
       cwd: process.cwd(),
       reuseKey: key,
       warmth: 'lazy',
-      systemPrompt: ix === MASTER_IX ? OVERVIEW_SYSTEM_PROMPT : VOICE_SYSTEM_PROMPT,
+      systemPrompt: OVERVIEW_SYSTEM_PROMPT,
+      model: OVERVIEW_MODEL,
+      effort: OVERVIEW_EFFORT,
     };
-    if (ix === MASTER_IX) {
-      options.model = OVERVIEW_MODEL;
-      options.effort = OVERVIEW_EFFORT;
-    }
     const client = await createDeckAgentClient(options);
     // a reset or destroy during creation must not install a stale client
-    const currentKey = ix === MASTER_IX ? MASTER_REUSE_KEY : this.laneKeys[ix];
+    const currentKey = MASTER_REUSE_KEY;
     if (this.destroyed || currentKey !== key) {
       void client.close().catch(() => undefined);
       throw new Error('lane was reset');
@@ -588,9 +593,7 @@ export class DeckRuntime extends EventEmitter {
     }
   }
 
-  /** The thread a lane's key currently points at, if one was recorded — the
-   * adapter writes this for fresh sessions too, so read it live rather than
-   * tracking it in memory. */
+  /** The exact Codex task assigned to a worker pad, if one was recorded. */
   private laneThreadId(index: number): string | null {
     try {
       const id = readFileSync(path.join(laneRuntimeDir(this.laneKeys[index]), 'codex-thread-id.txt'), 'utf8').trim();
@@ -600,8 +603,8 @@ export class DeckRuntime extends EventEmitter {
     }
   }
 
-  /** Channel mapper: bind a pad to an existing codex thread, or to a fresh
-   * session when threadId is null. Only ever called while no response is in
+  /** Channel mapper: bind a pad to an existing Codex task, or clear its
+   * assignment when threadId is null. Only ever called while no response is in
    * flight (apply() rejects lane.cycle/lane.assign when busy), so this never
    * touches another lane's turn. */
   private assignLane(index: number, threadId: string | null): void {
@@ -662,14 +665,14 @@ export class DeckRuntime extends EventEmitter {
         }
       }
     } else {
-      lane.title = 'new codex session on first ask';
+      lane.title = 'assign a Codex task before speaking';
       lane.threadId = undefined;
       lane.sessionAlias = undefined;
       lane.project = undefined;
       lane.cwd = undefined;
       lane.branch = undefined;
       lane.updatedAt = undefined;
-      this.log(threadId ? 'ASSIGN FAILED' : 'LANE RESET', `lane ${index + 1} → fresh session`);
+      this.log(threadId ? 'ASSIGN FAILED' : 'LANE CLEARED', `lane ${index + 1} → unassigned`);
     }
     this.changed();
   }
@@ -682,7 +685,7 @@ export class DeckRuntime extends EventEmitter {
    * line per lane: binding, state, title, and the last exchange if there is one. */
   private systemDigest(): string {
     const lines = this.lanes.slice(0, LANE_COUNT).map((lane, i) => {
-      const bound = lane.threadId ? `bound ${lane.sessionAlias}` : 'fresh session';
+      const bound = lane.threadId ? `bound ${lane.sessionAlias}` : 'unassigned';
       let line = `lane ${i + 1}: ${bound} · ${lane.state} · "${lane.title}"`;
       const msgs = this.threads[i];
       const lastYou = [...msgs].reverse().find((m) => m.role === 'you')?.text;
@@ -1016,19 +1019,45 @@ export class DeckRuntime extends EventEmitter {
     }
   }
 
-  /** Ask the lane's codex session and get a spoken-length answer back. Each
-   * lane owns one warm session via @openscout/agent-sessions — turns steer the
-   * codex app-server transport directly (no broker dispatch, no receipts), so
-   * follow-ups continue the exact same thread. */
+  /** Ask one lane. Existing worker bindings go through the sole Codex Desktop
+   * owner so the user's dictation is a native turn in the exact visible task.
+   * Luna remains confined to the deck-owned overview lane; it never receives
+   * or proxies a bound lane's user turn. */
   private async askAgent(question: string, laneIx: number): Promise<string> {
     const lane = this.lanes[laneIx];
+    const route = resolveDeckTurnRoute(laneIx, lane?.threadId);
     try {
-      const client = await this.laneClient(laneIx);
-      // the overview lane sees the whole deck: its question rides on a live digest
-      const input =
-        laneIx === MASTER_IX
-          ? `${this.systemDigest()}\n\nOperator asks: ${question.slice(0, 500)}`
-          : question.slice(0, 500);
+      if (route.kind === 'unassigned') {
+        this.log('LANE UNASSIGNED', `lane ${laneIx + 1} · no Codex task`);
+        return 'Assign a Codex task to this lane before speaking.';
+      }
+      if (route.kind === 'canonical') {
+        const controller = new AbortController();
+        this.canonicalTurnAbort = controller;
+        try {
+          const result = await submitCodexDesktopTurn(route.taskId, question, {
+            signal: controller.signal,
+            timeoutMs: 180_000,
+          });
+          lane.updatedAt = Date.now();
+          this.log(
+            'CANONICAL TURN',
+            result.delivery === 'steered-active-turn'
+              ? `lane ${laneIx + 1} · steered active Codex task`
+              : `lane ${laneIx + 1} · started in Codex Desktop`,
+          );
+          const text = result.response.trim();
+          if (!text) throw new Error('empty reply from the canonical task');
+          return text.length > 600 ? text.slice(0, 600).replace(/\s+\S*$/, '') + '…' : text;
+        } finally {
+          if (this.canonicalTurnAbort === controller) this.canonicalTurnAbort = null;
+        }
+      }
+
+      // Only the hidden overview role reaches this path. It receives a status
+      // digest, never a worker lane's transcript or canonical task context.
+      const client = await this.laneClient(MASTER_IX);
+      const input = `${this.systemDigest()}\n\nOperator asks: ${question.slice(0, 500)}`;
       const result = await client.turn({ input, timeoutMs: 180_000 });
       const thread = result.session.nativeId;
       // codex thread ids are UUIDv7 — the leading bytes are a timestamp, so
@@ -1047,7 +1076,12 @@ export class DeckRuntime extends EventEmitter {
       if (!text) throw new Error('empty reply from session');
       return text.length > 600 ? text.slice(0, 600).replace(/\s+\S*$/, '') + '…' : text;
     } catch (error) {
-      this.log('AGENT FAILED', (error as Error).message.slice(0, 60));
+      const canonical = route.kind === 'canonical';
+      this.log(canonical ? 'CANONICAL FAILED' : 'AGENT FAILED', (error as Error).message.slice(0, 60));
+      if (canonical) {
+        return 'I could not reach the exact Codex task. Open that task in Codex Desktop and try again. SpeakEasy did not send this turn anywhere else.';
+      }
+      if (route.kind === 'unassigned') return 'Assign a Codex task to this lane before speaking.';
       const who = this.lanes[laneIx]?.name.toLowerCase();
       return who
         ? `${who[0].toUpperCase() + who.slice(1)} didn't answer that one — try again in a moment.`
@@ -1057,6 +1091,8 @@ export class DeckRuntime extends EventEmitter {
 
   /** Interrupt any in-flight lane turn — called on stop, lane change, new capture, destroy. */
   private cancelAgentWork(): void {
+    this.canonicalTurnAbort?.abort();
+    this.canonicalTurnAbort = null;
     for (const { client } of this.laneClients.values()) client.interrupt?.();
   }
 

--- a/src/cli/deck-runtime.ts
+++ b/src/cli/deck-runtime.ts
@@ -10,7 +10,7 @@ import {
   type DeckAgentClient,
   type DeckAgentClientOptions,
 } from './deck-agent-client.js';
-import { submitCodexDesktopTurn } from './codex-desktop-submit.js';
+import { CodexDesktopSession } from './codex-desktop-submit.js';
 import { displayCodexThreadTitle, listCodexThreadReferences } from './codex-thread-catalog.js';
 
 /** execFile as a promise, capturing stdout, with a hard timeout. */
@@ -124,6 +124,8 @@ export interface DeckSnapshot {
 export interface DeckRuntimeOptions {
   /** Skip the eager Codex catalog read in isolated runtime tests. */
   warmCatalog?: boolean;
+  /** Skip exact-task owner prewarming in isolated runtime tests. */
+  warmCanonical?: boolean;
 }
 
 const intentSchema = z.discriminatedUnion('name', [
@@ -380,6 +382,10 @@ export class DeckRuntime extends EventEmitter {
   private laneClients = new Map<number, { key: string; client: LaneAgentClient }>();
   /** One direct turn currently owned by the Codex Desktop bridge. */
   private canonicalTurnAbort: AbortController | null = null;
+  /** Warm exact-task channel. Owner discovery is intentionally amortized
+   * across turns because mature Codex task snapshots can be hundreds of MB. */
+  private canonicalSession: CodexDesktopSession | null = null;
+  private canonicalSessionReady = false;
   private threads: DeckMessage[][] = Array.from({ length: LANE_COUNT + 1 }, () => []);
   private playing: string | null = null;
   private paused = false;
@@ -420,6 +426,7 @@ export class DeckRuntime extends EventEmitter {
     // Warm the exact Codex task catalog before the user opens lane setup. The
     // explicit refresh action reuses this in-flight request if it is still busy.
     if (options.warmCatalog !== false) void this.refreshThreadCatalog();
+    if (options.warmCanonical !== false) queueMicrotask(() => this.warmCanonicalLane(this.laneIx));
   }
 
   /** Copy identity from the exact Codex catalog record used for the binding.
@@ -708,6 +715,37 @@ export class DeckRuntime extends EventEmitter {
     this.setPhase(this.phase, `${status} · ${label}`);
     this.log('LANE SELECTED', index === MASTER_IX ? 'overview' : `lane ${index + 1}`);
     this.changed();
+    this.warmCanonicalLane(index);
+  }
+
+  /** Reuse one proven Desktop owner while a task remains selected. Switching
+   * targets replaces the warm channel only while no canonical response is in
+   * flight; navigation during work therefore cannot detach the origin turn. */
+  private canonicalSessionFor(taskId: string): CodexDesktopSession {
+    if (this.canonicalSession?.threadId === taskId) return this.canonicalSession;
+    this.canonicalSession?.close();
+    this.canonicalSession = new CodexDesktopSession(taskId);
+    this.canonicalSessionReady = false;
+    return this.canonicalSession;
+  }
+
+  private warmCanonicalLane(index: number): void {
+    if (this.destroyed || this.busy) return;
+    const route = resolveDeckTurnRoute(index, this.lanes[index]?.threadId);
+    if (route.kind !== 'canonical') return;
+    const session = this.canonicalSessionFor(route.taskId);
+    if (this.canonicalSessionReady) return;
+    void session.warm().then(() => {
+      if (this.destroyed || this.canonicalSession !== session || this.canonicalSessionReady) return;
+      this.canonicalSessionReady = true;
+      this.log('CODEX LINK READY', `lane ${index + 1} · exact task owner verified`);
+      this.changed();
+    }).catch((error) => {
+      if (this.destroyed || this.canonicalSession !== session) return;
+      this.canonicalSessionReady = false;
+      this.log('CODEX LINK FAILED', (error as Error).message.slice(0, 60));
+      this.changed();
+    });
   }
 
   /** Live, compact picture of the whole deck — the overview lane's eyes. One
@@ -1054,6 +1092,7 @@ export class DeckRuntime extends EventEmitter {
       this.busy = false;
       if (this.suppressAutoplayForGeneration === gen) this.suppressAutoplayForGeneration = null;
       if (this.lanes[lane]?.state !== 'speaking' && this.setLaneState(lane, 'idle')) this.changed();
+      if (this.laneIx !== lane) this.warmCanonicalLane(this.laneIx);
     }
   }
 
@@ -1073,10 +1112,12 @@ export class DeckRuntime extends EventEmitter {
         const controller = new AbortController();
         this.canonicalTurnAbort = controller;
         try {
-          const result = await submitCodexDesktopTurn(route.taskId, question, {
+          const session = this.canonicalSessionFor(route.taskId);
+          const result = await session.turn(question, {
             signal: controller.signal,
             timeoutMs: 180_000,
           });
+          this.canonicalSessionReady = true;
           lane.updatedAt = Date.now();
           this.log(
             'CANONICAL TURN',
@@ -1132,6 +1173,9 @@ export class DeckRuntime extends EventEmitter {
   private cancelAgentWork(): void {
     this.canonicalTurnAbort?.abort();
     this.canonicalTurnAbort = null;
+    this.canonicalSession?.close();
+    this.canonicalSession = null;
+    this.canonicalSessionReady = false;
     for (const { client } of this.laneClients.values()) client.interrupt?.();
   }
 

--- a/src/cli/deck-runtime.ts
+++ b/src/cli/deck-runtime.ts
@@ -138,7 +138,13 @@ const intentSchema = z.discriminatedUnion('name', [
   z.object({ name: z.literal('speak'), text: z.string().min(1).max(4000) }),
   z.object({ name: z.literal('lane.cycle'), index: z.number().int().min(0).max(8) }),
   z.object({ name: z.literal('catalog.refresh') }),
-  z.object({ name: z.literal('lane.assign'), index: z.number().int().min(0).max(8), threadId: z.string().max(64).nullable() }),
+  z.object({
+    name: z.literal('lane.assign'),
+    index: z.number().int().min(0).max(8),
+    threadId: z.string().max(64).nullable(),
+    /** The Deck picker activates what the operator just chose; Mac settings can map silently. */
+    activate: z.boolean().optional(),
+  }),
   z.object({ name: z.literal('playback.progress'), id: z.string().regex(/^\d:\d{1,3}$/), pos: z.number().min(0), dur: z.number().positive().optional() }),
   z.object({ name: z.literal('playback.ended'), id: z.string().regex(/^\d:\d{1,3}$/) }),
 ]);
@@ -681,6 +687,19 @@ export class DeckRuntime extends EventEmitter {
     return this.lanes[ix]?.name.toLowerCase() ?? `lane ${ix + 1}`;
   }
 
+  /** Change the conversation target and cancel work/audio owned by the old one. */
+  private selectLane(index: number): void {
+    this.gen++;
+    this.cancelAgentWork();
+    this.laneIx = index;
+    this.stopPlayer();
+    this.clearPlayback();
+    const label = index === MASTER_IX ? 'OVERVIEW' : `LANE ${String(index + 1).padStart(2, '0')}`;
+    this.setPhase(this.phase, `READY · ${label}`);
+    this.log('LANE SELECTED', index === MASTER_IX ? 'overview' : `lane ${index + 1}`);
+    this.changed();
+  }
+
   /** Live, compact picture of the whole deck — the overview lane's eyes. One
    * line per lane: binding, state, title, and the last exchange if there is one. */
   private systemDigest(): string {
@@ -764,15 +783,7 @@ export class DeckRuntime extends EventEmitter {
   async apply(intent: DeckIntent): Promise<{ ok: boolean; rev: number; error?: string }> {
     switch (intent.name) {
       case 'lane.select': {
-        this.gen++; // an in-flight response must not restart audio under a new lane
-        this.cancelAgentWork();
-        this.laneIx = intent.index;
-        this.stopPlayer();
-        this.clearPlayback();
-        const label = intent.index === MASTER_IX ? 'OVERVIEW' : `LANE ${String(intent.index + 1).padStart(2, '0')}`;
-        this.setPhase(this.phase, `READY · ${label}`);
-        this.log('LANE SELECTED', intent.index === MASTER_IX ? 'overview' : `lane ${intent.index + 1}`);
-        this.changed();
+        this.selectLane(intent.index);
         return { ok: true, rev: this.rev };
       }
       case 'playback.toggle': {
@@ -896,6 +907,16 @@ export class DeckRuntime extends EventEmitter {
           return { ok: false, rev: this.rev, error: 'that thread belongs to the overview lane' };
         }
         this.assignLane(intent.index, intent.threadId);
+        // Mapping from the Deck is also a destination choice. Do this only
+        // after the exact binding is visible, so a failed write cannot switch
+        // the microphone to a lane that merely looks assigned.
+        if (
+          intent.activate &&
+          intent.threadId &&
+          this.lanes[intent.index]?.threadId === intent.threadId
+        ) {
+          this.selectLane(intent.index);
+        }
         return { ok: true, rev: this.rev };
       }
       case 'playback.progress': {


### PR DESCRIPTION
## What changed

- Route each assigned Deck lane directly to its exact Codex task owner.
- Fail closed for unassigned lanes or mismatched task identity instead of creating a shadow conversation.
- Keep the proven Desktop IPC owner warm across sequential turns and lane navigation.
- Add task-routing, navigation, identity, cancellation, and bridge-parser coverage.
- Document the task-scoped conversation topology and authority boundaries.

## Why

SpeakEasy is a remote input/output surface for the canonical Codex task. It must not silently create a second task, rewrite the operator turn, or route through a broker when exact ownership cannot be proven.

## User impact

Lane selection now identifies the real conversation target, navigation no longer drops in-flight task IPC, and subsequent turns avoid unnecessary owner rediscovery.

## Checks

- 13 Bun routing/IPC tests passed.
- 5 Node bridge tests passed.

## Stack

Depends on #20. This is PR 2 of 3; the native hybrid Deck is stacked immediately above it.