### PR TITLE
✨ Add native hybrid iOS Deck control surface

### DIFF
--- a/deck/index.html
+++ b/deck/index.html
@@ -230,6 +230,34 @@ body{
 @media (prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
 }
+
+/* The iPad shell owns the latency-sensitive left plate. In console mode this
+   document becomes only the presentation-heavy lane viewer; it keeps its own
+   runtime socket so native lane intents flow through the same authoritative
+   snapshot instead of an iOS/JavaScript state bridge. */
+html[data-se-surface="console"],
+html[data-se-surface="console"] body,
+html[data-se-surface="console"] #deck{
+  height:100%!important;min-height:100%!important;
+  background:transparent!important;overflow:hidden!important
+}
+html[data-se-surface="console"] .se-shell{
+  height:100%!important;min-height:0!important;overflow:hidden!important;
+  padding:0!important;gap:0!important;background:transparent!important
+}
+html[data-se-surface="console"] .se-topbar,
+html[data-se-surface="console"] .se-keypad-plate{display:none!important}
+html[data-se-surface="console"] .se-decks{
+  display:block!important;position:relative!important;
+  flex:1 1 0!important;height:auto!important;min-height:0!important
+}
+html[data-se-surface="console"] .se-console-plate{
+  position:relative!important;inset:auto!important;box-sizing:border-box!important;
+  flex:1 1 0!important;width:100%!important;height:auto!important;min-height:0!important
+}
+html[data-se-surface="console"] .se-console-plate .se-conv{
+  flex:1 1 0!important;min-height:120px!important;overflow-y:auto!important
+}
 </style>
 </head>
 <body>
@@ -242,7 +270,11 @@ body{
 // A direct file open cannot reach the Mac runtime. It used to silently fall
 // back to canned lanes and replies, making a dead connection look real.
 // Redirect normal file opens to the live Deck; the showcase is opt-in only.
-const DEMO_MODE = new URLSearchParams(location.search).get('demo') === '1';
+const BOOT_QUERY = new URLSearchParams(location.search);
+const DEMO_MODE = BOOT_QUERY.get('demo') === '1';
+const SURFACE_MODE = BOOT_QUERY.get('surface') || 'deck';
+const NATIVE_AUDIO_HOST = BOOT_QUERY.get('nativeAudio') === '1';
+document.documentElement.dataset.seSurface = SURFACE_MODE;
 if (location.protocol === 'file:' && !DEMO_MODE) {
   location.replace('https://speak.air.local/');
   return;
@@ -327,7 +359,8 @@ const SPEEDS = [1, 1.25, 1.5, 0.75];
 // Seed themes. `paper` is the CSS :root default and needs no overrides; the
 // others replace the token values inline on <html> at boot. `ember` keeps the
 // paper pad plate — the pad surface is always paper, whatever the console
-// does. Selected with ?theme=paper|ember|flight or speakeasyDeck.setTheme().
+// does. Selected with ?theme=paper|porcelain|ember|flight|obsidian or
+// speakeasyDeck.setTheme().
 // ────────────────────────────────────────────────────────────────────────────
 
 const SEEDS = {
@@ -346,6 +379,54 @@ const SEEDS = {
     'btn-sheen': 'inset 0 1px 0 rgba(255,255,255,0.07)',
     'panel-shadow': 'inset 0 0 0 1px rgba(255,255,255,0.06), 0 14px 30px -16px rgba(0,0,0,0.65)',
     'card-shadow': '0 1px 2px rgba(0,0,0,0.4)'
+  } },
+  obsidian: { scheme: 'dark', vars: {
+    'page-bg': '#030405', 'panel': '#090b0d', 'panel-head': '#0d1013', 'cell': '#11151a', 'trace-bg': '#07090b',
+    'line': '#252c33', 'line-soft': '#181e24',
+    'ink': '#f1f4f6', 'ink-2': '#b6c0c9', 'ink-3': '#77838e', 'ink-4': '#4d5862',
+    'accent': '#79b8ff', 'accent-dim': '#4b82b8', 'accent-ink': '#9dcbff', 'accent-edge': '#244968',
+    'accent-ring': 'rgba(121,184,255,0.17)', 'accent-contrast': '#061522', 'chip-bg': '#091a2a', 'chip-ink': '#9dcbff', 'caption-ink': '#b6c0c9',
+    'you-bg': '#050709', 'you-edge': '#252c33', 'you-ink': '#f1f4f6',
+    'player-bg': '#0b1117', 'player-edge': '#252c33', 'player-ink': '#e6f2ff', 'player-text': '#79b8ff',
+    'wave-on': '#79b8ff', 'wave-off': '#2b3946',
+    'plate-bg': '#07090b', 'plate-wash': 'linear-gradient(168deg,#11151a,#06080a)', 'plate-edge': '#252c33',
+    'plate-rule': '#181e24', 'plate-ink': '#edf3f8', 'plate-ink-2': '#aebbc6', 'plate-ink-3': '#717e89',
+    'plate-track': '#151b21',
+    'pad-face': 'linear-gradient(160deg,#14191f,#0d1116)', 'pad-face-on': 'linear-gradient(160deg,#102b43,#091a2a)',
+    'pad-face-empty': 'linear-gradient(160deg,#0c1014,#080b0e)', 'pad-edge': '#28323b', 'pad-accent': '#79b8ff',
+    'pad-ring': 'rgba(121,184,255,0.16)', 'pad-num': '#dbe5ed', 'pad-num-empty': '#4d5862',
+    'pad-ink-idle': '#7d8994', 'pad-snippet': '#77838e', 'pad-snippet-on': '#bdd8f4', 'pad-spark-idle': '#2b3946',
+    'mic-a': '#256fa8', 'mic-b': '#184a72', 'mic-edge': '#5fa6df', 'mic-ink': '#f3f9ff', 'mic-sub-ink': '#b9d8ef',
+    'btn-face': 'linear-gradient(180deg,#171c22,#0e1216)', 'btn-edge': '#28323b', 'btn-ink': '#aebbc6',
+    'btn-sheen': 'inset 0 1px 0 rgba(255,255,255,0.06)',
+    'led-idle': '#34414b', 'led-empty': '#252d34', 'ink-empty': '#4d5862',
+    'status-working': '#e8b85d', 'status-working-ink': '#e8b85d', 'status-working-glow': '0 0 5px rgba(232,184,93,0.62)',
+    'panel-shadow': 'inset 0 0 0 1px rgba(255,255,255,0.04), 0 16px 34px -18px rgba(0,0,0,0.82)',
+    'card-shadow': '0 1px 2px rgba(0,0,0,0.55)'
+  } },
+  porcelain: { scheme: 'light', vars: {
+    'page-bg': '#eeece7', 'panel': '#fcfbf8', 'panel-head': '#f6f3ed', 'cell': '#ffffff', 'trace-bg': '#f3f0e9',
+    'line': '#d5d0c7', 'line-soft': '#e3ded5',
+    'ink': '#1e2328', 'ink-2': '#4d555d', 'ink-3': '#747c83', 'ink-4': '#a0a5a8',
+    'accent': '#245a74', 'accent-dim': '#5a8396', 'accent-ink': '#204d60', 'accent-edge': '#b8cfd8',
+    'accent-ring': 'rgba(36,90,116,0.14)', 'accent-contrast': '#f6fbfd', 'chip-bg': '#e4eef2', 'chip-ink': '#204d60', 'caption-ink': '#4d555d',
+    'you-bg': '#1e2328', 'you-edge': '#1e2328', 'you-ink': '#f8f9f9',
+    'player-bg': '#e8edef', 'player-edge': '#ccd7db', 'player-ink': '#f6fbfd', 'player-text': '#204d60',
+    'wave-on': '#245a74', 'wave-off': '#c1c9cc',
+    'plate-bg': '#f2f3f3', 'plate-wash': 'linear-gradient(168deg,#ffffff,#e6e8e8)', 'plate-edge': '#c8cdcf',
+    'plate-rule': '#daddde', 'plate-ink': '#252b30', 'plate-ink-2': '#555f65', 'plate-ink-3': '#7a8388',
+    'plate-track': '#dfe3e4',
+    'pad-face': 'linear-gradient(160deg,#fbfcfc,#edefef)', 'pad-face-on': 'linear-gradient(160deg,#f8fbfc,#e4eef2)',
+    'pad-face-empty': 'linear-gradient(160deg,#f1f2f2,#e5e7e7)', 'pad-edge': '#cfd4d5', 'pad-accent': '#245a74',
+    'pad-ring': 'rgba(36,90,116,0.14)', 'pad-num': '#30373c', 'pad-num-empty': '#a0a5a8',
+    'pad-ink-idle': '#7a8388', 'pad-snippet': '#747c83', 'pad-snippet-on': '#4d6570', 'pad-spark-idle': '#c3cbce',
+    'mic-a': '#2f6d85', 'mic-b': '#204d60', 'mic-edge': '#477f94', 'mic-ink': '#f7fcfe', 'mic-sub-ink': '#c7dce4',
+    'btn-face': 'linear-gradient(180deg,#ffffff,#ecefef)', 'btn-edge': '#cbd1d2', 'btn-ink': '#555f65',
+    'btn-sheen': 'inset 0 1px 0 #fff',
+    'led-idle': '#c3cbce', 'led-empty': '#d7dcdd', 'ink-empty': '#a0a5a8',
+    'status-working': '#9b6b22', 'status-working-ink': '#805719', 'status-working-glow': '0 0 5px rgba(155,107,34,0.35)',
+    'panel-shadow': 'inset 0 0 0 1px rgba(255,255,255,0.6), 0 10px 24px -19px rgba(22,30,34,0.3)',
+    'card-shadow': '0 1px 2px rgba(30,35,40,0.1)'
   } },
   flight: { scheme: 'dark', vars: {
     'page-bg': '#05090b', 'panel': '#0c161a', 'panel-head': '#0f1c21', 'cell': '#122228', 'trace-bg': '#0a1316',
@@ -473,7 +554,7 @@ const host = {
 
 // The host may use a non-persistent data store, so nothing here reads or writes
 // localStorage. Boot config comes from the query string instead.
-const Q = new URLSearchParams(location.search);
+const Q = BOOT_QUERY;
 const flag = (k, d) => (Q.has(k) ? !/^(0|false|off|no)$/i.test(Q.get(k) || '') : d);
 
 const PROPS = {
@@ -697,6 +778,9 @@ function ensureAudioEl() {
 }
 
 function syncAudio(snap) {
+  // The hybrid iPad shell uses AVAudioPlayer as the one playback owner. The
+  // web console still renders transport state and sends intents when tapped.
+  if (NATIVE_AUDIO_HOST) return;
   const el = ensureAudioEl();
   if (!snap.playing) {
     el.pause();
@@ -744,7 +828,7 @@ const unlockAudio = () => {
     })
     .catch(() => { /* rejected — stay registered for the next gesture */ });
 };
-document.addEventListener('pointerdown', unlockAudio);
+if (!NATIVE_AUDIO_HOST) document.addEventListener('pointerdown', unlockAudio);
 
 function demoRestore() {
   // back to a clean local state — never simulate over the last authoritative snapshot
@@ -1385,7 +1469,7 @@ function tpl(v) {
   '<div class="se-shell" style="height:100%;min-height:0;overflow:hidden;background:var(--se-page-bg);padding:calc(14px + env(safe-area-inset-top,0px)) 16px 12px;display:flex;flex-direction:column;gap:12px;">' +
 
     // ─────────── top bar — titled after the host we're linked to ───────────
-    '<div style="display:flex;align-items:center;justify-content:space-between;gap:20px;padding:0 4px;flex:none;">' +
+    '<div class="se-topbar" style="display:flex;align-items:center;justify-content:space-between;gap:20px;padding:0 4px;flex:none;">' +
       '<div style="display:flex;align-items:center;gap:12px;">' +
         '<div style="width:30px;height:30px;border-radius:7px;background:var(--se-chip-bg);border:1px solid var(--se-accent-edge);color:var(--se-accent-ink);font:600 11px var(--se-mono);display:flex;align-items:center;justify-content:center;">SE</div>' +
         '<div>' +
@@ -1406,7 +1490,7 @@ function tpl(v) {
     '<div class="se-decks" style="display:flex;gap:14px;align-items:stretch;flex:1;min-height:0;">' +
 
       // ═══════ LEFT · pad surface, always paper ═══════
-      '<div style="flex:0 1 600px;min-width:380px;min-height:0;background-color:var(--se-plate-bg);background-image:var(--se-plate-wash);border:1px solid var(--se-plate-edge);border-radius:12px;padding:16px;display:flex;flex-direction:column;gap:12px;box-shadow:var(--se-panel-shadow);position:relative;">' +
+      '<div class="se-keypad-plate" style="flex:0 1 600px;min-width:380px;min-height:0;background-color:var(--se-plate-bg);background-image:var(--se-plate-wash);border:1px solid var(--se-plate-edge);border-radius:12px;padding:16px;display:flex;flex-direction:column;gap:12px;box-shadow:var(--se-panel-shadow);position:relative;">' +
         '<span style="position:absolute;top:7px;left:7px;width:4px;height:4px;border-radius:50%;background:var(--se-plate-edge);"></span>' +
         '<span style="position:absolute;top:7px;right:7px;width:4px;height:4px;border-radius:50%;background:var(--se-plate-edge);"></span>' +
         '<span style="position:absolute;bottom:7px;left:7px;width:4px;height:4px;border-radius:50%;background:var(--se-plate-edge);"></span>' +
@@ -1491,7 +1575,7 @@ function tpl(v) {
       '</div>' +
 
       // ═══════ RIGHT · lane console ═══════
-      '<div style="flex:1;min-width:0;min-height:0;background:var(--se-panel);border:1px solid var(--se-line);border-radius:var(--se-radius);display:flex;flex-direction:column;overflow:hidden;box-shadow:var(--se-panel-shadow);">' +
+      '<div class="se-console-plate" style="flex:1;min-width:0;min-height:0;background:var(--se-panel);border:1px solid var(--se-line);border-radius:var(--se-radius);display:flex;flex-direction:column;overflow:hidden;box-shadow:var(--se-panel-shadow);">' +
 
         // lane header
         '<div class="se-lane-head">' +
@@ -1717,6 +1801,18 @@ function morph(live, next) {
 const root = document.getElementById('deck');
 const stage = document.createElement('div');
 
+function prepareSurface(container) {
+  if (SURFACE_MODE !== 'console') return;
+  const shell = container.firstElementChild;
+  const consolePlate = container.querySelector('.se-console-plate');
+  if (!shell || !consolePlate) return;
+  // Detach the lane console before discarding the full-deck siblings. Keeping
+  // it as the shell's direct flex child makes sizing deterministic inside a
+  // half-width WKWebView, independent of the browser deck's narrow breakpoint.
+  consolePlate.remove();
+  shell.replaceChildren(consolePlate);
+}
+
 let queued = false;
 function paint() {
   if (queued) return;
@@ -1725,6 +1821,7 @@ function paint() {
     queued = false;
     const v = view();
     stage.innerHTML = tpl(v);
+    prepareSurface(stage);
     if (!root.firstChild) root.appendChild(stage.firstChild);
     else morph(root.firstChild, stage.firstChild);
     host.publish('Speakeasy · ' + v.laneNum + ' ' + v.laneTitle + ' · ' + v.confirmLine);

--- a/deck/ipad/README.md
+++ b/deck/ipad/README.md
@@ -1,35 +1,54 @@
-# SpeakEasy Deck — iPad app
+# SpeakEasy Deck — iOS app
 
-A native shell for the deck: a full-screen web surface that finds every
-`speakeasy deck` on the local network, remembers the selected Mac, and loads
-it — plus a native hold-to-speak engine. No QR, URL entry, or pin.
+A hybrid iPad and iPhone control surface for `speakeasy deck`. It finds every
+Mac on the local network and remembers the selected one. The latency-sensitive
+controls are native SwiftUI; the presentation-heavy lane viewer remains a
+WebKit surface. iPad presents the two as a split. iPhone is intentionally a
+keypad-first instrument and opens the lane viewer only when you tap Activity.
+No QR, URL entry, or pin.
 
 ## How it works
 
 - `DeckDiscovery` browses `_http._tcp` for every `SpeakEasy Deck (<mac>)`
   service advertised over Bonjour. With multiple Macs, a native machine menu
   switches between them and remembers the last selection.
-- The deck page itself owns the WebSocket to the Mac runtime (same-origin,
-  through either the bundled server or Caddy proxy) — the app is a pure shell
-  for lanes, playback, themes, and the trace rail.
-- **Set lanes is shared with the website.** It shows all nine pads alongside
-  the Mac's Codex projects and exact user-facing task titles, so lane bindings
-  can be searched, moved, or reset to a fresh task without leaving the iPad.
-- **Hold to Speak is native.** The page posts capture phases to the
-  `speakeasyDeck` message handler; `SpeechCapture` runs `SFSpeechRecognizer`
-  with `AVAudioEngine` and streams partial and final transcripts back through
-  `window.speakeasyDeck.nativeTranscript`. The page marks the native path via
-  an injected `window.speakeasyNativeTranscription` user script, so the web
-  SpeechRecognition fallback stays for browsers.
+- `DeckConnection` owns a native `URLSessionWebSocketTask`. The Mac runtime is
+  still authoritative: it publishes `snapshot` messages and receives the same
+  schema-validated intents used by the browser deck.
+- `NativeDeckView` renders the established Flight keypad, hold-to-speak,
+  transport, volume, and searchable lane-assignment sheet as native SwiftUI.
+  These tactile controls send intents directly over the native socket.
+- The native Appearance sheet offers Flight, Obsidian, Ceramic, Porcelain, and
+  Amber as miniature renders of the complete hybrid surface. Its pinned action
+  bar keeps Apply Changes reachable at every scroll position. Applying a theme
+  updates both SwiftUI and the WebKit lane viewer, and persists the choice.
+- Control surface is independent from theme. Console, Cluster, Flight Deck,
+  Checklist, Glass PFD, and Micro Deck are six real SwiftUI lane arrangements;
+  every variant keeps lane selection, metering, and Hold to Speak native.
+  Flight Deck uses six wide mixer strips with an effort-level fader and a
+  three-detent model indicator: Terra left, Luna center, and Sol right.
+- Compact width is composed independently: the top controls become two rows,
+  transport controls become a 3×2 bank, Hold to Speak keeps a full single-line
+  label, and Flight Deck channels retain fixed widths in a horizontal scroller.
+- Companion Link is also native: it reports the actual paired route, can force
+  a reconnect or restart Mac discovery, and copies a safe diagnostic summary.
+- `DeckLaneWebView` loads the existing web lane console in presentation-only
+  mode. It shows conversation history, playback state, and traces without its
+  top bar or duplicate keypad. It follows native selections through the Mac's
+  authoritative snapshots, so there is no private JavaScript state bridge.
+- Narration downloads through the paired URL session and plays with
+  `AVAudioPlayer`. The iPad reports its real progress to the runtime, so pause,
+  speed, volume, replay, stop, and completion keep the existing semantics.
+- **Hold to Speak is Parakeet-first.** `SpeechCapture` records one private PCM
+  WAV with `AVAudioEngine`; release uploads it to `/api/transcribe`, where the
+  Mac app's embedded Parakeet model produces the only transcript. The iPad no
+  longer requests Speech Recognition permission or runs `SFSpeechRecognizer`.
+- While recording, the same native audio tap publishes a perceptual RMS level
+  at 30 Hz. SwiftUI uses it to animate the selected pad's sparkline in direct
+  response to the speaker's voice; no WebKit bridge participates.
 
-## HudsonKit note
-
-The first version of this app used HudsonKit's `HudWebView`. The speech
-bridge needs a script message handler, which `HudWebView` doesn't expose
-yet, so the surface is a thin `UIViewRepresentable` following the
-`HudCanvasSurface` handler convention instead. The clean upstream fix is
-message-handler support in `HudWebViewConfiguration`; when that lands, this
-app can go back to the stock component.
+The browser deck remains available from `speakeasy deck`; its full layout is
+unchanged unless `surface=console` is explicitly requested by the iPad shell.
 
 ## Build
 
@@ -38,6 +57,9 @@ xcodegen generate --spec project.yml
 # simulator:
 xcodebuild -project SpeakEasyDeck.xcodeproj -scheme SpeakEasyDeck \
   -destination 'platform=iOS Simulator,name=iPad Pro 11-inch (M5)' build
+# compact simulator:
+xcodebuild -project SpeakEasyDeck.xcodeproj -scheme SpeakEasyDeck \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
 # a real iPad (uses the Lattices team profile):
 ./build-device.sh
 ```
@@ -54,10 +76,16 @@ no certificate profile and remains connected when it is opened normally later.
 
 | File | Role |
 | --- | --- |
-| `project.yml` | xcodegen spec — team `2U83JFPW66`, Bonjour/network/mic/speech permissions |
+| `project.yml` | xcodegen spec — team `2U83JFPW66`, Bonjour/network/mic permissions |
 | `Sources/SpeakEasyDeckApp.swift` | `@main` entry point |
 | `Sources/DeckRootView.swift` | discovery-driven full-screen surface |
 | `Sources/DeckDiscovery.swift` | Bonjour discovery of the deck service |
-| `Sources/DeckWebView.swift` | WKWebView + `speakeasyDeck` message handler bridge |
-| `Sources/SpeechCapture.swift` | `SFSpeechRecognizer` + `AVAudioEngine` capture engine |
-| `Sources/Info.plist` | Bonjour, local-network, mic, speech permissions |
+| `Sources/DeckModels.swift` | Codable snapshot, lane, message, catalog, trace, and URL contract |
+| `Sources/DeckConnection.swift` | WebSocket intents/snapshots, Parakeet upload, and native audio playback |
+| `Sources/NativeDeckView.swift` | native keypad, hold-to-speak, transport, and lane setup |
+| `Sources/DeckSettingsView.swift` | sticky Appearance picker and companion diagnostics |
+| `Sources/DeckSurface.swift` | persistent native control-surface selection |
+| `Sources/DeckTheme.swift` | persistent native/WebKit theme palettes |
+| `Sources/DeckWebView.swift` | presentation-only WebKit lane viewer and paired-host trust |
+| `Sources/SpeechCapture.swift` | private PCM WAV capture for the Mac's Parakeet engine |
+| `Sources/Info.plist` | Bonjour, local-network, and microphone permissions |

--- a/deck/ipad/Sources/DeckConnection.swift
+++ b/deck/ipad/Sources/DeckConnection.swift
@@ -1,0 +1,642 @@
+import AVFAudio
+import Combine
+import Foundation
+import OSLog
+import Security
+
+enum DeckConnectionState: Equatable {
+    case disconnected
+    case connecting
+    case connected
+
+    var label: String {
+        switch self {
+        case .disconnected: "MAC OFFLINE"
+        case .connecting: "CONNECTING"
+        case .connected: "MAC LIVE"
+        }
+    }
+}
+
+enum DeckCapturePhase: Equatable {
+    case idle
+    case arming
+    case recording
+    case transcribing
+
+    var label: String {
+        switch self {
+        case .idle: "PARAKEET READY"
+        case .arming: "MICROPHONE STARTING"
+        case .recording: "LISTENING · PARAKEET"
+        case .transcribing: "PARAKEET · TRANSCRIBING"
+        }
+    }
+}
+
+/// Owns the native iPad data plane: snapshots and intents over WebSocket,
+/// Parakeet-first microphone uploads, and device-side narration playback.
+final class DeckConnection: NSObject, ObservableObject, URLSessionDelegate, URLSessionWebSocketDelegate, AVAudioPlayerDelegate {
+    @Published private(set) var snapshot: DeckSnapshot?
+    @Published private(set) var state: DeckConnectionState = .disconnected
+    @Published private(set) var capturePhase: DeckCapturePhase = .idle
+    @Published private(set) var inputLevel: Double = 0
+    @Published private(set) var localStatus: String?
+
+    private let logger = Logger(subsystem: "dev.arach.speakeasy.deck", category: "native-connection")
+    private let capture = SpeechCapture()
+    private var deckURL: URL?
+    private var pairedHost: String?
+    private var session: URLSession?
+    private var socket: URLSessionWebSocketTask?
+    private var reconnectWork: DispatchWorkItem?
+    private var generation = 0
+    private var intentID = 0
+    private var pttActive = false
+    private var serverCaptureStarted = false
+    private var transcriptionTask: URLSessionUploadTask?
+    private var pendingCaptureText: String?
+    private var pendingCaptureEndID: Int?
+    private var captureEndRetryWork: DispatchWorkItem?
+    private var cancelCaptureOnReconnect = false
+
+    private var audioPlayer: AVAudioPlayer?
+    private var audioPlayingID: String?
+    private var audioLoadTask: URLSessionDataTask?
+    private var progressTimer: Timer?
+
+    override init() {
+        super.init()
+        capture.onStarted = { [weak self] in
+            DispatchQueue.main.async { self?.captureDidStart() }
+        }
+        capture.onRecordingReady = { [weak self] url in
+            DispatchQueue.main.async { self?.transcribeWithParakeet(url) }
+        }
+        capture.onFailure = { [weak self] message in
+            DispatchQueue.main.async { self?.captureDidFail(message) }
+        }
+        capture.onLevel = { [weak self] level in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard self.capturePhase == .recording else {
+                    self.inputLevel = 0
+                    return
+                }
+                let target = Double(level)
+                let smoothing = target > self.inputLevel ? 0.62 : 0.2
+                self.inputLevel += (target - self.inputLevel) * smoothing
+            }
+        }
+    }
+
+    deinit {
+        reconnectWork?.cancel()
+        socket?.cancel(with: .goingAway, reason: nil)
+        session?.invalidateAndCancel()
+        capture.abort()
+        stopLocalPlayback()
+    }
+
+    func connect(to url: URL) {
+        if deckURL == url, state == .connected { return }
+        if let deckURL, deckURL != url {
+            resetCaptureRecovery()
+        }
+        generation &+= 1
+        let currentGeneration = generation
+        reconnectWork?.cancel()
+        reconnectWork = nil
+        closeTransport()
+
+        deckURL = url
+        pairedHost = url.host
+        state = .connecting
+        if pendingCaptureText != nil {
+            capturePhase = .transcribing
+            localStatus = "RECONNECTING TO FINISH CAPTURE"
+        } else {
+            localStatus = "OPENING NATIVE LINK"
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 185
+        let newSession = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        session = newSession
+        guard let socketURL = url.deckEndpoint(path: "/ws", webSocket: true) else {
+            connectionLost("INVALID DECK ADDRESS", generation: currentGeneration)
+            return
+        }
+        let newSocket = newSession.webSocketTask(with: socketURL)
+        socket = newSocket
+        newSocket.resume()
+        receiveNext(from: newSocket, generation: currentGeneration)
+    }
+
+    func disconnect() {
+        generation &+= 1
+        reconnectWork?.cancel()
+        reconnectWork = nil
+        closeTransport()
+        resetCaptureRecovery()
+        deckURL = nil
+        pairedHost = nil
+        snapshot = nil
+        state = .disconnected
+        localStatus = nil
+    }
+
+    func reconnectNow() {
+        guard let url = deckURL else {
+            localStatus = "NO PAIRED MAC"
+            return
+        }
+        state = .disconnected
+        connect(to: url)
+    }
+
+    private func closeTransport() {
+        capture.abort()
+        transcriptionTask?.cancel()
+        transcriptionTask = nil
+        pttActive = false
+        capturePhase = .idle
+        inputLevel = 0
+        stopLocalPlayback()
+        socket?.cancel(with: .goingAway, reason: nil)
+        socket = nil
+        session?.invalidateAndCancel()
+        session = nil
+    }
+
+    private func receiveNext(from task: URLSessionWebSocketTask, generation: Int) {
+        task.receive { [weak self, weak task] result in
+            guard let self, let task else { return }
+            switch result {
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    guard self.socket === task else { return }
+                    self.connectionLost(error.localizedDescription.uppercased(), generation: generation)
+                }
+            case .success(let message):
+                let data: Data?
+                switch message {
+                case .data(let value): data = value
+                case .string(let value): data = value.data(using: .utf8)
+                @unknown default: data = nil
+                }
+                if let data { self.consume(data, from: task) }
+                if self.socket === task {
+                    self.receiveNext(from: task, generation: generation)
+                }
+            }
+        }
+    }
+
+    private func consume(_ data: Data, from task: URLSessionWebSocketTask) {
+        struct Envelope: Decodable { let type: String }
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else { return }
+        switch envelope.type {
+        case "snapshot":
+            guard let next = try? JSONDecoder().decode(DeckSnapshot.self, from: data) else {
+                logger.error("Rejected an invalid deck snapshot")
+                return
+            }
+            DispatchQueue.main.async { [weak self, weak task] in
+                guard let self, let task, self.socket === task else { return }
+                guard next.rev > (self.snapshot?.rev ?? -1) else { return }
+                self.snapshot = next
+                self.state = .connected
+                self.reconcileCapture(with: next)
+                if self.capturePhase == .idle { self.localStatus = nil }
+                self.syncPlayback(to: next)
+            }
+        case "ack":
+            guard let ack = try? JSONDecoder().decode(DeckAck.self, from: data) else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                if self.handleCaptureEndAck(ack) { return }
+                if !ack.ok { self.localStatus = (ack.error ?? "COMMAND REJECTED").uppercased() }
+            }
+        default:
+            break
+        }
+    }
+
+    private func connectionLost(_ message: String, generation currentGeneration: Int) {
+        guard currentGeneration == generation else { return }
+        state = .disconnected
+        localStatus = "CONNECTION LOST · RETRYING"
+        stopLocalPlayback()
+        capture.abort()
+        pttActive = false
+        if serverCaptureStarted && pendingCaptureText == nil {
+            cancelCaptureOnReconnect = true
+        }
+        capturePhase = pendingCaptureText == nil ? .idle : .transcribing
+        inputLevel = 0
+        socket = nil
+
+        guard let reconnectURL = deckURL else { return }
+        reconnectWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.generation == currentGeneration else { return }
+            self.logger.notice("Reconnecting native deck after: \(message, privacy: .public)")
+            self.connect(to: reconnectURL)
+        }
+        reconnectWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: work)
+    }
+
+    @discardableResult
+    func sendIntent(_ name: String, _ arguments: [String: Any] = [:]) -> Int? {
+        guard state == .connected, let socket else {
+            localStatus = "MAC OFFLINE · RETRYING"
+            return nil
+        }
+        intentID &+= 1
+        let id = intentID
+        var envelope: [String: Any] = ["type": "intent", "id": id, "name": name]
+        arguments.forEach { envelope[$0.key] = $0.value }
+        guard JSONSerialization.isValidJSONObject(envelope),
+              let data = try? JSONSerialization.data(withJSONObject: envelope),
+              let string = String(data: data, encoding: .utf8) else { return nil }
+        socket.send(.string(string)) { [weak self] error in
+            guard let error else { return }
+            DispatchQueue.main.async {
+                self?.localStatus = error.localizedDescription.uppercased()
+            }
+        }
+        return id
+    }
+
+    func selectLane(_ index: Int) {
+        sendIntent("lane.select", ["index": index])
+    }
+
+    func assignLane(_ index: Int, threadID: String?) {
+        sendIntent("lane.assign", ["index": index, "threadId": threadID ?? NSNull(), "activate": threadID != nil])
+    }
+
+    func refreshCatalog() {
+        sendIntent("catalog.refresh")
+    }
+
+    func stop() {
+        if serverCaptureStarted { sendIntent("capture.cancel", ["reason": "CANCELLED ON IPAD"]) }
+        capture.abort()
+        transcriptionTask?.cancel()
+        transcriptionTask = nil
+        pttActive = false
+        resetCaptureRecovery()
+        capturePhase = .idle
+        inputLevel = 0
+        stopLocalPlayback()
+        sendIntent("playback.stop")
+    }
+
+    func replay() { sendIntent("playback.replay") }
+    func cycleSpeed() { sendIntent("playback.speed") }
+    func toggleAutoplay() { sendIntent("playback.autoplay") }
+    func setVolume(_ value: Double) { sendIntent("playback.volume", ["vol": min(1, max(0, value))]) }
+
+    func togglePlayback(lane: Int, message: Int) {
+        sendIntent("playback.toggle", ["id": "\(lane):\(message)"])
+    }
+
+    func pttBegan() {
+        guard state == .connected, capturePhase == .idle, let snapshot else {
+            localStatus = "MAC OFFLINE · OPEN SPEAKEASY"
+            return
+        }
+        if snapshot.lane != 9, snapshot.activeLane?.threadId == nil {
+            localStatus = "ASSIGN THIS LANE BEFORE SPEAKING"
+            return
+        }
+        pttActive = true
+        capturePhase = .arming
+        localStatus = capturePhase.label
+        stopLocalPlayback()
+        capture.start()
+    }
+
+    func pttEnded() {
+        guard pttActive else { return }
+        pttActive = false
+        capture.finish()
+    }
+
+    func pttCancelled() {
+        guard pttActive || capturePhase != .idle else { return }
+        pttActive = false
+        capture.abort()
+        transcriptionTask?.cancel()
+        transcriptionTask = nil
+        if serverCaptureStarted { sendIntent("capture.cancel", ["reason": "VOICE HOLD CANCELLED"]) }
+        resetCaptureRecovery()
+        capturePhase = .idle
+        inputLevel = 0
+        localStatus = "CANCELLED"
+    }
+
+    private func captureDidStart() {
+        guard pttActive else {
+            capture.abort()
+            return
+        }
+        serverCaptureStarted = true
+        capturePhase = .recording
+        localStatus = capturePhase.label
+        sendIntent("capture.start")
+    }
+
+    private func captureDidFail(_ message: String) {
+        transcriptionTask?.cancel()
+        transcriptionTask = nil
+        if serverCaptureStarted { sendIntent("capture.cancel", ["reason": message]) }
+        pttActive = false
+        resetCaptureRecovery()
+        capturePhase = .idle
+        inputLevel = 0
+        localStatus = message
+    }
+
+    private struct TranscriptionResult: Decodable {
+        let ok: Bool
+        let text: String?
+        let engine: String?
+        let error: String?
+    }
+
+    private func transcribeWithParakeet(_ fileURL: URL) {
+        guard serverCaptureStarted,
+              let endpoint = deckURL?.deckEndpoint(path: "/api/transcribe"),
+              let session else {
+            try? FileManager.default.removeItem(at: fileURL)
+            captureDidFail("LOCAL PARAKEET UNAVAILABLE")
+            return
+        }
+        inputLevel = 0
+        capturePhase = .transcribing
+        localStatus = capturePhase.label
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 185
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.setValue("audio/wav", forHTTPHeaderField: "Content-Type")
+
+        let task = session.uploadTask(with: request, fromFile: fileURL) { [weak self] data, response, error in
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+            DispatchQueue.main.async {
+                guard let self,
+                      self.serverCaptureStarted,
+                      self.capturePhase == .transcribing else { return }
+                self.transcriptionTask = nil
+                if let error {
+                    self.captureDidFail(error.localizedDescription.uppercased())
+                    return
+                }
+                guard let http = response as? HTTPURLResponse,
+                      let data,
+                      let result = try? JSONDecoder().decode(TranscriptionResult.self, from: data),
+                      (200..<300).contains(http.statusCode), result.ok,
+                      let text = result.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !text.isEmpty else {
+                    let result = data.flatMap { try? JSONDecoder().decode(TranscriptionResult.self, from: $0) }
+                    self.captureDidFail((result?.error ?? "NO SPEECH · TRY AGAIN").uppercased())
+                    return
+                }
+                // The Mac owns `listening`. Keep the native control in its
+                // transcribing state until an ack or corrective snapshot says
+                // the matching capture.end was accepted. If the socket drops,
+                // the retained transcript is retried after reconnect.
+                self.pendingCaptureText = String(text.prefix(500))
+                self.localStatus = "SENDING TRANSCRIPT TO MAC"
+                self.sendPendingCaptureEnd()
+            }
+        }
+        transcriptionTask = task
+        task.resume()
+    }
+
+    private func sendPendingCaptureEnd() {
+        guard pendingCaptureEndID == nil,
+              let text = pendingCaptureText else { return }
+        guard let id = sendIntent("capture.end", ["text": text]) else {
+            scheduleCaptureEndRetry(expectedID: nil)
+            return
+        }
+        pendingCaptureEndID = id
+        scheduleCaptureEndRetry(expectedID: id)
+    }
+
+    private func scheduleCaptureEndRetry(expectedID: Int?) {
+        captureEndRetryWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.pendingCaptureText != nil else { return }
+            guard self.pendingCaptureEndID == expectedID else { return }
+            if self.snapshot?.listening == false {
+                self.completeCaptureEnd()
+                return
+            }
+            self.pendingCaptureEndID = nil
+            self.localStatus = self.state == .connected
+                ? "CONFIRMING TRANSCRIPT WITH MAC"
+                : "RECONNECTING TO FINISH CAPTURE"
+            self.sendPendingCaptureEnd()
+        }
+        captureEndRetryWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: work)
+    }
+
+    private func handleCaptureEndAck(_ ack: DeckAck) -> Bool {
+        guard let id = ack.id, id == pendingCaptureEndID else { return false }
+        captureEndRetryWork?.cancel()
+        captureEndRetryWork = nil
+        pendingCaptureEndID = nil
+        if ack.ok || ack.error?.lowercased() == "not recording" {
+            completeCaptureEnd()
+        } else {
+            localStatus = (ack.error ?? "TRANSCRIPT NOT ACCEPTED").uppercased()
+            scheduleCaptureEndRetry(expectedID: nil)
+        }
+        return true
+    }
+
+    private func reconcileCapture(with snapshot: DeckSnapshot) {
+        if pendingCaptureText != nil {
+            if !snapshot.listening {
+                completeCaptureEnd()
+            } else if pendingCaptureEndID == nil {
+                sendPendingCaptureEnd()
+            }
+            return
+        }
+        guard cancelCaptureOnReconnect else { return }
+        cancelCaptureOnReconnect = false
+        if snapshot.listening {
+            sendIntent("capture.cancel", ["reason": "IPAD CAPTURE INTERRUPTED"])
+        }
+        serverCaptureStarted = false
+    }
+
+    private func completeCaptureEnd() {
+        captureEndRetryWork?.cancel()
+        captureEndRetryWork = nil
+        pendingCaptureEndID = nil
+        pendingCaptureText = nil
+        serverCaptureStarted = false
+        cancelCaptureOnReconnect = false
+        capturePhase = .idle
+        inputLevel = 0
+        localStatus = "SENT · PARAKEET LOCAL"
+    }
+
+    private func resetCaptureRecovery() {
+        captureEndRetryWork?.cancel()
+        captureEndRetryWork = nil
+        pendingCaptureEndID = nil
+        pendingCaptureText = nil
+        serverCaptureStarted = false
+        cancelCaptureOnReconnect = false
+    }
+
+    private let speeds = [1.0, 1.25, 1.5, 0.75]
+
+    private func syncPlayback(to snapshot: DeckSnapshot) {
+        guard capturePhase == .idle else { return }
+        guard let id = snapshot.playing else {
+            stopLocalPlayback()
+            return
+        }
+        guard let message = snapshot.message(id: id), let audioPath = message.audioUrl else { return }
+
+        if audioPlayingID != id {
+            audioLoadTask?.cancel()
+            audioPlayer?.stop()
+            audioPlayer = nil
+            audioPlayingID = id
+            guard let audioURL = deckURL?.deckEndpoint(path: audioPath), let session else { return }
+            let expectedID = id
+            let task = session.dataTask(with: audioURL) { [weak self] data, response, error in
+                DispatchQueue.main.async {
+                    guard let self, self.audioPlayingID == expectedID,
+                          error == nil,
+                          let http = response as? HTTPURLResponse,
+                          (200..<300).contains(http.statusCode),
+                          let data,
+                          let player = try? AVAudioPlayer(data: data) else {
+                        if self?.audioPlayingID == expectedID {
+                            self?.localStatus = "AUDIO PLAYBACK FAILED"
+                        }
+                        return
+                    }
+                    self.audioPlayer = player
+                    player.delegate = self
+                    player.enableRate = true
+                    self.configure(player, from: snapshot)
+                    player.prepareToPlay()
+                    if !snapshot.paused { player.play() }
+                    self.startProgressTimer()
+                }
+            }
+            audioLoadTask = task
+            task.resume()
+            return
+        }
+
+        guard let player = audioPlayer else { return }
+        configure(player, from: snapshot)
+        if snapshot.paused {
+            player.pause()
+        } else if !player.isPlaying {
+            player.play()
+        }
+        if abs(player.currentTime - snapshot.pos) > 2 {
+            player.currentTime = snapshot.pos
+        }
+    }
+
+    private func configure(_ player: AVAudioPlayer, from snapshot: DeckSnapshot) {
+        let speed = speeds.indices.contains(snapshot.speedIx) ? speeds[snapshot.speedIx] : 1
+        player.rate = Float(speed)
+        player.volume = Float(min(1, max(0, snapshot.vol)))
+        if player.currentTime == 0, snapshot.pos > 0 { player.currentTime = snapshot.pos }
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio)
+        try? AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    private func startProgressTimer() {
+        progressTimer?.invalidate()
+        progressTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            guard let self, let player = self.audioPlayer, player.isPlaying, let id = self.audioPlayingID else { return }
+            self.sendIntent("playback.progress", ["id": id, "pos": player.currentTime, "dur": player.duration])
+        }
+    }
+
+    private func stopLocalPlayback() {
+        progressTimer?.invalidate()
+        progressTimer = nil
+        audioLoadTask?.cancel()
+        audioLoadTask = nil
+        audioPlayer?.stop()
+        audioPlayer = nil
+        audioPlayingID = nil
+    }
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        guard let id = audioPlayingID else { return }
+        progressTimer?.invalidate()
+        progressTimer = nil
+        audioPlayer = nil
+        audioPlayingID = nil
+        sendIntent("playback.ended", ["id": id])
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let trust = challenge.protectionSpace.serverTrust,
+              let pairedHost,
+              challenge.protectionSpace.host.caseInsensitiveCompare(pairedHost) == .orderedSame,
+              let anchor = DeckProvisioning.trustAnchor else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        SecTrustSetAnchorCertificates(trust, [anchor] as CFArray)
+        SecTrustSetAnchorCertificatesOnly(trust, true)
+        var error: CFError?
+        guard SecTrustEvaluateWithError(trust, &error) else {
+            logger.error("Rejected paired Deck certificate: \(error?.localizedDescription ?? "unknown trust error", privacy: .public)")
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        DispatchQueue.main.async { [weak self, weak webSocketTask] in
+            guard let self, let webSocketTask, self.socket === webSocketTask else { return }
+            self.state = .connected
+            self.localStatus = "NATIVE LINK READY"
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        DispatchQueue.main.async { [weak self, weak webSocketTask] in
+            guard let self, let webSocketTask, self.socket === webSocketTask else { return }
+            self.connectionLost("SOCKET CLOSED", generation: self.generation)
+        }
+    }
+}

--- a/deck/ipad/Sources/DeckDiscovery.swift
+++ b/deck/ipad/Sources/DeckDiscovery.swift
@@ -11,19 +11,31 @@ enum DeckProvisioning {
     private static let urlAccount = "paired-url-v1"
     private static let rootAccount = "paired-root-der-v1"
 
-    static func importLaunchEnvironment() {
-        let environment = ProcessInfo.processInfo.environment
-        guard let rawURL = environment["SPEAKEASY_DECK_URL"],
+    /// Keep launch provisioning usable even if Keychain has not become
+    /// available yet (notably during the first frame of Simulator launches).
+    private static var launchURL: URL? {
+        guard let rawURL = ProcessInfo.processInfo.environment["SPEAKEASY_DECK_URL"],
               let url = URL(string: rawURL),
               url.scheme == "https",
-              url.host != nil,
-              let root = environment["SPEAKEASY_DECK_ROOT_DER"],
-              Data(base64Encoded: root) != nil else { return }
-        save(rawURL, account: urlAccount)
+              url.host != nil else { return nil }
+        return url
+    }
+
+    private static var launchRootData: Data? {
+        guard let encoded = ProcessInfo.processInfo.environment["SPEAKEASY_DECK_ROOT_DER"] else { return nil }
+        return Data(base64Encoded: encoded)
+    }
+
+    static func importLaunchEnvironment() {
+        guard let url = launchURL,
+              let root = ProcessInfo.processInfo.environment["SPEAKEASY_DECK_ROOT_DER"],
+              launchRootData != nil else { return }
+        save(url.absoluteString, account: urlAccount)
         save(root, account: rootAccount)
     }
 
     static var pairedURL: URL? {
+        if let launchURL { return launchURL }
         guard let raw = load(account: urlAccount),
               let url = URL(string: raw),
               url.scheme == "https",
@@ -32,8 +44,8 @@ enum DeckProvisioning {
     }
 
     static var trustAnchor: SecCertificate? {
-        guard let encoded = load(account: rootAccount),
-              let data = Data(base64Encoded: encoded) else { return nil }
+        let data = launchRootData ?? load(account: rootAccount).flatMap { Data(base64Encoded: $0) }
+        guard let data else { return nil }
         return SecCertificateCreateWithData(nil, data as CFData)
     }
 

--- a/deck/ipad/Sources/DeckModels.swift
+++ b/deck/ipad/Sources/DeckModels.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+enum DeckLaneState: String, Decodable {
+    case speaking
+    case working
+    case idle
+    case empty
+}
+
+struct DeckMessage: Decodable {
+    let role: String
+    let text: String
+    let dur: Double
+    let mirrored: Bool?
+    let file: String?
+    let audioUrl: String?
+
+    var hasAudio: Bool { file != nil && audioUrl != nil }
+}
+
+struct DeckTraceEntry: Decodable, Identifiable {
+    let at: String
+    let kind: String
+    let detail: String
+
+    var id: String { "\(at)|\(kind)|\(detail)" }
+}
+
+struct DeckThreadInfo: Decodable, Identifiable {
+    let id: String
+    let cwd: String
+    let snippet: String
+    let preview: String?
+    let project: String?
+    let at: Double
+    let originator: String
+    let isPinned: Bool?
+
+    var displayProject: String {
+        if let project, !project.isEmpty { return project }
+        let component = URL(fileURLWithPath: cwd).lastPathComponent
+        return component.isEmpty ? "Codex" : component
+    }
+
+    var alias: String {
+        String(id.replacingOccurrences(of: "-", with: "").suffix(8)).uppercased()
+    }
+}
+
+struct DeckLaneInfo: Decodable, Identifiable {
+    let num: String
+    let name: String
+    let title: String
+    let state: DeckLaneState
+    let threadId: String?
+    let sessionAlias: String?
+    let project: String?
+    let cwd: String?
+    let branch: String?
+    let updatedAt: Double?
+
+    var id: String { num }
+    var isAssigned: Bool { state != .empty && threadId != nil }
+}
+
+struct DeckSnapshot: Decodable {
+    let type: String
+    let rev: Int
+    let lane: Int
+    let lanes: [DeckLaneInfo]
+    let threads: [[DeckMessage]]
+    let playing: String?
+    let paused: Bool
+    let pos: Double
+    let speedIx: Int
+    let vol: Double
+    let autoplay: Bool
+    let listening: Bool
+    let phase: String
+    let confirm: String
+    let trace: [DeckTraceEntry]
+    let host: String
+    let catalog: [DeckThreadInfo]
+    let catalogError: String?
+    let clients: Int
+
+    var activeLane: DeckLaneInfo? {
+        lanes.indices.contains(lane) ? lanes[lane] : nil
+    }
+
+    var activeMessages: [DeckMessage] {
+        threads.indices.contains(lane) ? threads[lane] : []
+    }
+
+    func lastAgentMessage(in laneIndex: Int) -> DeckMessage? {
+        guard threads.indices.contains(laneIndex) else { return nil }
+        return threads[laneIndex].last(where: { $0.role == "agent" })
+    }
+
+    func message(id: String) -> DeckMessage? {
+        let parts = id.split(separator: ":").compactMap { Int($0) }
+        guard parts.count == 2,
+              threads.indices.contains(parts[0]),
+              threads[parts[0]].indices.contains(parts[1]) else { return nil }
+        return threads[parts[0]][parts[1]]
+    }
+}
+
+struct DeckAck: Decodable {
+    let type: String
+    let id: Int?
+    let ok: Bool
+    let rev: Int
+    let error: String?
+}
+
+extension URL {
+    var deckCapabilityToken: String? {
+        guard let fragment,
+              let components = URLComponents(string: "https://local.invalid/?\(fragment)") else { return nil }
+        return components.queryItems?.first(where: { $0.name == "k" })?.value
+    }
+
+    func deckEndpoint(path: String, webSocket: Bool = false) -> URL? {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }
+        if webSocket {
+            components.scheme = components.scheme == "https" ? "wss" : "ws"
+        }
+        components.path = path.hasPrefix("/") ? path : "/\(path)"
+        components.query = nil
+        components.fragment = nil
+        if let token = deckCapabilityToken, !token.isEmpty {
+            components.queryItems = [URLQueryItem(name: "k", value: token)]
+        }
+        return components.url
+    }
+}

--- a/deck/ipad/Sources/DeckRootView.swift
+++ b/deck/ipad/Sources/DeckRootView.swift
@@ -1,25 +1,36 @@
 import SwiftUI
 
-/// The whole app: the deck web surface, discovered on the LAN and hosted
-/// full-screen with the native speech bridge attached. The page itself owns
-/// the WebSocket to the Mac runtime.
+/// The hybrid deck: native controls on the left, WebKit lane presentation on
+/// the right, both synchronized through the Mac runtime.
 struct DeckRootView: View {
     @StateObject private var discovery = DeckDiscovery()
-    @StateObject private var controller = DeckWebController()
+    @StateObject private var connection = DeckConnection()
+    @StateObject private var laneViewer = DeckLaneViewerController()
+    @AppStorage(DeckThemeSelection.defaultsKey) private var selectedThemeRaw = DeckThemeID.flight.rawValue
 
     var body: some View {
         Group {
             if let deck = discovery.selectedDeck {
-                ZStack(alignment: .topTrailing) {
-                    DeckWebView(controller: controller)
-                        .ignoresSafeArea()
-                        .onAppear { controller.deckURL = deck.url }
-                        .onChange(of: deck.url) { _, newValue in controller.deckURL = newValue }
+                ZStack(alignment: .bottomTrailing) {
+                    NativeDeckView(
+                        connection: connection,
+                        laneViewer: laneViewer,
+                        selectedDeck: deck,
+                        onFindDecks: { discovery.refresh() }
+                    )
+                        .onAppear {
+                            connection.connect(to: deck.url)
+                            laneViewer.deckURL = deck.url
+                        }
+                        .onChange(of: deck.url) { _, newValue in
+                            connection.connect(to: newValue)
+                            laneViewer.deckURL = newValue
+                        }
 
                     if discovery.decks.count > 1 {
                         machineMenu(selected: deck)
-                            .padding(.top, 12)
-                            .padding(.trailing, 14)
+                            .padding(.bottom, 20)
+                            .padding(.trailing, 20)
                     }
                 }
             } else {
@@ -40,6 +51,7 @@ struct DeckRootView: View {
                 .background(Color(.systemBackground))
             }
         }
+        .onDisappear { connection.disconnect() }
     }
 
     private func machineMenu(selected: DiscoveredDeck) -> some View {
@@ -60,8 +72,9 @@ struct DeckRootView: View {
                 .font(.system(.caption, design: .monospaced, weight: .semibold))
                 .padding(.horizontal, 12)
                 .padding(.vertical, 9)
-                .background(.ultraThinMaterial, in: Capsule())
-                .overlay { Capsule().stroke(.white.opacity(0.16), lineWidth: 1) }
+                .foregroundStyle(DeckPalette.accent)
+                .background(DeckPalette.accentDark.opacity(0.94), in: Capsule())
+                .overlay { Capsule().stroke(DeckPalette.accentEdge, lineWidth: 1) }
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Current SpeakEasy Mac: \(selected.displayName)")

--- a/deck/ipad/Sources/DeckSettingsView.swift
+++ b/deck/ipad/Sources/DeckSettingsView.swift
@@ -1,0 +1,514 @@
+import SwiftUI
+import UIKit
+
+struct DeckAppearanceView: View {
+    @Binding var selectedThemeRaw: String
+    @Binding var selectedSurfaceRaw: String
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var draftTheme: DeckThemeID
+    @State private var draftSurface: DeckSurfaceID
+
+    init(selectedThemeRaw: Binding<String>, selectedSurfaceRaw: Binding<String>) {
+        _selectedThemeRaw = selectedThemeRaw
+        _selectedSurfaceRaw = selectedSurfaceRaw
+        _draftTheme = State(initialValue: DeckThemeID(rawValue: selectedThemeRaw.wrappedValue) ?? .flight)
+        _draftSurface = State(initialValue: DeckSurfaceID(rawValue: selectedSurfaceRaw.wrappedValue) ?? .micro)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("HYBRID DECK")
+                            .deckMono(9, weight: .semibold)
+                            .tracking(1.8)
+                            .foregroundStyle(DeckPalette.accent)
+                        Text("Appearance")
+                            .font(.system(size: 30, weight: .semibold, design: .rounded))
+                            .foregroundStyle(DeckPalette.ink)
+                        Text("Choose the native control layout and color system independently. The lane viewer stays in the iPad split and opens from Activity on iPhone.")
+                            .font(.system(size: 13, design: .monospaced))
+                            .foregroundStyle(DeckPalette.ink3)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    sectionHeading("CONTROL SURFACE", detail: "Native layout")
+
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 190), spacing: 12)], spacing: 12) {
+                        ForEach(DeckSurfaceID.allCases) { surface in
+                            Button { draftSurface = surface } label: {
+                                VStack(alignment: .leading, spacing: 9) {
+                                    SurfaceMiniature(surface: surface)
+                                    HStack(alignment: .top) {
+                                        VStack(alignment: .leading, spacing: 3) {
+                                            Text(surface.name.uppercased()).deckMono(9.5, weight: .semibold).tracking(1)
+                                            Text(surface.detail).deckMono(7.5).foregroundStyle(DeckPalette.ink3)
+                                        }
+                                        Spacer()
+                                        Image(systemName: draftSurface == surface ? "checkmark.circle.fill" : "circle")
+                                            .foregroundStyle(DeckPalette.accent)
+                                    }
+                                }
+                                .foregroundStyle(DeckPalette.ink)
+                                .padding(9)
+                                .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 10))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .stroke(draftSurface == surface ? DeckPalette.accent : DeckPalette.line, lineWidth: draftSurface == surface ? 2 : 1)
+                                }
+                            }
+                            .buttonStyle(DeckPressButtonStyle())
+                            .accessibilityAddTraits(draftSurface == surface ? .isSelected : [])
+                        }
+                    }
+
+                    sectionHeading("DECK THEME", detail: "Color system")
+
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 210), spacing: 14)], spacing: 14) {
+                        ForEach(DeckThemeID.allCases) { theme in
+                            Button {
+                                draftTheme = theme
+                            } label: {
+                                VStack(alignment: .leading, spacing: 10) {
+                                    HybridThemeMiniature(theme: theme)
+                                    HStack(alignment: .firstTextBaseline) {
+                                        VStack(alignment: .leading, spacing: 3) {
+                                            Text(theme.name.uppercased())
+                                                .deckMono(10, weight: .semibold)
+                                                .tracking(1.2)
+                                            Text(theme.detail)
+                                                .deckMono(8.5)
+                                                .foregroundStyle(theme.palette.ink3)
+                                        }
+                                        Spacer()
+                                        Image(systemName: draftTheme == theme ? "checkmark.circle.fill" : "circle")
+                                            .foregroundStyle(theme.palette.accent)
+                                    }
+                                    .foregroundStyle(theme.palette.ink)
+                                }
+                                .padding(10)
+                                .background(theme.palette.panel, in: RoundedRectangle(cornerRadius: 12))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .stroke(draftTheme == theme ? theme.palette.accent : theme.palette.line, lineWidth: draftTheme == theme ? 2 : 1)
+                                }
+                            }
+                            .buttonStyle(DeckPressButtonStyle())
+                            .accessibilityLabel("\(theme.name) theme, \(theme.detail)")
+                            .accessibilityAddTraits(draftTheme == theme ? .isSelected : [])
+                        }
+                    }
+
+                }
+                .padding(24)
+            }
+            .background(DeckPalette.page)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                appearanceActionBar
+            }
+            .navigationTitle("Appearance")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(DeckPalette.accent)
+                }
+            }
+        }
+        .preferredColorScheme(DeckThemeSelection.current.colorScheme)
+    }
+
+    private var hasChanges: Bool {
+        draftTheme.rawValue != selectedThemeRaw || draftSurface.rawValue != selectedSurfaceRaw
+    }
+
+    private var appearanceActionBar: some View {
+        Group {
+            if horizontalSizeClass == .compact {
+                VStack(spacing: 9) {
+                    HStack(spacing: 10) {
+                        appearanceStatus
+                        Spacer(minLength: 4)
+                        cancelAppearanceButton
+                    }
+                    applyAppearanceButton
+                        .frame(maxWidth: .infinity)
+                }
+            } else {
+                HStack(spacing: 12) {
+                    appearanceStatus
+                    Spacer(minLength: 8)
+                    cancelAppearanceButton
+                    applyAppearanceButton
+                }
+            }
+        }
+        .padding(.horizontal, horizontalSizeClass == .compact ? 14 : 24)
+        .padding(.vertical, horizontalSizeClass == .compact ? 10 : 12)
+        .background(DeckPalette.panel)
+        .overlay(alignment: .top) {
+            Rectangle().fill(DeckPalette.line).frame(height: 1)
+        }
+        .shadow(color: .black.opacity(0.16), radius: 10, y: -2)
+    }
+
+    private var appearanceStatus: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(hasChanges ? "UNAPPLIED PREVIEW" : "SAVED APPEARANCE")
+                .deckMono(8.5, weight: .semibold)
+                .tracking(1)
+                .foregroundStyle(hasChanges ? DeckPalette.accent : DeckPalette.ink2)
+                .lineLimit(1)
+            Text("\(draftSurface.name) · \(draftTheme.name)")
+                .deckMono(8)
+                .foregroundStyle(DeckPalette.ink3)
+                .lineLimit(1)
+                .minimumScaleFactor(0.76)
+        }
+    }
+
+    private var cancelAppearanceButton: some View {
+        Button { dismiss() } label: {
+            Text("CANCEL")
+                .deckMono(8.5, weight: .semibold)
+                .tracking(0.8)
+                .foregroundStyle(DeckPalette.ink2)
+                .padding(.horizontal, 16)
+                .frame(height: 46)
+                .background(DeckPalette.cell, in: RoundedRectangle(cornerRadius: 8))
+                .overlay { RoundedRectangle(cornerRadius: 8).stroke(DeckPalette.line) }
+        }
+        .buttonStyle(DeckPressButtonStyle())
+    }
+
+    private var applyAppearanceButton: some View {
+        Button {
+            selectedThemeRaw = draftTheme.rawValue
+            selectedSurfaceRaw = draftSurface.rawValue
+            dismiss()
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .frame(width: 25, height: 25)
+                    .background(.white.opacity(0.16), in: Circle())
+                Text("APPLY APPEARANCE")
+                    .deckMono(9.5, weight: .semibold)
+                    .tracking(0.8)
+                    .lineLimit(1)
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 17)
+            .frame(
+                minWidth: 190,
+                maxWidth: horizontalSizeClass == .compact ? .infinity : 190,
+                minHeight: 48
+            )
+            .background(
+                LinearGradient(
+                    colors: [draftTheme.palette.micTop, draftTheme.palette.micBottom],
+                    startPoint: .top,
+                    endPoint: .bottom
+                ),
+                in: RoundedRectangle(cornerRadius: 9)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 9)
+                    .stroke(draftTheme.palette.accent.opacity(0.75), lineWidth: 1)
+            }
+            .shadow(color: draftTheme.palette.accent.opacity(0.2), radius: 6, y: 2)
+        }
+        .buttonStyle(DeckPressButtonStyle())
+    }
+
+    private func sectionHeading(_ title: String, detail: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title).deckMono(9, weight: .semibold).tracking(1.7).foregroundStyle(DeckPalette.accent)
+            Spacer()
+            Text(detail).deckMono(8).foregroundStyle(DeckPalette.ink3)
+        }
+        .padding(.top, 4)
+    }
+}
+
+private struct SurfaceMiniature: View {
+    let surface: DeckSurfaceID
+
+    var body: some View {
+        ZStack {
+            DeckPalette.plate
+            switch surface {
+            case .console:
+                HStack(spacing: 4) { rows(6); activeField }
+            case .cluster:
+                VStack(spacing: 4) { Circle().stroke(DeckPalette.accent, lineWidth: 2).frame(width: 48, height: 48); keys(9, columns: 9) }
+            case .flightDeck:
+                HStack(spacing: 3) {
+                    ForEach(0..<6, id: \.self) { index in
+                        VStack(spacing: 2) {
+                            Capsule().fill(DeckPalette.line).frame(width: 2)
+                            HStack(spacing: 1) {
+                                ForEach(0..<3, id: \.self) { detent in
+                                    Circle()
+                                        .fill(detent == (2 - index % 3) ? DeckPalette.accent : DeckPalette.ink4)
+                                        .frame(width: 2.5, height: 2.5)
+                                }
+                            }
+                            .frame(height: 4)
+                        }
+                            .padding(3).background(DeckPalette.cell, in: RoundedRectangle(cornerRadius: 2))
+                    }
+                }
+            case .checklist:
+                rows(7)
+            case .pfd:
+                VStack(spacing: 4) { activeField; keys(9, columns: 9) }
+            case .micro:
+                VStack(spacing: 4) { keys(9, columns: 3); RoundedRectangle(cornerRadius: 3).fill(DeckPalette.accent).frame(height: 10) }
+            }
+        }
+        .padding(7)
+        .frame(height: 82)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay { RoundedRectangle(cornerRadius: 6).stroke(DeckPalette.line) }
+    }
+
+    private func keys(_ count: Int, columns: Int) -> some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 2), count: columns), spacing: 2) {
+            ForEach(0..<count, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 1.5)
+                    .fill(index == 1 ? DeckPalette.accentDark : DeckPalette.cell)
+                    .overlay { RoundedRectangle(cornerRadius: 1.5).stroke(index == 1 ? DeckPalette.accent : DeckPalette.line, lineWidth: 0.5) }
+                    .frame(minHeight: columns == 3 ? 14 : 9)
+            }
+        }
+    }
+
+    private func rows(_ count: Int) -> some View {
+        VStack(spacing: 2) {
+            ForEach(0..<count, id: \.self) { index in
+                HStack(spacing: 3) {
+                    RoundedRectangle(cornerRadius: 1).fill(index == 1 ? DeckPalette.accent : DeckPalette.ink3).frame(width: 12, height: 2)
+                    RoundedRectangle(cornerRadius: 1).fill(DeckPalette.line).frame(height: 2)
+                }
+                .padding(2)
+                .background(DeckPalette.cell, in: RoundedRectangle(cornerRadius: 1.5))
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var activeField: some View {
+        VStack(spacing: 4) {
+            Text("02").font(.system(size: 14, weight: .semibold, design: .monospaced)).foregroundStyle(DeckPalette.accent)
+            RoundedRectangle(cornerRadius: 1).fill(DeckPalette.accent).frame(width: 32, height: 2)
+            RoundedRectangle(cornerRadius: 1).fill(DeckPalette.line).frame(width: 44, height: 2)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 3))
+        .overlay { RoundedRectangle(cornerRadius: 3).stroke(DeckPalette.line) }
+    }
+}
+
+private struct HybridThemeMiniature: View {
+    let theme: DeckThemeID
+    private var palette: DeckThemePalette { theme.palette }
+
+    var body: some View {
+        VStack(spacing: 5) {
+            HStack(spacing: 4) {
+                RoundedRectangle(cornerRadius: 2).fill(palette.accent).frame(width: 15, height: 4)
+                RoundedRectangle(cornerRadius: 2).fill(palette.ink3).frame(width: 42, height: 3)
+                Spacer()
+                Circle().fill(palette.accent).frame(width: 4, height: 4)
+                RoundedRectangle(cornerRadius: 2).fill(palette.line).frame(width: 24, height: 4)
+            }
+
+            HStack(spacing: 5) {
+                VStack(spacing: 4) {
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 3), count: 3), spacing: 3) {
+                        ForEach(0..<9, id: \.self) { index in
+                            RoundedRectangle(cornerRadius: 2.5)
+                                .fill(index == 1 ? palette.accentDark : palette.pad)
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 2.5)
+                                        .stroke(index == 1 ? palette.accent : palette.line, lineWidth: 0.7)
+                                }
+                                .overlay(alignment: .topLeading) {
+                                    Text("\(index + 1)")
+                                        .font(.system(size: 4.5, weight: .semibold, design: .monospaced))
+                                        .foregroundStyle(index == 1 ? palette.accent : palette.ink2)
+                                        .padding(2)
+                                }
+                                .frame(height: 20)
+                        }
+                    }
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(LinearGradient(colors: [palette.micTop, palette.micBottom], startPoint: .top, endPoint: .bottom))
+                        .frame(height: 15)
+                        .overlay {
+                            HStack(spacing: 2) {
+                                Circle().fill(.white.opacity(0.9)).frame(width: 6, height: 6)
+                                RoundedRectangle(cornerRadius: 1).fill(.white.opacity(0.72)).frame(width: 32, height: 2)
+                            }
+                        }
+                }
+                .padding(5)
+                .frame(maxWidth: .infinity)
+                .background(palette.plate, in: RoundedRectangle(cornerRadius: 4))
+
+                VStack(spacing: 4) {
+                    ForEach(0..<3, id: \.self) { index in
+                        VStack(alignment: .leading, spacing: 3) {
+                            HStack {
+                                RoundedRectangle(cornerRadius: 1).fill(index == 0 ? palette.accent : palette.ink3).frame(width: 20 + CGFloat(index * 5), height: 2.5)
+                                Spacer()
+                                Circle().fill(index == 1 ? palette.amber : palette.accent).frame(width: 3, height: 3)
+                            }
+                            RoundedRectangle(cornerRadius: 1).fill(palette.line).frame(height: 2)
+                            RoundedRectangle(cornerRadius: 1).fill(palette.lineSoft).frame(width: 38, height: 2)
+                        }
+                        .padding(5)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(palette.cell, in: RoundedRectangle(cornerRadius: 3))
+                    }
+                }
+                .padding(5)
+                .frame(maxWidth: .infinity)
+                .background(palette.panel, in: RoundedRectangle(cornerRadius: 4))
+            }
+        }
+        .padding(7)
+        .frame(height: 118)
+        .background(palette.page, in: RoundedRectangle(cornerRadius: 7))
+        .overlay { RoundedRectangle(cornerRadius: 7).stroke(palette.line) }
+    }
+}
+
+struct DeckCompanionView: View {
+    @ObservedObject var connection: DeckConnection
+    let deck: DiscoveredDeck
+    let onFindDecks: () -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var copied = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 7) {
+                    Text("COMPANION LINK")
+                        .deckMono(9, weight: .semibold)
+                        .tracking(1.8)
+                        .foregroundStyle(DeckPalette.accent)
+                    Text(deck.displayName)
+                        .font(.system(size: 27, weight: .semibold, design: .rounded))
+                        .foregroundStyle(DeckPalette.ink)
+                    Text("The native controls and WebKit lane viewer share the same authoritative Mac runtime.")
+                        .font(.system(size: 12.5, design: .monospaced))
+                        .foregroundStyle(DeckPalette.ink3)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack(spacing: 12) {
+                    SignalBars(active: connection.state == .connected)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(connection.state.label)
+                            .deckMono(10, weight: .semibold)
+                            .tracking(1.4)
+                            .foregroundStyle(DeckPalette.accent)
+                        Text(connection.localStatus ?? "Native link ready")
+                            .deckMono(9)
+                            .foregroundStyle(DeckPalette.ink3)
+                    }
+                    Spacer()
+                }
+                .padding(14)
+                .background(DeckPalette.cell, in: RoundedRectangle(cornerRadius: 10))
+                .overlay { RoundedRectangle(cornerRadius: 10).stroke(DeckPalette.line) }
+
+                VStack(spacing: 0) {
+                    fact("PAIRING", "Approved iPad · Keychain")
+                    Divider().overlay(DeckPalette.lineSoft)
+                    fact("ROUTE", deck.url.scheme == "https" ? "Private HTTPS + WebSocket" : "Local network")
+                    Divider().overlay(DeckPalette.lineSoft)
+                    fact("HOST", deck.url.host ?? "Unknown Mac")
+                    Divider().overlay(DeckPalette.lineSoft)
+                    fact("AUDIO", "Native iPad player · Parakeet capture")
+                }
+                .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 10))
+                .overlay { RoundedRectangle(cornerRadius: 10).stroke(DeckPalette.line) }
+
+                HStack(spacing: 10) {
+                    Button("RECONNECT NOW") { connection.reconnectNow() }
+                        .buttonStyle(.borderedProminent)
+                        .tint(DeckPalette.accent)
+                        .foregroundStyle(DeckPalette.accentDark)
+                    Button("FIND MACS AGAIN") {
+                        onFindDecks()
+                        dismiss()
+                    }
+                    .buttonStyle(.bordered)
+                    Button(copied ? "COPIED" : "COPY DIAGNOSTICS") {
+                        UIPasteboard.general.string = diagnostics
+                        copied = true
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .deckMono(8.5, weight: .semibold)
+
+                Spacer()
+            }
+            .padding(24)
+            .background(DeckPalette.page)
+            .navigationTitle("Companion Link")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(DeckPalette.accent)
+                }
+            }
+        }
+        .preferredColorScheme(DeckThemeSelection.current.colorScheme)
+    }
+
+    private func fact(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).deckMono(8, weight: .semibold).tracking(1.2).foregroundStyle(DeckPalette.ink3)
+            Spacer()
+            Text(value).deckMono(9, weight: .medium).foregroundStyle(DeckPalette.ink2)
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 44)
+    }
+
+    private var diagnostics: String {
+        [
+            "SpeakEasy Deck diagnostics",
+            "Mac: \(deck.displayName)",
+            "Host: \(deck.url.host ?? "unknown")",
+            "Transport: \(deck.url.scheme ?? "unknown")",
+            "State: \(connection.state.label)",
+            "Status: \(connection.localStatus ?? "ready")",
+            "Theme: \(DeckThemeSelection.current.name)",
+            "Surface: native keypad + WebKit lane viewer",
+        ].joined(separator: "\n")
+    }
+}
+
+private struct SignalBars: View {
+    let active: Bool
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 3) {
+            ForEach(0..<4, id: \.self) { index in
+                Capsule()
+                    .fill(active ? DeckPalette.accent : DeckPalette.ink4)
+                    .frame(width: 4, height: CGFloat(7 + index * 4))
+            }
+        }
+        .frame(width: 26, height: 24)
+    }
+}

--- a/deck/ipad/Sources/DeckSurface.swift
+++ b/deck/ipad/Sources/DeckSurface.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum DeckSurfaceID: String, CaseIterable, Identifiable {
+    case console
+    case cluster
+    case flightDeck = "deck"
+    case checklist
+    case pfd
+    case micro
+
+    var id: String { rawValue }
+
+    var name: String {
+        switch self {
+        case .console: "Console"
+        case .cluster: "Cluster"
+        case .flightDeck: "Flight Deck"
+        case .checklist: "Checklist"
+        case .pfd: "Glass PFD"
+        case .micro: "Micro Deck"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .console: "Lane bank and active mission"
+        case .cluster: "One focal instrument"
+        case .flightDeck: "Six model / effort channels"
+        case .checklist: "Dense operations ledger"
+        case .pfd: "Live field with bezel keys"
+        case .micro: "Tactile nine-key hardware"
+        }
+    }
+}
+
+enum DeckSurfaceSelection {
+    static let defaultsKey = "speakeasy.deck.surface.v1"
+
+    static var current: DeckSurfaceID {
+        DeckSurfaceID(rawValue: UserDefaults.standard.string(forKey: defaultsKey) ?? "") ?? .micro
+    }
+}

--- a/deck/ipad/Sources/DeckTheme.swift
+++ b/deck/ipad/Sources/DeckTheme.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+enum DeckThemeID: String, CaseIterable, Identifiable {
+    case flight
+    case obsidian
+    case ceramic
+    case porcelain
+    case amber
+
+    var id: String { rawValue }
+
+    var name: String {
+        switch self {
+        case .flight: "Flight"
+        case .obsidian: "Obsidian"
+        case .ceramic: "Ceramic"
+        case .porcelain: "Porcelain"
+        case .amber: "Amber"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .flight: "Night instrument panel"
+        case .obsidian: "Technical black, cool blue"
+        case .ceramic: "Warm daylight console"
+        case .porcelain: "Quiet white, tailored graphite"
+        case .amber: "Low-light studio deck"
+        }
+    }
+
+    var webTheme: String {
+        switch self {
+        case .flight: "flight"
+        case .obsidian: "obsidian"
+        case .ceramic: "paper"
+        case .porcelain: "porcelain"
+        case .amber: "ember"
+        }
+    }
+
+    var colorScheme: ColorScheme {
+        self == .ceramic || self == .porcelain ? .light : .dark
+    }
+
+    var palette: DeckThemePalette {
+        switch self {
+        case .flight:
+            DeckThemePalette(
+                page: 0x05090B, panel: 0x0C161A, panelHead: 0x0F1C21, cell: 0x122228,
+                trace: 0x0A1316, line: 0x1F333A, lineSoft: 0x1A2B31,
+                ink: 0xE8F0EE, ink2: 0xA9BCB8, ink3: 0x6C7F7B, ink4: 0x4D605C,
+                accent: 0x74F2CE, accentDim: 0x49A88C, accentDark: 0x08231B, accentEdge: 0x1E4A3F,
+                amber: 0xE0A83F, plate: 0x0A1316, plateTop: 0x0E191D, plateBottom: 0x080F12,
+                pad: 0x142328, padBottom: 0x0D171B, empty: 0x0A1216,
+                micTop: 0x0E8A6C, micBottom: 0x0A5F4B
+            )
+        case .obsidian:
+            DeckThemePalette(
+                page: 0x030405, panel: 0x090B0D, panelHead: 0x0D1013, cell: 0x11151A,
+                trace: 0x07090B, line: 0x252C33, lineSoft: 0x181E24,
+                ink: 0xF1F4F6, ink2: 0xB6C0C9, ink3: 0x77838E, ink4: 0x4D5862,
+                accent: 0x79B8FF, accentDim: 0x4B82B8, accentDark: 0x091A2A, accentEdge: 0x244968,
+                amber: 0xE8B85D, plate: 0x07090B, plateTop: 0x11151A, plateBottom: 0x06080A,
+                pad: 0x14191F, padBottom: 0x0D1116, empty: 0x080B0E,
+                micTop: 0x256FA8, micBottom: 0x184A72
+            )
+        case .ceramic:
+            DeckThemePalette(
+                page: 0xE4DDD0, panel: 0xF5F1EA, panelHead: 0xFAF6EE, cell: 0xFFFDF8,
+                trace: 0xF4EEE2, line: 0xD9CFB9, lineSoft: 0xE2DAC7,
+                ink: 0x1A1612, ink2: 0x3B342B, ink3: 0x6B6356, ink4: 0x968B79,
+                accent: 0xB5421C, accentDim: 0xC9764F, accentDark: 0xF7E9D6, accentEdge: 0xE8D2B1,
+                amber: 0xB57B1B, plate: 0xEFEEE9, plateTop: 0xFAF9F5, plateBottom: 0xE8E7E2,
+                pad: 0xFFFDF8, padBottom: 0xEFEEE9, empty: 0xE7E6E1,
+                micTop: 0xB5421C, micBottom: 0x8F3A1C
+            )
+        case .porcelain:
+            DeckThemePalette(
+                page: 0xEEECE7, panel: 0xFCFBF8, panelHead: 0xF6F3ED, cell: 0xFFFFFF,
+                trace: 0xF3F0E9, line: 0xD5D0C7, lineSoft: 0xE3DED5,
+                ink: 0x1E2328, ink2: 0x4D555D, ink3: 0x747C83, ink4: 0xA0A5A8,
+                accent: 0x245A74, accentDim: 0x5A8396, accentDark: 0xE4EEF2, accentEdge: 0xB8CFD8,
+                amber: 0x9B6B22, plate: 0xF2F3F3, plateTop: 0xFFFFFF, plateBottom: 0xE6E8E8,
+                pad: 0xFBFCFC, padBottom: 0xEDEFEF, empty: 0xE5E7E7,
+                micTop: 0x2F6D85, micBottom: 0x204D60
+            )
+        case .amber:
+            DeckThemePalette(
+                page: 0x171209, panel: 0x211A12, panelHead: 0x282017, cell: 0x2B2218,
+                trace: 0x1E1710, line: 0x3D3122, lineSoft: 0x332A1E,
+                ink: 0xF3EAD9, ink2: 0xD9C9B0, ink3: 0xA1937A, ink4: 0x776C5B,
+                accent: 0xE0673A, accentDim: 0xB25A3A, accentDark: 0x35220F, accentEdge: 0x54331F,
+                amber: 0xE0A83F, plate: 0x1E1710, plateTop: 0x2E2417, plateBottom: 0x251C12,
+                pad: 0x2B2218, padBottom: 0x21180F, empty: 0x1E1710,
+                micTop: 0xC2521F, micBottom: 0x93391A
+            )
+        }
+    }
+}
+
+enum DeckThemeSelection {
+    static let defaultsKey = "speakeasy.deck.theme.v1"
+
+    static var current: DeckThemeID {
+        DeckThemeID(rawValue: UserDefaults.standard.string(forKey: defaultsKey) ?? "") ?? .flight
+    }
+}
+
+struct DeckThemePalette {
+    let page: Color
+    let panel: Color
+    let panelHead: Color
+    let cell: Color
+    let trace: Color
+    let line: Color
+    let lineSoft: Color
+    let ink: Color
+    let ink2: Color
+    let ink3: Color
+    let ink4: Color
+    let accent: Color
+    let accentDim: Color
+    let accentDark: Color
+    let accentEdge: Color
+    let amber: Color
+    let plate: Color
+    let plateTop: Color
+    let plateBottom: Color
+    let pad: Color
+    let padBottom: Color
+    let empty: Color
+    let micTop: Color
+    let micBottom: Color
+
+    init(
+        page: UInt32, panel: UInt32, panelHead: UInt32, cell: UInt32,
+        trace: UInt32, line: UInt32, lineSoft: UInt32,
+        ink: UInt32, ink2: UInt32, ink3: UInt32, ink4: UInt32,
+        accent: UInt32, accentDim: UInt32, accentDark: UInt32, accentEdge: UInt32,
+        amber: UInt32, plate: UInt32, plateTop: UInt32, plateBottom: UInt32,
+        pad: UInt32, padBottom: UInt32, empty: UInt32, micTop: UInt32, micBottom: UInt32
+    ) {
+        self.page = Color(deckHex: page)
+        self.panel = Color(deckHex: panel)
+        self.panelHead = Color(deckHex: panelHead)
+        self.cell = Color(deckHex: cell)
+        self.trace = Color(deckHex: trace)
+        self.line = Color(deckHex: line)
+        self.lineSoft = Color(deckHex: lineSoft)
+        self.ink = Color(deckHex: ink)
+        self.ink2 = Color(deckHex: ink2)
+        self.ink3 = Color(deckHex: ink3)
+        self.ink4 = Color(deckHex: ink4)
+        self.accent = Color(deckHex: accent)
+        self.accentDim = Color(deckHex: accentDim)
+        self.accentDark = Color(deckHex: accentDark)
+        self.accentEdge = Color(deckHex: accentEdge)
+        self.amber = Color(deckHex: amber)
+        self.plate = Color(deckHex: plate)
+        self.plateTop = Color(deckHex: plateTop)
+        self.plateBottom = Color(deckHex: plateBottom)
+        self.pad = Color(deckHex: pad)
+        self.padBottom = Color(deckHex: padBottom)
+        self.empty = Color(deckHex: empty)
+        self.micTop = Color(deckHex: micTop)
+        self.micBottom = Color(deckHex: micBottom)
+    }
+}
+
+private extension Color {
+    init(deckHex value: UInt32) {
+        self.init(
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255
+        )
+    }
+}
+
+/// Compatibility facade used by the tactile controls. `@AppStorage` at the
+/// shell level invalidates SwiftUI when this selection changes.
+enum DeckPalette {
+    private static var value: DeckThemePalette { DeckThemeSelection.current.palette }
+    static var page: Color { value.page }
+    static var panel: Color { value.panel }
+    static var panelHead: Color { value.panelHead }
+    static var cell: Color { value.cell }
+    static var trace: Color { value.trace }
+    static var line: Color { value.line }
+    static var lineSoft: Color { value.lineSoft }
+    static var ink: Color { value.ink }
+    static var ink2: Color { value.ink2 }
+    static var ink3: Color { value.ink3 }
+    static var ink4: Color { value.ink4 }
+    static var accent: Color { value.accent }
+    static var accentDim: Color { value.accentDim }
+    static var accentDark: Color { value.accentDark }
+    static var accentEdge: Color { value.accentEdge }
+    static var amber: Color { value.amber }
+    static var plate: Color { value.plate }
+    static var plateTop: Color { value.plateTop }
+    static var plateBottom: Color { value.plateBottom }
+    static var pad: Color { value.pad }
+    static var padBottom: Color { value.padBottom }
+    static var empty: Color { value.empty }
+    static var micTop: Color { value.micTop }
+    static var micBottom: Color { value.micBottom }
+}

--- a/deck/ipad/Sources/DeckWebView.swift
+++ b/deck/ipad/Sources/DeckWebView.swift
@@ -3,57 +3,76 @@ import WebKit
 import Security
 import OSLog
 
-/// The deck's web surface with the native speech bridge attached.
+/// Presentation-only WebKit surface for the right side of the hybrid deck.
 ///
-/// HudWebView does not (yet) expose script message handlers, so this surface
-/// follows the HudCanvasSurface handler convention directly: the page posts
-/// capture phases to `speakeasyDeck`, the controller drives SpeechCapture,
-/// and transcripts go back via `window.speakeasyDeck.nativeTranscript`.
-final class DeckWebController: NSObject, ObservableObject, WKNavigationDelegate, WKScriptMessageHandler {
+/// The page keeps a read/write runtime socket so its player and trace controls
+/// remain useful. `nativeAudio=1` prevents it from creating a second audio
+/// engine; DeckConnection owns capture and playback for the whole iPad shell.
+final class DeckLaneViewerController: NSObject, ObservableObject, WKNavigationDelegate {
     let webView: WKWebView
-    let capture = SpeechCapture()
-    private let logger = Logger(subsystem: "dev.arach.speakeasy.deck", category: "web-surface")
+    private let logger = Logger(subsystem: "dev.arach.speakeasy.deck", category: "lane-viewer")
 
     var deckURL: URL? {
-        didSet { loadIfNeeded() }
+        didSet { loadLaneViewer() }
+    }
+
+    var theme: DeckThemeID = .flight {
+        didSet {
+            guard oldValue != theme else { return }
+            applyTheme()
+        }
     }
 
     override init() {
         let configuration = WKWebViewConfiguration()
-        configuration.userContentController.addUserScript(WKUserScript(
-            source: "window.speakeasyNativeTranscription = true;",
-            injectionTime: .atDocumentStart,
-            forMainFrameOnly: true
-        ))
+        configuration.websiteDataStore = .nonPersistent()
         webView = WKWebView(frame: .zero, configuration: configuration)
         super.init()
-        configuration.userContentController.add(self, name: "speakeasyDeck")
+
         webView.navigationDelegate = self
         webView.isInspectable = true
-        capture.onTranscript = { [weak self] text, isFinal, failure in
-            self?.pushTranscript(text, isFinal: isFinal, failure: failure)
-        }
-        capture.onFallback = { [weak self] url, reason in
-            self?.transcribeLocally(url, reason: reason)
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        if #available(iOS 15.0, *) {
+            webView.underPageBackgroundColor = .clear
         }
     }
 
-    deinit {
-        capture.abort()
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "speakeasyDeck")
-    }
-
-    private func loadIfNeeded() {
-        guard let url = deckURL else { return }
-        capture.abort()
-        // the deck page ships with the server build — never let a stale
-        // WKWebView cache hold an old copy
+    private func loadLaneViewer() {
+        guard let source = deckURL,
+              let url = Self.laneViewerURL(from: source, theme: theme) else { return }
         webView.load(URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData))
     }
 
-    /// A direct Xcode install carries this Mac's public CA anchor in the app's
-    /// Keychain. Trust remains scoped to this WKWebView and this paired host;
-    /// it never changes the iPad's system trust settings.
+    private func applyTheme() {
+        guard webView.url != nil else { return }
+        webView.evaluateJavaScript("window.speakeasyDeck?.setTheme('\(theme.webTheme)')") { [logger] _, error in
+            if let error {
+                logger.error("Lane viewer theme update failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private static func laneViewerURL(from source: URL, theme: DeckThemeID) -> URL? {
+        guard var components = URLComponents(url: source, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        var items = components.queryItems ?? []
+        let ownedNames = Set(["surface", "nativeAudio", "theme", "trace"])
+        items.removeAll { ownedNames.contains($0.name) }
+        items.append(contentsOf: [
+            URLQueryItem(name: "surface", value: "console"),
+            URLQueryItem(name: "nativeAudio", value: "1"),
+            URLQueryItem(name: "theme", value: theme.webTheme),
+            URLQueryItem(name: "trace", value: "1"),
+        ])
+        components.queryItems = items
+        return components.url
+    }
+
+    /// Trust the paired Mac's private CA only for this view and exact host.
     func webView(
         _ webView: WKWebView,
         didReceive challenge: URLAuthenticationChallenge,
@@ -80,106 +99,12 @@ final class DeckWebController: NSObject, ObservableObject, WKNavigationDelegate,
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        logger.error("Deck navigation failed: \(error.localizedDescription, privacy: .public)")
-    }
-
-    // JS → native: capture phases from the page's host bridge
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard message.name == "speakeasyDeck",
-              let body = message.body as? [String: Any],
-              let type = body["type"] as? String, type == "capture",
-              let phase = body["phase"] as? String else { return }
-        switch phase {
-        case "start": capture.start()
-        case "end": capture.finish()
-        case "cancel": capture.abort()
-        default: break
-        }
-    }
-
-    // native → JS: partial and final transcripts
-    private func pushTranscript(_ text: String, isFinal: Bool, failure: String?) {
-        let jsFailure = failure.map(Self.jsString) ?? "null"
-        let js = "window.speakeasyDeck && window.speakeasyDeck.nativeTranscript(\(Self.jsString(text)), \(isFinal ? "true" : "false"), \(jsFailure));"
-        DispatchQueue.main.async { [weak self] in
-            self?.webView.evaluateJavaScript(js, completionHandler: nil)
-        }
-    }
-
-    private struct TranscriptionResult: Decodable {
-        let ok: Bool
-        let text: String?
-        let error: String?
-    }
-
-    private func transcribeLocally(_ fileURL: URL, reason: String) {
-        guard let endpoint = transcriptionEndpoint() else {
-            try? FileManager.default.removeItem(at: fileURL)
-            pushTranscript("", isFinal: true, failure: "LOCAL TRANSCRIBER UNAVAILABLE")
-            return
-        }
-
-        // Keep the pending hold visibly alive while the Mac loads/runs the
-        // local model. The final callback settles the same native capture.
-        pushTranscript("", isFinal: false, failure: reason)
-        var request = URLRequest(url: endpoint)
-        request.httpMethod = "POST"
-        request.timeoutInterval = 185
-        request.cachePolicy = .reloadIgnoringLocalCacheData
-        request.setValue("audio/wav", forHTTPHeaderField: "Content-Type")
-
-        URLSession.shared.uploadTask(with: request, fromFile: fileURL) { [weak self] data, response, error in
-            defer { try? FileManager.default.removeItem(at: fileURL) }
-            guard let self else { return }
-            if let error {
-                self.pushTranscript("", isFinal: true, failure: error.localizedDescription.uppercased())
-                return
-            }
-            guard let http = response as? HTTPURLResponse,
-                  let data,
-                  let result = try? JSONDecoder().decode(TranscriptionResult.self, from: data),
-                  (200..<300).contains(http.statusCode),
-                  result.ok,
-                  let text = result.text?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !text.isEmpty else {
-                let message = data.flatMap { try? JSONDecoder().decode(TranscriptionResult.self, from: $0).error }
-                self.pushTranscript("", isFinal: true, failure: message?.uppercased() ?? "LOCAL TRANSCRIPTION FAILED")
-                return
-            }
-            self.pushTranscript(text, isFinal: true, failure: nil)
-        }.resume()
-    }
-
-    private func transcriptionEndpoint() -> URL? {
-        guard let deckURL, var components = URLComponents(url: deckURL, resolvingAgainstBaseURL: false) else {
-            return nil
-        }
-        let token = components.fragment.flatMap { fragment in
-            URLComponents(string: "https://local.invalid/?\(fragment)")?
-                .queryItems?
-                .first(where: { $0.name == "k" })?
-                .value
-        }
-        components.path = "/api/transcribe"
-        components.query = nil
-        components.fragment = nil
-        if let token, !token.isEmpty {
-            components.queryItems = [URLQueryItem(name: "k", value: token)]
-        }
-        return components.url
-    }
-
-    private static func jsString(_ string: String) -> String {
-        var out = string.replacingOccurrences(of: "\\", with: "\\\\")
-        out = out.replacingOccurrences(of: "'", with: "\\'")
-        out = out.replacingOccurrences(of: "\n", with: "\\n")
-        out = out.replacingOccurrences(of: "\r", with: "")
-        return "'\(out)'"
+        logger.error("Lane viewer navigation failed: \(error.localizedDescription, privacy: .public)")
     }
 }
 
-struct DeckWebView: UIViewRepresentable {
-    let controller: DeckWebController
+struct DeckLaneWebView: UIViewRepresentable {
+    let controller: DeckLaneViewerController
 
     func makeUIView(context: Context) -> WKWebView {
         controller.webView

--- a/deck/ipad/Sources/Info.plist
+++ b/deck/ipad/Sources/Info.plist
@@ -32,11 +32,13 @@
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>SpeakEasy Deck finds and drives your Mac over your local network.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Hold to Speak transcribes your voice on this iPad so your Mac can answer.</string>
-	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Hold to Speak transcribes your voice on this iPad so your Mac can answer.</string>
+	<string>Hold to Speak transcribes your voice on this device so your Mac can answer.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/deck/ipad/Sources/NativeDeckView.swift
+++ b/deck/ipad/Sources/NativeDeckView.swift
@@ -1,0 +1,1439 @@
+import SwiftUI
+
+extension View {
+    func deckMono(_ size: CGFloat, weight: Font.Weight = .regular) -> some View {
+        font(.system(size: size, weight: weight, design: .monospaced))
+    }
+}
+
+struct NativeDeckView: View {
+    @ObservedObject var connection: DeckConnection
+    let laneViewer: DeckLaneViewerController
+    let selectedDeck: DiscoveredDeck
+    let onFindDecks: () -> Void
+    @AppStorage(DeckThemeSelection.defaultsKey) private var selectedThemeRaw = DeckThemeID.flight.rawValue
+    @AppStorage(DeckSurfaceSelection.defaultsKey) private var selectedSurfaceRaw = DeckSurfaceID.micro.rawValue
+    @State private var showingLaneSetup = false
+    @State private var showingAppearance = {
+        #if DEBUG
+        ProcessInfo.processInfo.environment["SPEAKEASY_SHOW_APPEARANCE"] == "1"
+        #else
+        false
+        #endif
+    }()
+    @State private var showingCompanion = false
+    @State private var showingLaneActivity = {
+        #if DEBUG
+        ProcessInfo.processInfo.environment["SPEAKEASY_SHOW_ACTIVITY"] == "1"
+        #else
+        false
+        #endif
+    }()
+
+    private var selectedTheme: DeckThemeID {
+        DeckThemeID(rawValue: selectedThemeRaw) ?? .flight
+    }
+
+    private var selectedSurface: DeckSurfaceID {
+        DeckSurfaceID(rawValue: selectedSurfaceRaw) ?? .micro
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let compact = geometry.size.width < 620
+            VStack(spacing: compact ? 9 : 12) {
+                if compact { compactTopBar } else { topBar }
+
+                if let snapshot = connection.snapshot {
+                    if compact {
+                        KeypadPanel(
+                            connection: connection,
+                            snapshot: snapshot,
+                            surface: selectedSurface,
+                            compact: true,
+                            showLaneSetup: { showingLaneSetup = true },
+                            showActivity: { showingLaneActivity = true }
+                        )
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else if geometry.size.width >= 980 {
+                        HStack(spacing: 14) {
+                            KeypadPanel(
+                                connection: connection,
+                                snapshot: snapshot,
+                                surface: selectedSurface,
+                                compact: false,
+                                showLaneSetup: { showingLaneSetup = true }
+                            )
+                            .frame(width: min(600, geometry.size.width * 0.46))
+
+                            DeckLaneWebView(controller: laneViewer)
+                                .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 9))
+                                .clipShape(RoundedRectangle(cornerRadius: 9))
+                        }
+                    } else {
+                        ScrollView(.vertical, showsIndicators: false) {
+                            VStack(spacing: 14) {
+                                KeypadPanel(
+                                    connection: connection,
+                                    snapshot: snapshot,
+                                    surface: selectedSurface,
+                                    compact: false,
+                                    showLaneSetup: { showingLaneSetup = true }
+                                )
+                                .frame(height: 720)
+
+                                DeckLaneWebView(controller: laneViewer)
+                                    .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 9))
+                                    .clipShape(RoundedRectangle(cornerRadius: 9))
+                                    .frame(height: 720)
+                            }
+                        }
+                    }
+                } else {
+                    nativeLinkPlaceholder
+                }
+            }
+            .padding(.horizontal, compact ? 10 : 16)
+            .padding(.top, compact ? 8 : 14)
+            .padding(.bottom, compact ? 8 : 12)
+        }
+        .background(DeckPalette.page.ignoresSafeArea())
+        .preferredColorScheme(selectedTheme.colorScheme)
+        .onAppear { laneViewer.theme = selectedTheme }
+        .onChange(of: selectedThemeRaw) { _, _ in laneViewer.theme = selectedTheme }
+        .sheet(isPresented: $showingLaneSetup) {
+            LaneSetupView(connection: connection)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showingAppearance) {
+            DeckAppearanceView(selectedThemeRaw: $selectedThemeRaw, selectedSurfaceRaw: $selectedSurfaceRaw)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showingCompanion) {
+            DeckCompanionView(connection: connection, deck: selectedDeck, onFindDecks: onFindDecks)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .fullScreenCover(isPresented: $showingLaneActivity) {
+            CompactLaneActivityView(controller: laneViewer)
+                .preferredColorScheme(selectedTheme.colorScheme)
+        }
+    }
+
+    private var topBar: some View {
+        HStack(spacing: 12) {
+            Text("SE")
+                .deckMono(11, weight: .semibold)
+                .foregroundStyle(DeckPalette.accent)
+                .frame(width: 30, height: 30)
+                .background(DeckPalette.accentDark, in: RoundedRectangle(cornerRadius: 7))
+                .overlay { RoundedRectangle(cornerRadius: 7).stroke(DeckPalette.accentEdge) }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text((connection.snapshot?.host ?? "SPEAKEASY").uppercased())
+                    .deckMono(11.5, weight: .semibold)
+                    .tracking(2.4)
+                    .foregroundStyle(DeckPalette.ink)
+                    .lineLimit(1)
+                Text("NATIVE KEYPAD · WEB LANE VIEWER")
+                    .deckMono(8.5)
+                    .tracking(1.5)
+                    .foregroundStyle(DeckPalette.ink3)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Button { showingCompanion = true } label: {
+                HStack(spacing: 7) {
+                    Circle()
+                        .fill(connection.state == .connected ? DeckPalette.accent : DeckPalette.ink4)
+                        .frame(width: 6, height: 6)
+                        .shadow(color: connection.state == .connected ? DeckPalette.accent.opacity(0.7) : .clear, radius: 5)
+                    Text(connection.state.label)
+                        .deckMono(8, weight: .medium)
+                        .tracking(1.2)
+                        .foregroundStyle(DeckPalette.ink3)
+                }
+                .frame(height: 34)
+                .padding(.horizontal, 9)
+                .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 8))
+                .overlay { RoundedRectangle(cornerRadius: 8).stroke(DeckPalette.line) }
+            }
+            .buttonStyle(DeckPressButtonStyle())
+
+            Button { showingAppearance = true } label: {
+                Label(selectedSurface.name.uppercased(), systemImage: "square.grid.3x3")
+                    .deckMono(8.5, weight: .semibold)
+                    .tracking(1)
+                    .foregroundStyle(DeckPalette.ink2)
+                    .lineLimit(1)
+                    .frame(height: 34)
+                    .padding(.horizontal, 10)
+                    .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 8))
+                    .overlay { RoundedRectangle(cornerRadius: 8).stroke(DeckPalette.line) }
+            }
+            .buttonStyle(DeckPressButtonStyle())
+
+            Button("SET LANES") { showingLaneSetup = true }
+                .deckMono(9, weight: .semibold)
+                .tracking(1.2)
+                .foregroundStyle(DeckPalette.accent)
+                .padding(.horizontal, 13)
+                .frame(height: 36)
+                .background(DeckPalette.accentDark, in: RoundedRectangle(cornerRadius: 8))
+                .overlay { RoundedRectangle(cornerRadius: 8).stroke(DeckPalette.accentEdge) }
+                .buttonStyle(DeckPressButtonStyle())
+        }
+        .padding(.horizontal, 4)
+        .frame(height: 36)
+    }
+
+    private var compactTopBar: some View {
+        VStack(spacing: 7) {
+            HStack(spacing: 9) {
+                Text("SE")
+                    .deckMono(10, weight: .semibold)
+                    .foregroundStyle(DeckPalette.accent)
+                    .frame(width: 32, height: 32)
+                    .background(DeckPalette.accentDark, in: RoundedRectangle(cornerRadius: 7))
+                    .overlay { RoundedRectangle(cornerRadius: 7).stroke(DeckPalette.accentEdge) }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text((connection.snapshot?.host ?? "SPEAKEASY").uppercased())
+                        .deckMono(10, weight: .semibold)
+                        .tracking(1.7)
+                        .foregroundStyle(DeckPalette.ink)
+                        .lineLimit(1)
+                    Text("NATIVE DECK")
+                        .deckMono(7.5, weight: .medium)
+                        .tracking(1.2)
+                        .foregroundStyle(DeckPalette.ink3)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 4)
+
+                Button { showingCompanion = true } label: {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(connection.state == .connected ? DeckPalette.accent : DeckPalette.ink4)
+                            .frame(width: 6, height: 6)
+                        Text(connection.state == .connected ? "LIVE" : "LINK")
+                            .deckMono(7.5, weight: .semibold)
+                            .tracking(1)
+                            .lineLimit(1)
+                    }
+                    .foregroundStyle(DeckPalette.ink2)
+                    .padding(.horizontal, 10)
+                    .frame(height: 32)
+                    .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 7))
+                    .overlay { RoundedRectangle(cornerRadius: 7).stroke(DeckPalette.line) }
+                }
+                .buttonStyle(DeckPressButtonStyle())
+            }
+
+            HStack(spacing: 7) {
+                Button { showingAppearance = true } label: {
+                    Label(selectedSurface.name.uppercased(), systemImage: "slider.horizontal.3")
+                        .deckMono(7.5, weight: .semibold)
+                        .tracking(0.7)
+                        .foregroundStyle(DeckPalette.ink2)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
+                        .frame(maxWidth: .infinity, minHeight: 34)
+                        .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 7))
+                        .overlay { RoundedRectangle(cornerRadius: 7).stroke(DeckPalette.line) }
+                }
+                .buttonStyle(DeckPressButtonStyle())
+
+                Button { showingLaneSetup = true } label: {
+                    Text("SET LANES")
+                        .deckMono(8, weight: .semibold)
+                        .tracking(0.9)
+                        .foregroundStyle(DeckPalette.accent)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, minHeight: 34)
+                        .background(DeckPalette.accentDark, in: RoundedRectangle(cornerRadius: 7))
+                        .overlay { RoundedRectangle(cornerRadius: 7).stroke(DeckPalette.accentEdge) }
+                }
+                .buttonStyle(DeckPressButtonStyle())
+            }
+        }
+    }
+
+    private var nativeLinkPlaceholder: some View {
+        VStack(spacing: 14) {
+            ProgressView()
+                .controlSize(.large)
+                .tint(DeckPalette.accent)
+            Text(connection.localStatus ?? "OPENING NATIVE LINK")
+                .deckMono(11, weight: .semibold)
+                .tracking(1.4)
+                .foregroundStyle(DeckPalette.ink2)
+            Text("The native keypad is waiting for its first runtime snapshot.")
+                .deckMono(9)
+                .foregroundStyle(DeckPalette.ink3)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 12))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(DeckPalette.line) }
+    }
+}
+
+struct KeypadPanel: View {
+    @ObservedObject var connection: DeckConnection
+    let snapshot: DeckSnapshot
+    let surface: DeckSurfaceID
+    var compact = false
+    let showLaneSetup: () -> Void
+    var showActivity: (() -> Void)? = nil
+    @State private var volume: Double = 0.8
+
+    var body: some View {
+        VStack(spacing: compact ? 9 : 12) {
+            HStack(alignment: .top) {
+                Text(surface.name.uppercased())
+                    .deckMono(8.5, weight: .medium)
+                    .tracking(1.7)
+                    .foregroundStyle(DeckPalette.ink3)
+                    .lineLimit(1)
+                Spacer()
+                Button(action: showLaneSetup) {
+                    if compact {
+                        Text("\(snapshot.lanes.prefix(9).filter(\.isAssigned).count) / 9 BOUND")
+                            .deckMono(7.5, weight: .semibold)
+                            .tracking(0.8)
+                            .foregroundStyle(DeckPalette.accent)
+                            .lineLimit(1)
+                    } else {
+                        VStack(alignment: .trailing, spacing: 4) {
+                        Text("\(snapshot.lanes.prefix(9).filter(\.isAssigned).count) / 9 BOUND")
+                            .deckMono(8.5, weight: .medium)
+                            .tracking(1.3)
+                            .foregroundStyle(DeckPalette.accent)
+                        Text("9 KEYS · NATIVE")
+                            .deckMono(8.5)
+                            .tracking(0.8)
+                            .foregroundStyle(DeckPalette.ink3)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 6)
+            .padding(.bottom, 11)
+            .overlay(alignment: .bottom) { Rectangle().fill(DeckPalette.lineSoft).frame(height: 1) }
+
+            HStack(spacing: compact ? 9 : 14) {
+                HardwareKnob(diameter: compact ? 36 : 44)
+
+                VStack(spacing: 5) {
+                    HStack {
+                        Text("NARRATION")
+                            .deckMono(8.5, weight: .medium)
+                            .tracking(1.4)
+                            .foregroundStyle(DeckPalette.ink2)
+                            .lineLimit(1)
+                        Spacer()
+                        Text("\(Int(volume * 100))%")
+                            .deckMono(8.5, weight: .semibold)
+                            .foregroundStyle(DeckPalette.accent)
+                    }
+                    Slider(value: $volume, in: 0...1) { editing in
+                        if !editing { connection.setVolume(volume) }
+                    }
+                    .tint(DeckPalette.accent)
+                    .controlSize(.small)
+                    Text("NATIVE AUDIO ENGINE")
+                        .deckMono(7.5, weight: .medium)
+                        .tracking(1.2)
+                        .foregroundStyle(DeckPalette.ink3)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                SpeakerGrille(diameter: compact ? 36 : 44)
+            }
+            .padding(.horizontal, 6)
+
+            GeometryReader { geometry in
+                NativeLaneSurface(
+                    surface: surface,
+                    connection: connection,
+                    snapshot: snapshot,
+                    size: geometry.size,
+                    compact: compact
+                )
+            }
+
+            HStack(spacing: compact ? 8 : 12) {
+                if !compact { HardwareKnob(diameter: 48, dark: true) }
+                HoldToSpeakButton(
+                    phase: connection.capturePhase,
+                    lane: snapshot.lane,
+                    compact: compact,
+                    onPress: connection.pttBegan,
+                    onRelease: connection.pttEnded,
+                    onCancel: connection.pttCancelled
+                )
+                VStack(spacing: 6) {
+                    CompactDeckButton("LANES", action: showLaneSetup)
+                    CompactDeckButton("STOP", action: connection.stop)
+                }
+                .frame(width: compact ? 64 : 76)
+            }
+            .frame(height: compact ? 62 : 68)
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 7), count: compact ? 3 : 6), spacing: 7) {
+                CompactDeckButton(compact ? "ACTIVITY" : "OVERVIEW") {
+                    if compact, let showActivity {
+                        showActivity()
+                    } else {
+                        connection.selectLane(9)
+                    }
+                }
+                CompactDeckButton("SET LANES", action: showLaneSetup)
+                CompactDeckButton("CANCEL", action: connection.stop)
+                CompactDeckButton("REPLAY", action: connection.replay)
+                CompactDeckButton(snapshot.autoplay ? "AUTO ON" : "AUTO OFF", action: connection.toggleAutoplay)
+                CompactDeckButton(speedLabel, action: connection.cycleSpeed)
+            }
+            .frame(height: compact ? 70 : 38)
+        }
+        .padding(compact ? 12 : 16)
+        .background(
+            LinearGradient(colors: [DeckPalette.plateTop, DeckPalette.plateBottom], startPoint: .topLeading, endPoint: .bottomTrailing),
+            in: RoundedRectangle(cornerRadius: 12)
+        )
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(DeckPalette.line) }
+        .overlay { PlateFasteners() }
+        .onAppear { volume = snapshot.vol }
+        .onChange(of: snapshot.vol) { _, next in volume = next }
+        .sensoryFeedback(.selection, trigger: snapshot.lane)
+    }
+
+    private var speedLabel: String {
+        let speeds = [1.0, 1.25, 1.5, 0.75]
+        let speed = speeds.indices.contains(snapshot.speedIx) ? speeds[snapshot.speedIx] : 1
+        return String(format: "%.2F×", speed)
+    }
+}
+
+private struct CompactLaneActivityView: View {
+    @Environment(\.dismiss) private var dismiss
+    let controller: DeckLaneViewerController
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("LANE ACTIVITY")
+                        .deckMono(11, weight: .semibold)
+                        .tracking(1.5)
+                        .foregroundStyle(DeckPalette.ink)
+                    Text("SECONDARY WEB VIEWER")
+                        .deckMono(7.5, weight: .medium)
+                        .tracking(1.1)
+                        .foregroundStyle(DeckPalette.ink3)
+                }
+
+                Spacer()
+
+                Button { dismiss() } label: {
+                    Label("KEYPAD", systemImage: "chevron.backward")
+                        .deckMono(8.5, weight: .semibold)
+                        .tracking(0.9)
+                        .foregroundStyle(DeckPalette.accent)
+                        .lineLimit(1)
+                        .padding(.horizontal, 12)
+                        .frame(height: 36)
+                        .background(DeckPalette.accentDark, in: RoundedRectangle(cornerRadius: 8))
+                        .overlay { RoundedRectangle(cornerRadius: 8).stroke(DeckPalette.accentEdge) }
+                }
+                .buttonStyle(DeckPressButtonStyle())
+            }
+            .padding(.horizontal, 4)
+
+            DeckLaneWebView(controller: controller)
+                .background(DeckPalette.panel, in: RoundedRectangle(cornerRadius: 9))
+                .clipShape(RoundedRectangle(cornerRadius: 9))
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+        .padding(.bottom, 10)
+        .background(DeckPalette.page.ignoresSafeArea())
+    }
+}
+
+struct NativeLaneSurface: View {
+    let surface: DeckSurfaceID
+    @ObservedObject var connection: DeckConnection
+    let snapshot: DeckSnapshot
+    let size: CGSize
+    let compact: Bool
+
+    private var lanes: [(offset: Int, element: DeckLaneInfo)] {
+        Array(snapshot.lanes.prefix(9).enumerated())
+    }
+
+    private var flightLanes: [(offset: Int, element: DeckLaneInfo)] {
+        Array(snapshot.lanes.prefix(6).enumerated())
+    }
+
+    private var active: (offset: Int, element: DeckLaneInfo)? {
+        lanes.first(where: { $0.offset == snapshot.lane }) ?? lanes.first
+    }
+
+    @ViewBuilder
+    var body: some View {
+        switch surface {
+        case .console:
+            consoleSurface
+        case .cluster:
+            clusterSurface
+        case .flightDeck:
+            flightDeckSurface
+        case .checklist:
+            checklistSurface
+        case .pfd:
+            pfdSurface
+        case .micro:
+            microSurface
+        }
+    }
+
+    private var microSurface: some View {
+        let cellHeight = max(72, (size.height - 18) / 3)
+        return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 9), count: 3), spacing: 9) {
+            ForEach(lanes, id: \.offset) { item in
+                fullLaneKey(item).frame(height: cellHeight)
+            }
+        }
+    }
+
+    private var consoleSurface: some View {
+        HStack(spacing: 10) {
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: 5) {
+                    ForEach(lanes, id: \.offset) { item in
+                        CompactLaneRow(index: item.offset, lane: item.element, selected: snapshot.lane == item.offset) {
+                            connection.selectLane(item.offset)
+                        }
+                    }
+                }
+            }
+            .frame(width: size.width * 0.43)
+
+            if let active {
+                ActiveLaneInstrument(
+                    index: active.offset,
+                    lane: active.element,
+                    snippet: snapshot.lastAgentMessage(in: active.offset)?.text,
+                    phase: connection.capturePhase,
+                    inputLevel: connection.inputLevel
+                )
+            }
+        }
+    }
+
+    private var clusterSurface: some View {
+        VStack(spacing: 9) {
+            if let active {
+                ActiveLaneInstrument(
+                    index: active.offset,
+                    lane: active.element,
+                    snippet: snapshot.lastAgentMessage(in: active.offset)?.text,
+                    phase: connection.capturePhase,
+                    inputLevel: connection.inputLevel,
+                    circular: true
+                )
+            }
+            compactGrid
+                .frame(height: min(96, size.height * 0.28))
+        }
+    }
+
+    @ViewBuilder
+    private var flightDeckSurface: some View {
+        if compact {
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 8) {
+                    ForEach(flightLanes, id: \.offset) { item in
+                        flightStrip(item)
+                            .frame(width: 108)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.viewAligned)
+        } else {
+            HStack(spacing: 7) {
+                ForEach(flightLanes, id: \.offset) { item in
+                    flightStrip(item)
+                }
+            }
+        }
+    }
+
+    private func flightStrip(_ item: (offset: Int, element: DeckLaneInfo)) -> some View {
+        FlightChannelStrip(
+            index: item.offset,
+            lane: item.element,
+            selected: snapshot.lane == item.offset,
+            active: snapshot.playing?.hasPrefix("\(item.offset):") == true || item.element.state == .working
+        ) {
+            connection.selectLane(item.offset)
+        }
+    }
+
+    private var checklistSurface: some View {
+        ScrollView(showsIndicators: false) {
+            LazyVStack(spacing: 5) {
+                ForEach(lanes, id: \.offset) { item in
+                    CompactLaneRow(
+                        index: item.offset,
+                        lane: item.element,
+                        selected: snapshot.lane == item.offset,
+                        showsTask: true
+                    ) {
+                        connection.selectLane(item.offset)
+                    }
+                }
+            }
+        }
+    }
+
+    private var pfdSurface: some View {
+        VStack(spacing: 8) {
+            if let active {
+                ActiveLaneInstrument(
+                    index: active.offset,
+                    lane: active.element,
+                    snippet: snapshot.lastAgentMessage(in: active.offset)?.text,
+                    phase: connection.capturePhase,
+                    inputLevel: connection.inputLevel,
+                    glass: true
+                )
+            }
+            compactGrid.frame(height: min(100, size.height * 0.3))
+        }
+    }
+
+    private var compactGrid: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 5), count: 3), spacing: 5) {
+            ForEach(lanes, id: \.offset) { item in
+                Button { connection.selectLane(item.offset) } label: {
+                    HStack(spacing: 5) {
+                        Text(String(format: "%02d", item.offset + 1)).deckMono(8.5, weight: .semibold)
+                        Text(item.element.name.uppercased()).deckMono(7.5).lineLimit(1)
+                        Spacer(minLength: 0)
+                    }
+                    .foregroundStyle(snapshot.lane == item.offset ? DeckPalette.accent : DeckPalette.ink2)
+                    .padding(.horizontal, 7)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(snapshot.lane == item.offset ? DeckPalette.accentDark : DeckPalette.cell, in: RoundedRectangle(cornerRadius: 5))
+                    .overlay { RoundedRectangle(cornerRadius: 5).stroke(snapshot.lane == item.offset ? DeckPalette.accent : DeckPalette.line) }
+                }
+                .buttonStyle(DeckPressButtonStyle())
+            }
+        }
+    }
+
+    private func fullLaneKey(_ item: (offset: Int, element: DeckLaneInfo)) -> some View {
+        LaneKey(
+            index: item.offset,
+            lane: item.element,
+            selected: snapshot.lane == item.offset,
+            playing: snapshot.playing?.hasPrefix("\(item.offset):") == true,
+            snippet: snapshot.lastAgentMessage(in: item.offset)?.text,
+            voiceReactive: connection.capturePhase == .recording && snapshot.lane == item.offset,
+            inputLevel: snapshot.lane == item.offset ? connection.inputLevel : 0
+        ) {
+            connection.selectLane(item.offset)
+        }
+    }
+}
+
+struct CompactLaneRow: View {
+    let index: Int
+    let lane: DeckLaneInfo
+    let selected: Bool
+    var showsTask = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 9) {
+                Text(String(format: "%02d", index + 1))
+                    .deckMono(10, weight: .semibold)
+                    .foregroundStyle(selected ? DeckPalette.accent : DeckPalette.ink2)
+                    .frame(width: 24, alignment: .leading)
+                Circle()
+                    .fill(lane.state == .working ? DeckPalette.amber : lane.state == .speaking ? DeckPalette.accent : DeckPalette.ink4)
+                    .frame(width: 5, height: 5)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(lane.name.uppercased()).deckMono(8.5, weight: .semibold).lineLimit(1)
+                    if showsTask {
+                        Text(lane.title).deckMono(7).foregroundStyle(DeckPalette.ink3).lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 2)
+                Text(lane.threadId == nil ? "EMPTY" : selected ? "ACTIVE" : "ARMED")
+                    .deckMono(6.5, weight: .semibold)
+                    .foregroundStyle(selected ? DeckPalette.accent : DeckPalette.ink3)
+            }
+            .foregroundStyle(DeckPalette.ink)
+            .padding(.horizontal, 9)
+            .frame(maxWidth: .infinity, minHeight: showsTask ? 40 : 31)
+            .background(selected ? DeckPalette.accentDark : DeckPalette.cell, in: RoundedRectangle(cornerRadius: 6))
+            .overlay { RoundedRectangle(cornerRadius: 6).stroke(selected ? DeckPalette.accent : DeckPalette.line) }
+        }
+        .buttonStyle(DeckPressButtonStyle())
+    }
+}
+
+struct ActiveLaneInstrument: View {
+    let index: Int
+    let lane: DeckLaneInfo
+    let snippet: String?
+    let phase: DeckCapturePhase
+    let inputLevel: Double
+    var circular = false
+    var glass = false
+
+    var body: some View {
+        VStack(spacing: circular ? 8 : 12) {
+            Text(phase == .recording ? "LISTENING" : phase == .transcribing ? "TRANSCRIBING" : "ACTIVE LANE")
+                .deckMono(7.5, weight: .semibold)
+                .tracking(1.8)
+                .foregroundStyle(DeckPalette.accent)
+            Text(String(format: "%02d", index + 1))
+                .font(.system(size: circular ? 38 : 30, weight: .semibold, design: .monospaced))
+                .foregroundStyle(DeckPalette.accent)
+            Text(lane.name.uppercased())
+                .deckMono(12, weight: .semibold)
+                .tracking(1.3)
+                .foregroundStyle(DeckPalette.ink)
+                .lineLimit(1)
+            LaneSparkline(seed: lane.name, active: lane.state != .idle, voiceReactive: phase == .recording, inputLevel: inputLevel)
+                .foregroundStyle(DeckPalette.accent)
+                .frame(height: 24)
+                .padding(.horizontal, 16)
+            Text(snippet ?? lane.title)
+                .deckMono(8.5)
+                .lineSpacing(3)
+                .foregroundStyle(DeckPalette.ink3)
+                .lineLimit(3)
+                .multilineTextAlignment(.center)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            glass ? DeckPalette.trace.opacity(0.78) : DeckPalette.panel,
+            in: RoundedRectangle(cornerRadius: circular ? 80 : 10)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: circular ? 80 : 10)
+                .stroke(glass || circular ? DeckPalette.accentDim : DeckPalette.line, lineWidth: glass ? 1.5 : 1)
+        }
+        .shadow(color: (glass || circular) ? DeckPalette.accent.opacity(0.1) : .clear, radius: 14)
+    }
+}
+
+struct FlightChannelStrip: View {
+    let index: Int
+    let lane: DeckLaneInfo
+    let selected: Bool
+    let active: Bool
+    let action: () -> Void
+
+    private var profile: FlightMixerProfile { FlightMixerProfile.forLane(index) }
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                HStack(spacing: 4) {
+                    Text(String(format: "%02d", index + 1)).deckMono(10, weight: .semibold)
+                    Spacer(minLength: 0)
+                    Circle()
+                        .fill(active ? DeckPalette.amber : selected ? DeckPalette.accent : DeckPalette.ink4)
+                        .frame(width: 6, height: 6)
+                        .shadow(color: active ? DeckPalette.amber.opacity(0.65) : .clear, radius: 4)
+                }
+
+                Text(lane.name.uppercased())
+                    .deckMono(7.5, weight: .semibold)
+                    .tracking(0.7)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.55)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("EFFORT")
+                        .deckMono(5.5, weight: .semibold)
+                        .tracking(0.8)
+                        .foregroundStyle(DeckPalette.ink3)
+                    Text(profile.effort)
+                        .deckMono(7, weight: .semibold)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .foregroundStyle(selected ? DeckPalette.accent : DeckPalette.ink2)
+
+                GeometryReader { geometry in
+                    let travel = max(0, geometry.size.height - 18)
+                    let faderY = travel * CGFloat(1 - profile.level)
+                    ZStack(alignment: .top) {
+                        VStack {
+                            Rectangle().fill(DeckPalette.lineSoft).frame(height: 1)
+                            Spacer()
+                            Rectangle().fill(DeckPalette.lineSoft).frame(height: 1)
+                            Spacer()
+                            Rectangle().fill(DeckPalette.lineSoft).frame(height: 1)
+                        }
+                        .padding(.horizontal, 6)
+
+                        Capsule()
+                            .fill(DeckPalette.line)
+                            .frame(width: 4)
+                            .frame(maxWidth: .infinity)
+
+                        Capsule()
+                            .fill(selected ? DeckPalette.accent.opacity(0.34) : DeckPalette.ink4.opacity(0.4))
+                            .frame(width: 4, height: max(2, geometry.size.height - faderY - 8))
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(
+                                LinearGradient(
+                                    colors: selected ? [DeckPalette.accent, DeckPalette.accentDim] : [DeckPalette.ink2, DeckPalette.ink3],
+                                    startPoint: .top,
+                                    endPoint: .bottom
+                                )
+                            )
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 18)
+                            .overlay { RoundedRectangle(cornerRadius: 3).stroke(DeckPalette.line) }
+                            .shadow(color: .black.opacity(0.28), radius: 2, y: 1)
+                            .offset(y: faderY)
+                    }
+                }
+
+                FlightModelSwitch(model: profile.model, selected: selected)
+            }
+            .foregroundStyle(selected ? DeckPalette.accent : DeckPalette.ink2)
+            .padding(9)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(selected ? DeckPalette.accentDark : DeckPalette.cell, in: RoundedRectangle(cornerRadius: 6))
+            .overlay { RoundedRectangle(cornerRadius: 6).stroke(selected ? DeckPalette.accent : DeckPalette.line) }
+        }
+        .buttonStyle(DeckPressButtonStyle())
+        .accessibilityLabel("Lane \(index + 1), \(lane.name), \(profile.model.name), effort \(profile.effort)")
+    }
+}
+
+private struct FlightModelSwitch: View {
+    let model: FlightModelTier
+    let selected: Bool
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("MODEL")
+                .deckMono(5.2, weight: .semibold)
+                .tracking(1)
+                .foregroundStyle(DeckPalette.ink3)
+
+            HStack(spacing: 0) {
+                ForEach(FlightModelTier.allCases, id: \.rawValue) { tier in
+                    Text(tier.shortName)
+                        .deckMono(5.5, weight: .semibold)
+                        .foregroundStyle(tier == model ? (selected ? DeckPalette.accent : DeckPalette.ink) : DeckPalette.ink4)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+
+            GeometryReader { geometry in
+                let inset: CGFloat = 2
+                let segment = max(1, (geometry.size.width - inset * 2) / 3)
+                ZStack(alignment: .leading) {
+                    Capsule().fill(DeckPalette.lineSoft)
+                    HStack(spacing: 0) {
+                        ForEach(0..<3, id: \.self) { _ in
+                            Circle().fill(DeckPalette.ink4.opacity(0.42)).frame(width: 2.5, height: 2.5).frame(maxWidth: .infinity)
+                        }
+                    }
+                    .padding(.horizontal, 4)
+
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(selected ? DeckPalette.accent : DeckPalette.ink2)
+                        .frame(width: segment, height: geometry.size.height - inset * 2)
+                        .overlay { RoundedRectangle(cornerRadius: 3).stroke(DeckPalette.line) }
+                        .shadow(color: .black.opacity(0.24), radius: 1.5, y: 1)
+                        .offset(x: inset + segment * CGFloat(model.detent), y: inset)
+                }
+            }
+            .frame(height: 10)
+
+            Text(model.name)
+                .deckMono(7.5, weight: .semibold)
+                .tracking(0.8)
+                .foregroundStyle(selected ? DeckPalette.accent : DeckPalette.ink2)
+                .lineLimit(1)
+                .minimumScaleFactor(0.68)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 6)
+        .background(DeckPalette.plate, in: RoundedRectangle(cornerRadius: 4))
+        .overlay { RoundedRectangle(cornerRadius: 4).stroke(selected ? DeckPalette.accentEdge : DeckPalette.line) }
+    }
+}
+
+private enum FlightModelTier: String, CaseIterable {
+    case terra
+    case luna
+    case sol
+
+    var name: String { rawValue.uppercased() }
+    var shortName: String {
+        switch self {
+        case .terra: "T"
+        case .luna: "L"
+        case .sol: "S"
+        }
+    }
+    var detent: Int {
+        switch self {
+        case .terra: 0
+        case .luna: 1
+        case .sol: 2
+        }
+    }
+}
+
+private struct FlightMixerProfile {
+    let model: FlightModelTier
+    let effort: String
+    let level: Double
+
+    static func forLane(_ index: Int) -> FlightMixerProfile {
+        let profiles = [
+            FlightMixerProfile(model: .sol, effort: "XHIGH", level: 0.86),
+            FlightMixerProfile(model: .luna, effort: "HIGH", level: 0.69),
+            FlightMixerProfile(model: .terra, effort: "MED", level: 0.51),
+            FlightMixerProfile(model: .sol, effort: "HIGH", level: 0.72),
+            FlightMixerProfile(model: .luna, effort: "MED", level: 0.50),
+            FlightMixerProfile(model: .terra, effort: "LOW", level: 0.29),
+        ]
+        return profiles[index % profiles.count]
+    }
+}
+
+struct LaneKey: View {
+    @Environment(\.displayScale) private var displayScale
+    let index: Int
+    let lane: DeckLaneInfo
+    let selected: Bool
+    let playing: Bool
+    let snippet: String?
+    let voiceReactive: Bool
+    let inputLevel: Double
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .top) {
+                    Text("\(index + 1)")
+                        .deckMono(17, weight: .semibold)
+                        .foregroundStyle(isUnassigned ? DeckPalette.ink4 : selected ? DeckPalette.accent : DeckPalette.ink)
+                    Spacer()
+                    Circle()
+                        .fill(stateColor)
+                        .frame(width: 6, height: 6)
+                        .shadow(color: isLive ? stateColor.opacity(0.8) : .clear, radius: 4)
+                }
+
+                if !isUnassigned, let snippet, !snippet.isEmpty {
+                    Text("“\(snippet)”")
+                        .deckMono(8.5)
+                        .lineSpacing(3)
+                        .foregroundStyle(selected ? DeckPalette.ink2 : DeckPalette.ink3)
+                        .lineLimit(3)
+                        .padding(.top, 8)
+                }
+
+                Spacer(minLength: 6)
+
+                LaneSparkline(
+                    seed: lane.name,
+                    active: isLive,
+                    voiceReactive: voiceReactive,
+                    inputLevel: inputLevel
+                )
+                    .foregroundStyle(selected ? DeckPalette.accent : isLive ? stateColor : DeckPalette.line)
+                    .frame(height: 16)
+                    .padding(.bottom, 7)
+
+                Text(lane.name.uppercased())
+                    .deckMono(8.5, weight: .semibold)
+                    .tracking(1.2)
+                    .foregroundStyle(selected ? DeckPalette.accent : DeckPalette.ink2)
+                    .lineLimit(1)
+                Text(playing ? "PLAYING" : isUnassigned ? "UNASSIGNED" : lane.state.rawValue.uppercased())
+                    .deckMono(8, weight: .medium)
+                    .tracking(0.8)
+                    .foregroundStyle(selected ? DeckPalette.accent : stateColor)
+                    .padding(.top, 3)
+            }
+            .padding(11)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .background(
+                LinearGradient(
+                    colors: selected ? [DeckPalette.accentDark.opacity(0.95), DeckPalette.padBottom] : isUnassigned ? [DeckPalette.empty, DeckPalette.page] : [DeckPalette.pad, DeckPalette.padBottom],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                ),
+                in: RoundedRectangle(cornerRadius: 9)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 9)
+                    .strokeBorder(
+                        selected ? DeckPalette.accent : DeckPalette.line,
+                        lineWidth: borderWidth
+                    )
+            }
+            .shadow(color: selected ? DeckPalette.accent.opacity(0.1) : .clear, radius: selected ? 5 : 0)
+        }
+        .buttonStyle(DeckPressButtonStyle())
+        .accessibilityLabel("Lane \(index + 1), \(lane.name), \(lane.state.rawValue)")
+    }
+
+    private var isUnassigned: Bool { lane.threadId == nil }
+    private var isLive: Bool { lane.state == .working || lane.state == .speaking || playing }
+    private var borderWidth: CGFloat { (selected ? 2 : 1) / max(displayScale, 1) }
+    private var stateColor: Color {
+        if isUnassigned { return DeckPalette.ink4 }
+        switch lane.state {
+        case .speaking: return DeckPalette.accent
+        case .working: return DeckPalette.amber
+        case .idle: return DeckPalette.ink3
+        case .empty: return DeckPalette.ink4
+        }
+    }
+}
+
+struct LaneSparkline: View {
+    let seed: String
+    let active: Bool
+    let voiceReactive: Bool
+    let inputLevel: Double
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: !voiceReactive)) { timeline in
+            Canvas { context, size in
+                let path = voiceReactive
+                    ? voicePath(size: size, time: timeline.date.timeIntervalSinceReferenceDate)
+                    : seededPath(size: size)
+
+                if voiceReactive {
+                    context.opacity = 0.24
+                    context.stroke(path, with: .foreground, lineWidth: 4.5)
+                    context.opacity = 1
+                    context.stroke(path, with: .foreground, lineWidth: 1.7)
+                } else {
+                    context.stroke(path, with: .foreground, lineWidth: 1.2)
+                }
+            }
+        }
+    }
+
+    private func seededPath(size: CGSize) -> Path {
+        var value = seed.unicodeScalars.reduce(0) { ($0 &* 37 &+ Int($1.value)) % 99_991 }
+        var path = Path()
+        path.move(to: CGPoint(x: 0, y: size.height / 2))
+        for index in 1...10 {
+            value = (value &* 1_103_515_245 &+ 12_345) & 0x7fffffff
+            let random = CGFloat(value) / CGFloat(Int32.max)
+            let amplitude = active ? size.height * 0.72 : size.height * 0.18
+            let y = size.height / 2 + (random - 0.5) * amplitude
+            path.addLine(to: CGPoint(x: size.width * CGFloat(index) / 10, y: y))
+        }
+        return path
+    }
+
+    private func voicePath(size: CGSize, time: TimeInterval) -> Path {
+        let level = CGFloat(min(1, max(0, inputLevel)))
+        let amplitude = size.height * (0.05 + level * 0.82)
+        let middle = size.height / 2
+        var path = Path()
+
+        for index in 0...28 {
+            let progress = CGFloat(index) / 28
+            let envelope = 0.35 + 0.65 * sin(progress * .pi)
+            let primary = sin(progress * .pi * 4 + CGFloat(time * 11.5))
+            let detail = sin(progress * .pi * 9 - CGFloat(time * 16.0)) * 0.36
+            let y = middle + (primary + detail) * amplitude * envelope * 0.5
+            let point = CGPoint(x: size.width * progress, y: y)
+            index == 0 ? path.move(to: point) : path.addLine(to: point)
+        }
+        return path
+    }
+}
+
+struct HoldToSpeakButton: View {
+    let phase: DeckCapturePhase
+    let lane: Int
+    var compact = false
+    let onPress: () -> Void
+    let onRelease: () -> Void
+    let onCancel: () -> Void
+    @State private var ownsHold = false
+
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(spacing: compact ? 9 : 14) {
+                ZStack {
+                    Circle().fill(DeckPalette.ink.opacity(0.95))
+                    Capsule().fill(DeckPalette.micBottom).frame(width: 8, height: 15)
+                }
+                .frame(width: compact ? 28 : 32, height: compact ? 28 : 32)
+                .overlay { Circle().stroke(DeckPalette.accentDim, lineWidth: 1.5) }
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(phase == .recording ? "LISTENING…" : phase == .transcribing ? "TRANSCRIBING…" : "HOLD TO SPEAK")
+                        .deckMono(compact ? 10 : 12, weight: .semibold)
+                        .tracking(compact ? 1.1 : 1.8)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.68)
+                    Text(phase == .idle ? "Parakeet · lane \(lane == 9 ? "overview" : String(format: "%02d", lane + 1))" : phase.label)
+                        .deckMono(8.5)
+                        .foregroundStyle(Color(red: 0.62, green: 0.86, blue: 0.78))
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 4)
+                ListeningBars(active: phase == .recording)
+            }
+            .padding(.horizontal, compact ? 11 : 16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                LinearGradient(colors: [DeckPalette.micTop, DeckPalette.micBottom], startPoint: .top, endPoint: .bottom),
+                in: RoundedRectangle(cornerRadius: 10)
+            )
+            .overlay { RoundedRectangle(cornerRadius: 10).stroke(DeckPalette.accentDim, lineWidth: 1.5) }
+            .scaleEffect(ownsHold ? 0.985 : 1)
+            .brightness(ownsHold ? 0.05 : 0)
+            .contentShape(RoundedRectangle(cornerRadius: 10))
+            .gesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .local)
+                    .onChanged { _ in
+                        guard !ownsHold else { return }
+                        ownsHold = true
+                        onPress()
+                    }
+                    .onEnded { value in
+                        guard ownsHold else { return }
+                        ownsHold = false
+                        let point = value.location
+                        let inside = point.x >= 0 && point.y >= 0 && point.x <= geometry.size.width && point.y <= geometry.size.height
+                        inside ? onRelease() : onCancel()
+                    }
+            )
+            .accessibilityElement()
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel("Hold to speak using local Parakeet")
+            .onDisappear {
+                if ownsHold { ownsHold = false; onCancel() }
+            }
+        }
+    }
+}
+
+struct ListeningBars: View {
+    let active: Bool
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 2.5) {
+            ForEach(0..<10, id: \.self) { index in
+                Capsule()
+                    .fill(.white.opacity(active ? 0.9 : 0.45))
+                    .frame(width: 2.5, height: active ? CGFloat(6 + (index * 7) % 4 * 4) : 4)
+                    .animation(
+                        active ? .easeInOut(duration: 0.45 + Double(index % 5) * 0.08).repeatForever(autoreverses: true).delay(Double(index % 4) * 0.04) : .default,
+                        value: active
+                    )
+            }
+        }
+        .frame(height: 28)
+    }
+}
+
+struct LaneSetupView: View {
+    @ObservedObject var connection: DeckConnection
+    @Environment(\.dismiss) private var dismiss
+    @State private var laneIndex = 0
+    @State private var query = ""
+
+    var body: some View {
+        NavigationStack {
+            GeometryReader { geometry in
+                if geometry.size.width >= 700 {
+                    HStack(spacing: 0) {
+                        lanePicker.frame(width: 280)
+                        Rectangle().fill(DeckPalette.lineSoft).frame(width: 1)
+                        catalog
+                    }
+                } else {
+                    VStack(spacing: 0) {
+                        lanePicker.frame(height: 190)
+                        Rectangle().fill(DeckPalette.lineSoft).frame(height: 1)
+                        catalog
+                    }
+                }
+            }
+            .background(DeckPalette.panel)
+            .navigationTitle("Set lanes")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }.foregroundStyle(DeckPalette.accent)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+        .onAppear {
+            laneIndex = min(8, max(0, connection.snapshot?.lane ?? 0))
+            connection.refreshCatalog()
+        }
+    }
+
+    private var lanePicker: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())], spacing: 7) {
+                ForEach(Array((connection.snapshot?.lanes ?? []).prefix(9).enumerated()), id: \.offset) { index, lane in
+                    Button {
+                        laneIndex = index
+                    } label: {
+                        VStack(alignment: .leading, spacing: 5) {
+                            Text(String(format: "%02d", index + 1)).deckMono(11, weight: .semibold)
+                            Text(lane.threadId == nil ? "FRESH" : "BOUND")
+                                .deckMono(7, weight: .semibold)
+                                .foregroundStyle(lane.threadId == nil ? DeckPalette.ink3 : DeckPalette.accent)
+                            Text(lane.title).deckMono(8).lineLimit(2).foregroundStyle(DeckPalette.ink2)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+                        .padding(9)
+                        .background(laneIndex == index ? DeckPalette.accentDark : DeckPalette.cell, in: RoundedRectangle(cornerRadius: 8))
+                        .overlay { RoundedRectangle(cornerRadius: 8).stroke(laneIndex == index ? DeckPalette.accent : DeckPalette.line) }
+                    }
+                    .buttonStyle(DeckPressButtonStyle())
+                }
+            }
+            .padding(12)
+        }
+        .background(DeckPalette.panelHead)
+    }
+
+    private var catalog: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 9) {
+                Text("PAD \(String(format: "%02d", laneIndex + 1))")
+                    .deckMono(8.5, weight: .semibold)
+                    .tracking(1.3)
+                    .foregroundStyle(DeckPalette.accent)
+                Text(currentLane?.title ?? "Unassigned — choose a Codex task")
+                    .font(.system(size: 14, weight: .medium, design: .monospaced))
+                    .foregroundStyle(DeckPalette.ink)
+                    .lineLimit(1)
+                TextField("Search Codex task titles or projects", text: $query)
+                    .textFieldStyle(.plain)
+                    .deckMono(11)
+                    .padding(.horizontal, 12)
+                    .frame(height: 40)
+                    .background(DeckPalette.cell, in: RoundedRectangle(cornerRadius: 8))
+                    .overlay { RoundedRectangle(cornerRadius: 8).stroke(DeckPalette.line) }
+            }
+            .padding(14)
+            .overlay(alignment: .bottom) { Rectangle().fill(DeckPalette.lineSoft).frame(height: 1) }
+
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    Button {
+                        connection.assignLane(laneIndex, threadID: nil)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("CLEAR ASSIGNMENT").deckMono(9, weight: .semibold).tracking(1.1).foregroundStyle(DeckPalette.accent)
+                            Text("Leave this pad unassigned. Speaking will not create a shadow task.")
+                                .deckMono(8.5).foregroundStyle(DeckPalette.ink3)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                        .background(DeckPalette.accentDark, in: RoundedRectangle(cornerRadius: 9))
+                        .overlay { RoundedRectangle(cornerRadius: 9).stroke(DeckPalette.accentEdge, style: StrokeStyle(lineWidth: 1, dash: [5])) }
+                    }
+                    .buttonStyle(DeckPressButtonStyle())
+
+                    ForEach(filteredCatalog) { thread in
+                        Button {
+                            connection.assignLane(laneIndex, threadID: thread.id)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(thread.snippet)
+                                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                                    .foregroundStyle(DeckPalette.ink)
+                                    .lineLimit(2)
+                                HStack {
+                                    Text("\(thread.displayProject.uppercased()) · \(thread.alias)")
+                                        .deckMono(7.5, weight: .medium)
+                                        .tracking(0.7)
+                                        .foregroundStyle(DeckPalette.ink3)
+                                    Spacer()
+                                    if boundLane(for: thread.id) != nil {
+                                        Text("PAD \((boundLane(for: thread.id) ?? 0) + 1)")
+                                            .deckMono(7.5, weight: .semibold)
+                                            .foregroundStyle(DeckPalette.accent)
+                                    }
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(12)
+                            .background(currentLane?.threadId == thread.id ? DeckPalette.accentDark : DeckPalette.cell, in: RoundedRectangle(cornerRadius: 9))
+                            .overlay { RoundedRectangle(cornerRadius: 9).stroke(currentLane?.threadId == thread.id ? DeckPalette.accentEdge : DeckPalette.line) }
+                        }
+                        .buttonStyle(DeckPressButtonStyle())
+                    }
+
+                    if filteredCatalog.isEmpty {
+                        Text(connection.snapshot?.catalogError ?? "No matching Codex tasks")
+                            .deckMono(9)
+                            .foregroundStyle(DeckPalette.ink3)
+                            .padding(30)
+                    }
+                }
+                .padding(14)
+            }
+        }
+    }
+
+    private var currentLane: DeckLaneInfo? {
+        guard let lanes = connection.snapshot?.lanes, lanes.indices.contains(laneIndex) else { return nil }
+        return lanes[laneIndex]
+    }
+
+    private var filteredCatalog: [DeckThreadInfo] {
+        let catalog = connection.snapshot?.catalog ?? []
+        let terms = query.lowercased().split(whereSeparator: \.isWhitespace)
+        guard !terms.isEmpty else { return catalog }
+        return catalog.filter { thread in
+            let haystack = "\(thread.displayProject) \(thread.snippet) \(thread.preview ?? "") \(thread.cwd) \(thread.id)".lowercased()
+            return terms.allSatisfy { haystack.contains($0) }
+        }
+    }
+
+    private func boundLane(for threadID: String) -> Int? {
+        connection.snapshot?.lanes.prefix(9).firstIndex(where: { $0.threadId == threadID })
+    }
+}
+
+struct CompactDeckButton: View {
+    let title: String
+    let action: () -> Void
+
+    init(_ title: String, action: @escaping () -> Void) {
+        self.title = title
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .deckMono(7.5, weight: .semibold)
+                .tracking(0.7)
+                .foregroundStyle(DeckPalette.ink2)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .frame(maxWidth: .infinity, minHeight: 30, maxHeight: .infinity)
+                .background(
+                    LinearGradient(colors: [DeckPalette.pad, DeckPalette.padBottom], startPoint: .top, endPoint: .bottom),
+                    in: RoundedRectangle(cornerRadius: 7)
+                )
+                .overlay { RoundedRectangle(cornerRadius: 7).stroke(DeckPalette.line) }
+        }
+        .buttonStyle(DeckPressButtonStyle())
+    }
+}
+
+struct DeckPressButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .brightness(configuration.isPressed ? 0.05 : 0)
+            .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+    }
+}
+
+struct HardwareKnob: View {
+    var diameter: CGFloat = 44
+    var dark = false
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: dark ? [Color(white: 0.24), Color(white: 0.08)] : [Color(white: 0.92), Color(white: 0.45)],
+                        center: UnitPoint(x: 0.35, y: 0.28),
+                        startRadius: 1,
+                        endRadius: diameter / 2
+                    )
+                )
+                .shadow(color: .black.opacity(0.45), radius: 4, y: 3)
+            Capsule()
+                .fill(dark ? DeckPalette.ink3 : Color(white: 0.2))
+                .frame(width: 2, height: 9)
+                .padding(.top, 5)
+        }
+        .frame(width: diameter, height: diameter)
+        .overlay { Circle().stroke(DeckPalette.ink4, lineWidth: 1) }
+    }
+}
+
+struct SpeakerGrille: View {
+    var diameter: CGFloat = 44
+
+    var body: some View {
+        Canvas { context, size in
+            for x in stride(from: 7.0, through: size.width - 5, by: 4) {
+                for y in stride(from: 7.0, through: size.height - 5, by: 4) {
+                    context.fill(Path(ellipseIn: CGRect(x: x, y: y, width: 1.2, height: 1.2)), with: .color(DeckPalette.ink3.opacity(0.8)))
+                }
+            }
+        }
+        .frame(width: diameter, height: diameter)
+        .background(Color(white: 0.09), in: Circle())
+        .overlay { Circle().stroke(DeckPalette.ink4) }
+        .shadow(color: .black.opacity(0.4), radius: 3, y: 2)
+    }
+}
+
+struct PlateFasteners: View {
+    var body: some View {
+        GeometryReader { geometry in
+            ForEach(0..<4, id: \.self) { index in
+                Circle()
+                    .fill(DeckPalette.line)
+                    .frame(width: 4, height: 4)
+                    .position(
+                        x: index % 2 == 0 ? 8 : geometry.size.width - 8,
+                        y: index < 2 ? 8 : geometry.size.height - 8
+                    )
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}

--- a/deck/ipad/Sources/SpeechCapture.swift
+++ b/deck/ipad/Sources/SpeechCapture.swift
@@ -1,44 +1,38 @@
-import Speech
 import AVFAudio
 import OSLog
 
-/// Native hold-to-speak capture. Apple Speech supplies low-latency partials
-/// when it is healthy; every utterance is also recorded so the paired Mac can
-/// fall back to its local Parakeet model without reopening the microphone.
+/// Native hold-to-speak recorder.
+///
+/// Recognition deliberately does not happen on the iPad. Every utterance is
+/// captured once as PCM WAV and sent to the paired Mac's local Parakeet model.
+/// This keeps one transcription engine authoritative and avoids the latency,
+/// permissions, and result drift of running Apple Speech first.
 final class SpeechCapture: NSObject {
-    /// (text, isFinal, user-facing failure)
-    var onTranscript: (String, Bool, String?) -> Void = { _, _, _ in }
-    /// (private PCM WAV, reason Apple Speech was skipped/failed)
-    var onFallback: (URL, String) -> Void = { _, _ in }
+    var onStarted: () -> Void = {}
+    var onRecordingReady: (URL) -> Void = { _ in }
+    var onFailure: (String) -> Void = { _ in }
+    var onLevel: (Float) -> Void = { _ in }
 
     private enum State {
         case idle
         case authorizing(UInt64)
         case capturing(UInt64)
-        case finishing(UInt64)
 
         var token: UInt64? {
             switch self {
             case .idle: nil
-            case .authorizing(let token), .capturing(let token), .finishing(let token): token
+            case .authorizing(let token), .capturing(let token): token
             }
         }
     }
 
-    private let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
     private let engine = AVAudioEngine()
     private let logger = Logger(subsystem: "dev.arach.speakeasy.deck", category: "speech-capture")
-    private var request: SFSpeechAudioBufferRecognitionRequest?
-    private var task: SFSpeechRecognitionTask?
     private var recordingFile: AVAudioFile?
     private var recordingURL: URL?
     private var state: State = .idle
     private var nextToken: UInt64 = 0
     private var tapInstalled = false
-    private var appleRecognitionEnabled = false
-    private var recognitionFailure: String?
-    private var latestText = ""
-    private var finishBackstop: DispatchWorkItem?
 
     func start() {
         onMain { [weak self] in self?.startOnMain() }
@@ -49,41 +43,13 @@ final class SpeechCapture: NSObject {
         nextToken &+= 1
         let token = nextToken
         state = .authorizing(token)
-        latestText = ""
-        recognitionFailure = nil
-        appleRecognitionEnabled = false
-        logger.info("Capture \(token) requesting microphone access")
+        logger.info("Capture \(token) requesting microphone access for Parakeet")
 
-#if targetEnvironment(simulator)
-        // iOS Simulator currently installs a device-specialized Apple Speech
-        // asset that its local recognizer cannot load. Capture real audio and
-        // go straight to Parakeet instead of failing after the mic opens.
-        requestMicrophone(token: token)
-#else
-        SFSpeechRecognizer.requestAuthorization { [weak self] status in
-            self?.onMain {
-                guard let self, self.state.token == token else { return }
-                self.appleRecognitionEnabled = status == .authorized && self.recognizer?.isAvailable == true
-                if !self.appleRecognitionEnabled {
-                    self.logger.notice("Capture \(token) will use local Parakeet because Apple Speech is unavailable")
-                }
-                self.requestMicrophone(token: token)
-            }
-        }
-#endif
-    }
-
-    private func requestMicrophone(token: UInt64) {
         AVAudioApplication.requestRecordPermission { [weak self] granted in
             self?.onMain {
                 guard let self, self.state.token == token else { return }
                 guard granted else {
-                    self.complete(
-                        token: token,
-                        text: "",
-                        failure: "MICROPHONE PERMISSION REQUIRED",
-                        cancelTask: true
-                    )
+                    self.fail(token: token, message: "MICROPHONE PERMISSION REQUIRED")
                     return
                 }
                 self.begin(token: token)
@@ -99,52 +65,44 @@ final class SpeechCapture: NSObject {
             try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             logger.error("Capture \(token) could not activate audio session: \(error.localizedDescription, privacy: .public)")
-            complete(token: token, text: "", failure: "MICROPHONE START FAILED", cancelTask: true)
+            fail(token: token, message: "MICROPHONE START FAILED")
             return
         }
 
         let input = engine.inputNode
-        let hardwareFormat = input.inputFormat(forBus: 0)
-        let tapFormat = input.outputFormat(forBus: 0)
-        guard session.isInputAvailable,
-              Self.isUsable(hardwareFormat),
-              Self.isUsable(tapFormat),
-              !tapInstalled else {
-            logger.error(
-                "Capture \(token) has no usable input (available=\(session.isInputAvailable), hardware=\(hardwareFormat.sampleRate, privacy: .public)/\(hardwareFormat.channelCount), tap=\(tapFormat.sampleRate, privacy: .public)/\(tapFormat.channelCount), tapInstalled=\(self.tapInstalled))"
-            )
-            complete(token: token, text: "", failure: "MICROPHONE INPUT UNAVAILABLE", cancelTask: true)
+        let format = input.outputFormat(forBus: 0)
+        guard session.isInputAvailable, Self.isUsable(format), !tapInstalled else {
+            fail(token: token, message: "MICROPHONE INPUT UNAVAILABLE")
             return
         }
 
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("speakeasy-deck-\(UUID().uuidString)")
+            .appendingPathComponent("speakeasy-parakeet-\(UUID().uuidString)")
             .appendingPathExtension("wav")
         let file: AVAudioFile
         do {
-            file = try AVAudioFile(forWriting: url, settings: tapFormat.settings)
+            file = try AVAudioFile(forWriting: url, settings: format.settings)
             try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
             recordingFile = file
             recordingURL = url
         } catch {
             logger.error("Capture \(token) could not create its recording: \(error.localizedDescription, privacy: .public)")
-            complete(token: token, text: "", failure: "MICROPHONE RECORDING FAILED", cancelTask: true)
+            fail(token: token, message: "MICROPHONE RECORDING FAILED")
             return
         }
 
-        if appleRecognitionEnabled {
-            let speechRequest = SFSpeechAudioBufferRecognitionRequest()
-            speechRequest.shouldReportPartialResults = true
-            request = speechRequest
-        }
-
-        input.installTap(onBus: 0, bufferSize: 1024, format: tapFormat) { [weak self] buffer, _ in
+        var lastMeterUpdate = 0.0
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
             do {
                 try file.write(from: buffer)
             } catch {
                 self?.logger.error("Capture \(token) could not write audio: \(error.localizedDescription, privacy: .public)")
             }
-            self?.request?.append(buffer)
+
+            let now = ProcessInfo.processInfo.systemUptime
+            guard now - lastMeterUpdate >= 1.0 / 30.0 else { return }
+            lastMeterUpdate = now
+            self?.onLevel(Self.normalizedLevel(in: buffer))
         }
         tapInstalled = true
         engine.prepare()
@@ -152,35 +110,13 @@ final class SpeechCapture: NSObject {
             try engine.start()
         } catch {
             logger.error("Capture \(token) audio engine failed: \(error.localizedDescription, privacy: .public)")
-            complete(token: token, text: "", failure: "MICROPHONE START FAILED", cancelTask: true)
+            fail(token: token, message: "MICROPHONE START FAILED")
             return
         }
 
         state = .capturing(token)
-        logger.info("Capture \(token) started at \(tapFormat.sampleRate, privacy: .public) Hz with \(tapFormat.channelCount) channel(s)")
-
-        if let recognizer, let request {
-            task = recognizer.recognitionTask(with: request) { [weak self] result, error in
-                self?.onMain {
-                    guard let self, self.state.token == token else { return }
-                    if let result {
-                        let text = result.bestTranscription.formattedString
-                        self.latestText = text
-                        if result.isFinal {
-                            self.complete(token: token, text: text)
-                            return
-                        }
-                        self.onTranscript(text, false, nil)
-                    }
-                    if let error {
-                        self.logger.error("Capture \(token) Apple Speech failed: \(error.localizedDescription, privacy: .public)")
-                        self.recognitionFailure = "APPLE SPEECH FAILED · USING PARAKEET"
-                        self.request?.endAudio()
-                        self.request = nil
-                    }
-                }
-            }
-        }
+        logger.info("Capture \(token) started at \(format.sampleRate, privacy: .public) Hz with \(format.channelCount) channel(s)")
+        onStarted()
     }
 
     func finish() {
@@ -188,35 +124,22 @@ final class SpeechCapture: NSObject {
             guard let self else { return }
             switch self.state {
             case .authorizing(let token):
-                self.complete(token: token, text: "", failure: "MICROPHONE STILL STARTING · HOLD AGAIN", cancelTask: true)
+                self.fail(token: token, message: "MICROPHONE STILL STARTING · HOLD AGAIN")
             case .capturing(let token):
-                self.state = .finishing(token)
-                self.stopAudioInput()
-                self.request?.endAudio()
-
-                if self.task == nil || self.recognitionFailure != nil {
-                    self.complete(
-                        token: token,
-                        text: self.latestText,
-                        failure: self.recognitionFailure ?? "TRANSCRIBING LOCALLY",
-                        cancelTask: true
-                    )
+                guard let url = self.recordingURL else {
+                    self.fail(token: token, message: "MICROPHONE RECORDING FAILED")
                     return
                 }
-
-                self.finishBackstop?.cancel()
-                let work = DispatchWorkItem { [weak self] in
-                    guard let self, self.state.token == token else { return }
-                    self.complete(
-                        token: token,
-                        text: self.latestText,
-                        failure: self.latestText.isEmpty ? "APPLE SPEECH TIMED OUT · USING PARAKEET" : nil,
-                        cancelTask: true
-                    )
+                self.teardown(token: token, preserveRecording: true)
+                let bytes = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?.intValue ?? 0
+                guard bytes > 44 else {
+                    try? FileManager.default.removeItem(at: url)
+                    self.onFailure("NO SPEECH · TRY AGAIN")
+                    return
                 }
-                self.finishBackstop = work
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
-            case .finishing, .idle:
+                self.logger.notice("Capture \(token) recorded \(bytes) bytes for local Parakeet")
+                self.onRecordingReady(url)
+            case .idle:
                 break
             }
         }
@@ -225,61 +148,29 @@ final class SpeechCapture: NSObject {
     func abort() {
         onMain { [weak self] in
             guard let self, let token = self.state.token else { return }
-            self.teardown(token: token, cancelTask: true, preserveRecording: false)
+            self.teardown(token: token, preserveRecording: false)
         }
     }
 
-    private func complete(
-        token: UInt64,
-        text: String,
-        failure: String? = nil,
-        cancelTask: Bool = false
-    ) {
+    private func fail(token: UInt64, message: String) {
         guard state.token == token else { return }
-        let cleanedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        let shouldFallback = recordingURL != nil && (failure != nil || cleanedText.isEmpty)
-        let fallbackURL = shouldFallback ? recordingURL : nil
-        teardown(token: token, cancelTask: cancelTask, preserveRecording: shouldFallback)
-
-        if let fallbackURL {
-            logger.notice("Capture \(token) recorded locally; sending it to Parakeet")
-            onFallback(fallbackURL, failure ?? "TRANSCRIBING LOCALLY")
-        } else {
-            if let failure {
-                logger.error("Capture \(token) ended: \(failure, privacy: .public)")
-            } else {
-                logger.info("Capture \(token) ended with \(cleanedText.count) transcript characters")
-            }
-            onTranscript(cleanedText, true, failure)
-        }
+        logger.error("Capture \(token) ended: \(message, privacy: .public)")
+        teardown(token: token, preserveRecording: false)
+        onFailure(message)
     }
 
-    private func stopAudioInput() {
+    private func teardown(token: UInt64, preserveRecording: Bool) {
+        guard state.token == token else { return }
+        state = .idle
         if engine.isRunning { engine.stop() }
         if tapInstalled {
             engine.inputNode.removeTap(onBus: 0)
             tapInstalled = false
         }
         recordingFile = nil
-    }
-
-    private func teardown(token: UInt64, cancelTask: Bool, preserveRecording: Bool) {
-        guard state.token == token else { return }
-        state = .idle
-        finishBackstop?.cancel()
-        finishBackstop = nil
-        latestText = ""
-        recognitionFailure = nil
-        appleRecognitionEnabled = false
-
-        let oldTask = task
-        task = nil
-        request = nil
-        if cancelTask { oldTask?.cancel() }
-
-        stopAudioInput()
         engine.reset()
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        onLevel(0)
 
         let oldRecordingURL = recordingURL
         recordingURL = nil
@@ -290,6 +181,30 @@ final class SpeechCapture: NSObject {
 
     private static func isUsable(_ format: AVAudioFormat) -> Bool {
         format.sampleRate.isFinite && format.sampleRate > 0 && format.channelCount > 0
+    }
+
+    /// Convert the microphone's RMS energy into a perceptual 0...1 meter.
+    /// Roughly -55 dB is silence and -10 dB is full scale for this surface.
+    private static func normalizedLevel(in buffer: AVAudioPCMBuffer) -> Float {
+        guard let channels = buffer.floatChannelData,
+              buffer.frameLength > 0,
+              buffer.format.channelCount > 0 else { return 0 }
+
+        let frameCount = Int(buffer.frameLength)
+        let channelCount = Int(buffer.format.channelCount)
+        var sum: Float = 0
+        for channel in 0..<channelCount {
+            let samples = channels[channel]
+            for frame in 0..<frameCount {
+                let sample = samples[frame]
+                sum += sample * sample
+            }
+        }
+
+        let rms = sqrt(sum / Float(frameCount * channelCount))
+        let decibels = 20 * log10(max(rms, 0.000_01))
+        let linear = min(1, max(0, (decibels + 55) / 45))
+        return pow(linear, 0.72)
     }
 
     private func onMain(_ operation: @escaping () -> Void) {

--- a/deck/ipad/project.yml
+++ b/deck/ipad/project.yml
@@ -12,7 +12,7 @@ settings:
     CODE_SIGN_STYLE: Automatic
     CODE_SIGN_IDENTITY: Apple Development
     SWIFT_VERSION: "5.0"
-    TARGETED_DEVICE_FAMILY: "2"
+    TARGETED_DEVICE_FAMILY: "1,2"
 
 targets:
   SpeakEasyDeck:
@@ -36,9 +36,10 @@ targets:
         NSBonjourServices:
           - _http._tcp
         NSLocalNetworkUsageDescription: SpeakEasy Deck finds and drives your Mac over your local network.
-        NSMicrophoneUsageDescription: Hold to Speak transcribes your voice on this iPad so your Mac can answer.
-        NSSpeechRecognitionUsageDescription: Hold to Speak transcribes your voice on this iPad so your Mac can answer.
+        NSMicrophoneUsageDescription: Hold to Speak transcribes your voice on this device so your Mac can answer.
         UILaunchStoryboardName: LaunchScreen
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
         UISupportedInterfaceOrientations~ipad:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationLandscapeLeft


### PR DESCRIPTION
## What changed

- Replace the full-screen web shell with a native SwiftUI keypad and a presentation-only WebKit lane viewer.
- Add native WebSocket state, lane assignment, transport controls, audio playback, and companion diagnostics.
- Make Hold to Speak Parakeet-first and animate the selected lane meter from live microphone RMS.
- Add six native control surfaces and five coordinated native/web themes with miniature previews and a pinned Apply action.
- Compose an iPad split view and an intentionally keypad-first iPhone layout.
- Add console-only and native-audio-host modes to the web Deck surface.

## Why

The keypad, microphone, and transport path are latency-sensitive controls and should be native. Conversation history and trace presentation retain the flexibility of the existing web Deck.

## User impact

iPad gets the native-left/web-right hybrid surface; iPhone gets a compact keypad-first instrument. Both remain synchronized through the Mac runtime's authoritative snapshots.

## Checks

- Built `SpeakEasyDeck` for the iPad Pro 11-inch (M5) iOS 26.2 simulator.
- Validated the complete stack alongside the routing and bridge suites.

## Stack

Depends on #21, which depends on #20. This is PR 3 of 3 in the native Deck stack.