### PR TITLE
💄 Refine Pad appearance and link controls

### DIFF
--- a/pad/index.html
+++ b/pad/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#071013" />
     <meta name="color-scheme" content="dark" />
     <meta name="description" content="A focused iPad control surface for SpeakEasy voice lanes." />

--- a/pad/src/app.ts
+++ b/pad/src/app.ts
@@ -13,7 +13,7 @@ import {
   type PadCommand,
   type PadSnapshot,
 } from "./model.ts";
-import { createTransport, linkAllowsCommands, type PadTransport } from "./transport.ts";
+import { createTransport, forgetStoredLANSession, linkAllowsCommands, type PadTransport } from "./transport.ts";
 import { finishCommandAfterRecording, RecordingStartLatch } from "./ptt.ts";
 import {
   applyPadTheme,
@@ -33,7 +33,7 @@ import { applyPadMode, PAD_MODE_COPY, PAD_MODE_IDS, readPadMode, savePadMode, ty
 const mount = document.querySelector<HTMLDivElement>("#app");
 if (!mount) throw new Error("SpeakEasy Pad could not find its app mount.");
 const root: HTMLDivElement = mount;
-const PAD_BUILD = "0726.6";
+const PAD_BUILD = "0802.1";
 
 const bootstrap = consumeBootstrapFromLocation(window.location, window.history);
 const transport = createTransport(bootstrap.kind === "valid" ? bootstrap.payload : undefined);
@@ -62,8 +62,13 @@ let appearanceSheetOpen = false;
 let appearanceSheetView: "browse" | "editor" = "browse";
 let editorThemeId: string | undefined;
 let editorText = "";
+let editorInitialText = "";
 let editorErrors: string[] = [];
+let editorDiscardArmed = false;
+let editorDiscardDestination: "browse" | "close" = "browse";
 let themeDeleteArmed = false;
+let linkActionArmed: "pair" | "forget" | undefined;
+let focusAfterRender: string | undefined;
 let deferredInstall: BeforeInstallPromptEvent | undefined;
 let pttStart: Promise<boolean> | undefined;
 let pressButton: HTMLElement | undefined;
@@ -589,38 +594,55 @@ function receiptMarkup(): string {
   </div>`;
 }
 
+function themePreviewMarkup(item: PadTheme): string {
+  return `<span class="theme-preview" data-preview-scheme="${item.scheme}" style="--preview-accent:${esc(themeAccent(item))}" aria-hidden="true">
+    <i><b></b><b></b><b></b></i><i><b></b><b></b></i>
+  </span>`;
+}
+
+function appearanceHasChanges(): boolean {
+  return mode !== readPadMode() || theme.id !== readPadTheme().id;
+}
+
 function sheetMarkup(): string {
   if (!connectionSheetOpen && !installSheetOpen && !appearanceSheetOpen) return "";
   if (appearanceSheetOpen) {
     if (appearanceSheetView === "editor") return themeEditorMarkup();
     const themes = listPadThemes();
+    const dirty = appearanceHasChanges();
     return `<div class="sheet-backdrop" data-dismiss-sheet>
-      <section class="sheet appearance-sheet" role="dialog" aria-modal="true" aria-labelledby="appearance-title">
-        <button class="sheet-close" type="button" data-dismiss-sheet aria-label="Close">${icons.close}</button>
-        <p class="eyebrow">STUDIO CONTROL SURFACES</p>
-        <h2 id="appearance-title">Choose a Pad layout</h2>
-        <div class="mode-options">${PAD_MODE_IDS.map((id, index) => `<button type="button" class="mode-option" data-select-mode="${id}" data-selected="${id === mode}" aria-pressed="${id === mode}">
+      <section class="sheet appearance-sheet" role="dialog" aria-modal="true" aria-labelledby="appearance-title" aria-describedby="appearance-description" tabindex="-1" data-focus-id="dialog">
+        <button class="sheet-close" type="button" data-dismiss-sheet data-focus-id="sheet-close" aria-label="Cancel appearance changes">${icons.close}</button>
+        <p class="eyebrow">STUDIO APPEARANCE</p>
+        <h2 id="appearance-title">Appearance</h2>
+        <p class="sheet-intro" id="appearance-description">Choose the control layout and visual theme independently. Changes preview live and stay on this Pad only after you apply them.</p>
+        <div class="appearance-section-heading"><p class="eyebrow">CONTROL SURFACE</p><span>Layout</span></div>
+        <div class="mode-options">${PAD_MODE_IDS.map((id, index) => `<button type="button" class="mode-option" data-select-mode="${id}" data-focus-id="mode-${id}" data-selected="${id === mode}" aria-pressed="${id === mode}">
           <span class="mode-preview" data-preview="${id}" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span>
           <span><strong>${(index + 1).toString().padStart(2, "0")} · ${PAD_MODE_COPY[id].label}</strong><small>${PAD_MODE_COPY[id].description}</small></span>
         </button>`).join("")}</div>
-        <div class="finish-label"><p class="eyebrow">DECK THEME</p><span>Manifest · Contract v1</span></div>
-        <div class="finish-options">${themes.map((item) => `<button type="button" data-select-theme="${item.id}" data-selected="${item.id === theme.id}" aria-pressed="${item.id === theme.id}"><i style="background:${themeAccent(item)}"></i>${esc(item.name)}</button>`).join("")}
-          <button type="button" class="finish-new" data-new-theme><i aria-hidden="true">+</i>NEW DECK THEME</button>
+        <div class="appearance-section-heading"><p class="eyebrow">DECK THEME</p><span>Color system</span></div>
+        <div class="finish-options">${themes.map((item) => `<button type="button" class="theme-option" data-select-theme="${item.id}" data-focus-id="theme-${item.id}" data-selected="${item.id === theme.id}" aria-pressed="${item.id === theme.id}">${themePreviewMarkup(item)}<span>${esc(item.name)}</span></button>`).join("")}
+          <button type="button" class="finish-new" data-new-theme data-focus-id="new-theme"><i aria-hidden="true">+</i><span><strong>CREATE THEME</strong><small>Advanced</small></span></button>
         </div>
         ${theme.source === "custom" ? `<div class="theme-edit-row">
           <span>CUSTOM · ${esc(theme.name)}</span>
-          <button type="button" data-edit-theme="${theme.id}">EDIT MANIFEST</button>
-          <button type="button" class="theme-delete" data-delete-theme data-armed="${themeDeleteArmed}">${themeDeleteArmed ? "CONFIRM DELETE" : "DELETE"}</button>
+          <button type="button" data-edit-theme="${theme.id}" data-focus-id="edit-theme">EDIT</button>
+          <button type="button" class="theme-delete" data-delete-theme data-focus-id="delete-theme" data-armed="${themeDeleteArmed}">${themeDeleteArmed ? "CONFIRM DELETE" : "DELETE"}</button>
         </div>` : ""}
-        <p class="sheet-note">Deck themes are Chrome-style manifests — colors, CSS, and HTML chrome bound through Pad Theme Contract v1 (docs/theme-contract.md). Saved on this device; the Mac link keeps running while you switch.</p>
+        <div class="appearance-actions">
+          <p role="status">${dirty ? "Previewing unapplied changes" : "Using saved appearance"}</p>
+          <button type="button" class="sheet-secondary" data-appearance-cancel data-focus-id="appearance-cancel">CANCEL</button>
+          <button type="button" class="sheet-primary" data-appearance-apply data-focus-id="appearance-apply" ${dirty ? "" : "disabled"}>APPLY CHANGES</button>
+        </div>
       </section>
     </div>`;
   }
   if (connectionSheetOpen) {
     const copy = LINK_COPY[health];
     return `<div class="sheet-backdrop" data-dismiss-sheet>
-      <section class="sheet" role="dialog" aria-modal="true" aria-labelledby="connection-title">
-        <button class="sheet-close" type="button" data-dismiss-sheet aria-label="Close">${icons.close}</button>
+      <section class="sheet connection-sheet" role="dialog" aria-modal="true" aria-labelledby="connection-title" aria-describedby="connection-description" tabindex="-1" data-focus-id="dialog">
+        <button class="sheet-close" type="button" data-dismiss-sheet data-focus-id="sheet-close" aria-label="Close Companion Link settings">${icons.close}</button>
         <p class="eyebrow">COMPANION LINK</p>
         <h2 id="connection-title">${esc(hostName)}</h2>
         <div class="link-readout" data-health="${health}">
@@ -633,13 +655,20 @@ function sheetMarkup(): string {
           <div><dt>ROUTE</dt><dd>${sessionSecurity === "demo" ? "In-browser simulator" : sessionSecurity === "lan-prototype-v1" ? "Trusted-LAN pilot · plaintext" : "End-to-end encrypted"}</dd></div>
           <div><dt>AUTHORITY</dt><dd>${transport.mode === "demo" ? "Browser demo state · no Mac connected" : "The Mac acknowledges every command"}</dd></div>
         </dl>
-        <p class="sheet-note">Connection health and pairing trust are separate. If the route drops, this Pad keeps no command queued.</p>
+        <div class="link-actions">
+          <button type="button" class="sheet-primary" data-link-reconnect data-focus-id="link-reconnect">${health === "healthy" ? "CHECK CONNECTION" : "RECONNECT NOW"}</button>
+          <button type="button" class="sheet-secondary" data-link-copy data-focus-id="link-copy">COPY DIAGNOSTICS</button>
+          <button type="button" class="sheet-secondary" data-link-pair data-focus-id="link-pair" data-armed="${linkActionArmed === "pair"}" ${transport.mode === "demo" ? "disabled" : ""}>${linkActionArmed === "pair" ? "CONFIRM PAIR AGAIN" : "PAIR AGAIN"}</button>
+          <button type="button" class="sheet-secondary danger-action" data-link-forget data-focus-id="link-forget" data-armed="${linkActionArmed === "forget"}" ${transport.mode === "demo" ? "disabled" : ""}>${linkActionArmed === "forget" ? "CONFIRM FORGET" : "FORGET THIS PAD"}</button>
+        </div>
+        ${linkActionArmed ? `<p class="link-action-warning" role="alert">${linkActionArmed === "pair" ? "This removes the current pairing, then waits for a fresh code from your Mac." : "This removes pairing, custom themes, and saved appearance from this Pad."}</p>` : ""}
+        <p class="sheet-note" id="connection-description">Connection health and pairing trust are separate. If the route drops, this Pad keeps no command queued.</p>
       </section>
     </div>`;
   }
   return `<div class="sheet-backdrop" data-dismiss-sheet>
-    <section class="sheet install-sheet" role="dialog" aria-modal="true" aria-labelledby="install-title">
-      <button class="sheet-close" type="button" data-dismiss-sheet aria-label="Close">${icons.close}</button>
+    <section class="sheet install-sheet" role="dialog" aria-modal="true" aria-labelledby="install-title" tabindex="-1" data-focus-id="dialog">
+      <button class="sheet-close" type="button" data-dismiss-sheet data-focus-id="sheet-close" aria-label="Close install instructions">${icons.close}</button>
       <p class="eyebrow">FULL-SCREEN CONTROL SURFACE</p>
       <h2 id="install-title">Add SpeakEasy Pad to Home Screen</h2>
       <ol>
@@ -674,17 +703,19 @@ const THEME_STARTER_MANIFEST = `{
 function themeEditorMarkup(): string {
   const title = editorThemeId ? `Edit “${esc(findPadTheme(editorThemeId)?.name ?? "deck theme")}”` : "New deck theme";
   return `<div class="sheet-backdrop" data-dismiss-sheet>
-    <section class="sheet appearance-sheet theme-editor" role="dialog" aria-modal="true" aria-labelledby="theme-editor-title">
-      <button class="sheet-close" type="button" data-dismiss-sheet aria-label="Close">${icons.close}</button>
-      <p class="eyebrow">PAD THEME CONTRACT v1</p>
+    <section class="sheet appearance-sheet theme-editor" role="dialog" aria-modal="true" aria-labelledby="theme-editor-title" aria-describedby="theme-editor-description" tabindex="-1" data-focus-id="dialog">
+      <button class="sheet-close" type="button" data-dismiss-sheet data-focus-id="sheet-close" aria-label="Close theme editor">${icons.close}</button>
+      <p class="eyebrow">ADVANCED THEME EDITOR</p>
       <h2 id="theme-editor-title">${title}</h2>
-      <p class="sheet-note">A deck theme is a Chrome-style manifest: metadata, <b>colors</b> (design tokens), <b>css</b>, and <b>html</b> chrome with <b>data-pad-slot</b> mounts. Full contract: docs/theme-contract.md.</p>
-      <textarea class="theme-manifest" data-theme-manifest spellcheck="false" autocomplete="off" aria-label="Theme manifest JSON">${esc(editorText)}</textarea>
+      <p class="sheet-intro" id="theme-editor-description">Edit the theme colors and optional custom chrome as JSON. Nothing is saved until you choose Save theme.</p>
+      <details class="theme-contract-details"><summary>Theme manifest details</summary><p>Pad Theme Contract v1 supports metadata, color tokens, CSS, and optional HTML mount regions. The full reference is in <code>docs/theme-contract.md</code>.</p></details>
+      <textarea class="theme-manifest" data-theme-manifest data-focus-id="theme-manifest" spellcheck="false" autocomplete="off" aria-label="Theme manifest JSON">${esc(editorText)}</textarea>
       ${editorErrors.length > 0 ? `<ul class="theme-editor-errors" role="alert">${editorErrors.map((error) => `<li>${esc(error)}</li>`).join("")}</ul>` : ""}
+      ${editorDiscardArmed ? `<div class="theme-editor-warning" role="alert"><span>Discard your unsaved changes?</span><button type="button" class="sheet-secondary" data-theme-keep data-focus-id="theme-keep">KEEP EDITING</button><button type="button" class="sheet-secondary danger-action" data-theme-discard data-focus-id="theme-discard">DISCARD</button></div>` : ""}
       <div class="theme-editor-actions">
-        <button type="button" class="sheet-primary" data-theme-save>SAVE THEME</button>
-        <button type="button" class="sheet-secondary" data-theme-template>STARTER TEMPLATE</button>
-        <button type="button" class="sheet-secondary" data-theme-back>BACK</button>
+        <button type="button" class="sheet-primary" data-theme-save data-focus-id="theme-save">SAVE THEME</button>
+        <button type="button" class="sheet-secondary" data-theme-template data-focus-id="theme-template">STARTER TEMPLATE</button>
+        <button type="button" class="sheet-secondary" data-theme-back data-focus-id="theme-back">BACK TO APPEARANCE</button>
       </div>
     </section>
   </div>`;
@@ -705,11 +736,11 @@ function topbarMarkup(): string {
       <span class="brand-copy"><strong>SPEAKEASY</strong><small>PAD / CONTROL SURFACE</small></span>
     </div>
     <div class="topbar-actions">
-      <button class="theme-button" type="button" data-appearance aria-label="Change layout and deck theme. Current layout ${PAD_MODE_COPY[mode].label}, ${esc(theme.name)} theme">
+      <button class="theme-button" type="button" data-appearance data-focus-id="appearance-trigger" aria-label="Change layout and deck theme. Current layout ${PAD_MODE_COPY[mode].label}, ${esc(theme.name)} theme">
         <span class="theme-swatch" aria-hidden="true"></span>${icons.theme}<span>${PAD_MODE_COPY[mode].label}</span>
       </button>
-      <button class="install-button" type="button" data-install aria-label="Install SpeakEasy Pad">${icons.install}<span>INSTALL</span></button>
-      <button class="link-chip" type="button" data-connection data-health="${health}" aria-label="${esc(link.label)}. ${esc(linkDetail || link.detail)}">
+      <button class="install-button" type="button" data-install data-focus-id="install-trigger" aria-label="Install SpeakEasy Pad">${icons.install}<span>INSTALL</span></button>
+      <button class="link-chip" type="button" data-connection data-focus-id="connection-trigger" data-health="${health}" aria-label="${esc(link.label)}. ${esc(linkDetail || link.detail)}">
         ${mode === "micro" ? `<span class="link-measure">${health === "offline" ? "OFF" : lastAckLatencyMs === undefined ? "— MS" : `${lastAckLatencyMs} MS`}</span>` : barsMarkup(link.bars)}
         <span><strong>${transport.mode === "demo" ? "LOCAL DEMO" : mode === "micro" ? "COMMAND RTT" : esc(link.label)}</strong><small>${transport.mode === "demo" ? "AUDIO ON THIS DEVICE" : esc(hostName)}</small></span>
       </button>
@@ -731,6 +762,7 @@ function padStateAttributes(): string {
 }
 
 function render(): void {
+  const previousFocusId = (document.activeElement as HTMLElement | null)?.dataset.focusId;
   const regions: Array<[string, string]> = [
     ["topbar", topbarMarkup()],
     ["surface", surfaceMarkup()],
@@ -754,6 +786,20 @@ function render(): void {
   root.replaceChildren(shell);
 
   bindEvents();
+  const dialog = root.querySelector<HTMLElement>(".sheet[role=\"dialog\"]");
+  if (dialog) {
+    root.querySelectorAll<HTMLElement>(".topbar, .studio-surface, .status-rail, .fastener").forEach((element) => {
+      element.inert = true;
+      element.setAttribute("aria-hidden", "true");
+    });
+  }
+  const targetFocusId = focusAfterRender ?? previousFocusId ?? (dialog ? "sheet-close" : undefined);
+  focusAfterRender = undefined;
+  if (targetFocusId) {
+    const target = Array.from(root.querySelectorAll<HTMLElement>("[data-focus-id]"))
+      .find((element) => element.dataset.focusId === targetFocusId && !element.matches(":disabled"));
+    target?.focus({ preventScroll: true });
+  }
 }
 
 function showNotice(message: string, tone: "info" | "error" = "info"): void {
@@ -940,13 +986,118 @@ async function finishPtt(cancelled: boolean): Promise<void> {
   }
 }
 
-function closeSheets(): void {
+function closeSheets(returnFocusId?: "appearance-trigger" | "connection-trigger" | "install-trigger"): void {
   connectionSheetOpen = false;
   installSheetOpen = false;
   appearanceSheetOpen = false;
   appearanceSheetView = "browse";
   editorErrors = [];
+  editorDiscardArmed = false;
   themeDeleteArmed = false;
+  linkActionArmed = undefined;
+  focusAfterRender = returnFocusId;
+}
+
+function cancelAppearance(): void {
+  theme = readPadTheme();
+  mode = readPadMode();
+  applyPadTheme(theme);
+  applyPadMode(mode);
+  closeSheets("appearance-trigger");
+}
+
+function editorHasUnsavedChanges(): boolean {
+  return editorText !== editorInitialText;
+}
+
+function requestEditorExit(destination: "browse" | "close"): void {
+  if (editorHasUnsavedChanges()) {
+    editorDiscardArmed = true;
+    editorDiscardDestination = destination;
+    focusAfterRender = "theme-discard";
+    render();
+    return;
+  }
+  if (destination === "close") cancelAppearance();
+  else {
+    appearanceSheetView = "browse";
+    editorErrors = [];
+    focusAfterRender = editorThemeId ? `theme-${editorThemeId}` : "new-theme";
+  }
+  render();
+}
+
+function requestSheetDismiss(): void {
+  if (appearanceSheetOpen && appearanceSheetView === "editor") {
+    requestEditorExit("close");
+    return;
+  }
+  if (appearanceSheetOpen) {
+    cancelAppearance();
+    render();
+    return;
+  }
+  closeSheets(connectionSheetOpen ? "connection-trigger" : "install-trigger");
+  render();
+}
+
+function connectionDiagnostics(): string {
+  return [
+    "SpeakEasy Pad diagnostics",
+    `Build: ${PAD_BUILD}`,
+    `Host: ${hostName}`,
+    `Transport: ${transport.mode}`,
+    `Link: ${health} · ${linkDetail}`,
+    `Security: ${sessionSecurity}`,
+    `Lease remaining: ${leaseRemaining()}`,
+    `Layout: ${PAD_MODE_COPY[mode].label}`,
+    `Theme: ${theme.name}`,
+    `Revision: ${snapshot.revision}`,
+    `Last snapshot: ${snapshotAgeLabel()}`,
+    `Acknowledged commands: ${acknowledgedCommandCount}`,
+    `Last round trip: ${lastAckLatencyMs === undefined ? "not measured" : `${lastAckLatencyMs} ms`}`,
+  ].join("\n");
+}
+
+async function copyDiagnostics(): Promise<void> {
+  const text = connectionDiagnostics();
+  let copied = false;
+  const field = document.createElement("textarea");
+  field.value = text;
+  field.setAttribute("readonly", "");
+  field.style.position = "fixed";
+  field.style.opacity = "0";
+  document.body.append(field);
+  field.select();
+  try {
+    copied = document.execCommand("copy");
+  } finally {
+    field.remove();
+  }
+  if (!copied && navigator.clipboard) {
+    copied = await Promise.race([
+      navigator.clipboard.writeText(text).then(() => true).catch(() => false),
+      new Promise<boolean>((resolve) => window.setTimeout(() => resolve(false), 900)),
+    ]);
+  }
+  showNotice(copied ? "Connection diagnostics copied." : "Could not copy diagnostics on this browser.", copied ? "info" : "error");
+}
+
+function returnToUnpairedPad(forgetAppearance: boolean): void {
+  transport.forgetPairing?.();
+  forgetStoredLANSession();
+  if (forgetAppearance) {
+    try {
+      for (let index = localStorage.length - 1; index >= 0; index -= 1) {
+        const key = localStorage.key(index);
+        if (key?.startsWith("speakeasy.pad.")) localStorage.removeItem(key);
+      }
+    } catch {
+      // Navigation still returns the Pad to an unpaired state if storage is unavailable.
+    }
+  }
+  const cleanURL = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+  window.location.replace(cleanURL);
 }
 
 function bindEvents(): void {
@@ -965,6 +1116,8 @@ function bindEvents(): void {
 
   root.querySelector<HTMLButtonElement>("[data-appearance]")?.addEventListener("click", () => {
     appearanceSheetOpen = true;
+    appearanceSheetView = "browse";
+    focusAfterRender = "sheet-close";
     render();
   });
   root.querySelectorAll<HTMLButtonElement>("[data-select-mode]").forEach((button) => {
@@ -972,9 +1125,8 @@ function bindEvents(): void {
       const next = button.dataset.selectMode as PadMode;
       if (!PAD_MODE_IDS.includes(next)) return;
       mode = next;
-      savePadMode(mode);
       applyPadMode(mode);
-      notifyNative("selection");
+      focusAfterRender = `mode-${next}`;
       render();
     });
   });
@@ -983,10 +1135,9 @@ function bindEvents(): void {
       const next = findPadTheme(button.dataset.selectTheme ?? "");
       if (!next) return;
       theme = next;
-      savePadTheme(theme.id);
       applyPadTheme(theme);
       themeDeleteArmed = false;
-      notifyNative("selection");
+      focusAfterRender = `theme-${next.id}`;
       render();
     });
   });
@@ -994,7 +1145,10 @@ function bindEvents(): void {
     appearanceSheetView = "editor";
     editorThemeId = undefined;
     editorText = THEME_STARTER_MANIFEST;
+    editorInitialText = editorText;
     editorErrors = [];
+    editorDiscardArmed = false;
+    focusAfterRender = "theme-manifest";
     render();
   });
   root.querySelector<HTMLButtonElement>("[data-edit-theme]")?.addEventListener("click", (event) => {
@@ -1003,22 +1157,25 @@ function bindEvents(): void {
     appearanceSheetView = "editor";
     editorThemeId = target.id;
     editorText = JSON.stringify(target.manifest, null, 2);
+    editorInitialText = editorText;
     editorErrors = [];
+    editorDiscardArmed = false;
+    focusAfterRender = "theme-manifest";
     render();
   });
   root.querySelector<HTMLButtonElement>("[data-delete-theme]")?.addEventListener("click", () => {
     if (theme.source !== "custom") return;
     if (!themeDeleteArmed) {
       themeDeleteArmed = true;
+      focusAfterRender = "delete-theme";
       render();
       return;
     }
     themeDeleteArmed = false;
     deleteCustomTheme(theme.id);
     theme = readPadTheme({ getItem: () => null });
-    savePadTheme(theme.id);
     applyPadTheme(theme);
-    notifyNative("selection");
+    focusAfterRender = `theme-${theme.id}`;
     render();
   });
   root.querySelector<HTMLTextAreaElement>("[data-theme-manifest]")?.addEventListener("input", (event) => {
@@ -1027,11 +1184,28 @@ function bindEvents(): void {
   root.querySelector<HTMLButtonElement>("[data-theme-template]")?.addEventListener("click", () => {
     editorText = THEME_STARTER_MANIFEST;
     editorErrors = [];
+    editorDiscardArmed = false;
+    focusAfterRender = "theme-manifest";
     render();
   });
   root.querySelector<HTMLButtonElement>("[data-theme-back]")?.addEventListener("click", () => {
+    requestEditorExit("browse");
+  });
+  root.querySelector<HTMLButtonElement>("[data-theme-keep]")?.addEventListener("click", () => {
+    editorDiscardArmed = false;
+    focusAfterRender = "theme-manifest";
+    render();
+  });
+  root.querySelector<HTMLButtonElement>("[data-theme-discard]")?.addEventListener("click", () => {
+    editorDiscardArmed = false;
+    if (editorDiscardDestination === "close") {
+      cancelAppearance();
+      render();
+      return;
+    }
     appearanceSheetView = "browse";
     editorErrors = [];
+    focusAfterRender = editorThemeId ? `theme-${editorThemeId}` : "new-theme";
     render();
   });
   root.querySelector<HTMLButtonElement>("[data-theme-save]")?.addEventListener("click", () => {
@@ -1043,13 +1217,28 @@ function bindEvents(): void {
     }
     const saved = upsertCustomTheme(result.manifest, editorThemeId);
     theme = saved;
-    savePadTheme(theme.id);
     applyPadTheme(theme);
     appearanceSheetView = "browse";
+    editorText = JSON.stringify(result.manifest, null, 2);
+    editorInitialText = editorText;
     editorErrors = [];
+    editorDiscardArmed = false;
     themeDeleteArmed = false;
-    notifyNative("selection");
+    focusAfterRender = `theme-${saved.id}`;
     showNotice(`Deck theme “${saved.name}” saved.`);
+  });
+  root.querySelector<HTMLButtonElement>("[data-appearance-cancel]")?.addEventListener("click", () => {
+    cancelAppearance();
+    render();
+  });
+  root.querySelector<HTMLButtonElement>("[data-appearance-apply]")?.addEventListener("click", () => {
+    savePadMode(mode);
+    savePadTheme(theme.id);
+    applyPadMode(mode);
+    applyPadTheme(theme);
+    notifyNative("selection");
+    closeSheets("appearance-trigger");
+    showNotice(`Appearance applied · ${PAD_MODE_COPY[mode].label} · ${theme.name}.`);
   });
 
   const ptt = root.querySelector<HTMLButtonElement>("[data-ptt]");
@@ -1081,7 +1270,53 @@ function bindEvents(): void {
 
   root.querySelector<HTMLButtonElement>("[data-connection]")?.addEventListener("click", () => {
     connectionSheetOpen = true;
+    linkActionArmed = undefined;
+    focusAfterRender = "sheet-close";
     render();
+  });
+  root.querySelector<HTMLButtonElement>("[data-link-reconnect]")?.addEventListener("click", async () => {
+    linkActionArmed = undefined;
+    if (health === "healthy") {
+      await pingMac();
+      return;
+    }
+    health = "connecting";
+    linkDetail = `Finding ${hostName}`;
+    focusAfterRender = "link-reconnect";
+    render();
+    try {
+      await transport.connect();
+      showNotice(`Connected to ${hostName}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `Could not connect to ${hostName}.`;
+      health = "offline";
+      linkDetail = message;
+      showNotice(message, "error");
+    }
+  });
+  root.querySelector<HTMLButtonElement>("[data-link-copy]")?.addEventListener("click", () => {
+    focusAfterRender = "link-copy";
+    void copyDiagnostics();
+  });
+  root.querySelector<HTMLButtonElement>("[data-link-pair]")?.addEventListener("click", () => {
+    if (transport.mode === "demo") return;
+    if (linkActionArmed !== "pair") {
+      linkActionArmed = "pair";
+      focusAfterRender = "link-pair";
+      render();
+      return;
+    }
+    returnToUnpairedPad(false);
+  });
+  root.querySelector<HTMLButtonElement>("[data-link-forget]")?.addEventListener("click", () => {
+    if (transport.mode === "demo") return;
+    if (linkActionArmed !== "forget") {
+      linkActionArmed = "forget";
+      focusAfterRender = "link-forget";
+      render();
+      return;
+    }
+    returnToUnpairedPad(true);
   });
 
   const volumeSlider = root.querySelector<HTMLInputElement>("[data-demo-volume]");
@@ -1098,13 +1333,13 @@ function bindEvents(): void {
   });
   root.querySelector<HTMLButtonElement>("[data-install]")?.addEventListener("click", () => {
     installSheetOpen = true;
+    focusAfterRender = "sheet-close";
     render();
   });
   root.querySelectorAll<HTMLElement>("[data-dismiss-sheet]").forEach((element) => {
     element.addEventListener("click", (event) => {
       if (event.currentTarget !== event.target && (event.currentTarget as HTMLElement).classList.contains("sheet-backdrop")) return;
-      closeSheets();
-      render();
+      requestSheetDismiss();
     });
   });
   root.querySelector<HTMLButtonElement>("[data-install-now]")?.addEventListener("click", async () => {
@@ -1136,14 +1371,34 @@ window.addEventListener("pointermove", (event) => {
 });
 window.addEventListener("blur", () => void finishPtt(true));
 window.addEventListener("keydown", (event) => {
+  if (event.key === "Tab" && (connectionSheetOpen || installSheetOpen || appearanceSheetOpen)) {
+    const dialog = root.querySelector<HTMLElement>(".sheet[role=\"dialog\"]");
+    const focusable = dialog ? Array.from(dialog.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), textarea:not(:disabled), input:not(:disabled), select:not(:disabled), a[href], summary, [tabindex]:not([tabindex="-1"])',
+    )).filter((element) => !element.hidden && element.getAttribute("aria-hidden") !== "true") : [];
+    if (dialog && focusable.length === 0) {
+      event.preventDefault();
+      dialog.focus();
+    } else if (focusable.length > 0) {
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (event.shiftKey && (document.activeElement === first || !dialog?.contains(document.activeElement))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (document.activeElement === last || !dialog?.contains(document.activeElement))) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  }
   if ((event.code === "Space" || event.code === "Enter") && !event.repeat && !connectionSheetOpen && !installSheetOpen && !appearanceSheetOpen && document.activeElement?.tagName !== "BUTTON") {
     event.preventDefault();
     startPtt(pressButton ?? root);
   }
   if (event.key === "Escape") {
     if (connectionSheetOpen || installSheetOpen || appearanceSheetOpen) {
-      closeSheets();
-      render();
+      event.preventDefault();
+      requestSheetDismiss();
     } else if (pttPressed) void finishPtt(true);
   }
 });

--- a/pad/src/styles.css
+++ b/pad/src/styles.css
@@ -80,6 +80,7 @@ body {
 }
 
 button { color: inherit; font: inherit; }
+button:not(:disabled) { cursor: pointer; }
 button:focus-visible { outline: 2px solid var(--signal); outline-offset: 3px; }
 button:disabled { cursor: not-allowed; }
 
@@ -381,34 +382,42 @@ button:disabled { cursor: not-allowed; }
 .pad[data-link="offline"] .status-light { background: var(--danger); box-shadow: 0 0 7px rgba(255,102,92,.6); }
 
 .sheet-backdrop { position: fixed; inset: 0; z-index: 100; display: grid; place-items: center; padding: 22px; background: rgba(0,5,6,.72); backdrop-filter: blur(12px); }
-.sheet { position: relative; width: min(460px, 100%); padding: 28px; border: 1px solid var(--rule-strong); border-radius: 15px; background: linear-gradient(145deg, rgba(226,239,235,.07), transparent 38%), #0a1417; box-shadow: 0 28px 90px rgba(0,0,0,.7), inset 0 1px rgba(255,255,255,.05); }
+.sheet { position: relative; width: min(460px, 100%); max-height: min(88vh, 820px); overflow: auto; overscroll-behavior: contain; padding: 28px; border: 1px solid var(--rule-strong); border-radius: 15px; background: linear-gradient(145deg, rgba(226,239,235,.07), transparent 38%), #0a1417; box-shadow: 0 28px 90px rgba(0,0,0,.7), inset 0 1px rgba(255,255,255,.05); }
 .pad[data-scheme="light"] .sheet { background: linear-gradient(145deg, rgba(255,255,255,.9), transparent 38%), #e5ebe8; box-shadow: 0 28px 90px rgba(31,48,43,.28), inset 0 1px #fff; }
-.sheet h2 { margin: 10px 0 20px; font: 600 26px/1.1 var(--display); letter-spacing: -.025em; }
+.sheet h2 { margin: 10px 0 12px; font: 600 26px/1.1 var(--display); letter-spacing: -.025em; }
 .sheet-close { position: absolute; right: 14px; top: 14px; width: 44px; height: 44px; border: 1px solid var(--rule); border-radius: 8px; background: transparent; display: grid; place-items: center; }
+.sheet-close:not(:disabled):hover { color: var(--signal); border-color: rgba(var(--signal-rgb),.52); background: rgba(var(--signal-rgb),.06); }
 .sheet-close svg { width: 17px; height: 17px; fill: none; stroke: currentColor; stroke-width: 1.5; }
 .link-readout { display: flex; gap: 14px; align-items: center; padding: 15px; border: 1px solid var(--rule); border-radius: 8px; background: rgba(255,255,255,.025); }
 .link-readout > div { display: flex; flex-direction: column; gap: 5px; }
 .link-readout strong { font: 600 10px/1 var(--mono); letter-spacing: .18em; color: var(--signal); }
-.link-readout span { font: 400 10px/1.3 var(--mono); color: var(--ink-3); }
+.link-readout span { font: 400 12px/1.4 var(--mono); color: var(--ink-2); }
 .link-readout[data-health="offline"] strong, .link-readout[data-health="offline"] .signal-bars { color: var(--danger); }
 .session-facts { margin: 18px 0 0; }
 .session-facts div { display: grid; grid-template-columns: 105px 1fr; gap: 14px; padding: 11px 0; border-bottom: 1px solid var(--rule); }
-.session-facts dt { font: 500 8px/1.4 var(--mono); letter-spacing: .18em; color: var(--ink-3); }
+.session-facts dt { font: 600 10px/1.4 var(--mono); letter-spacing: .14em; color: var(--ink-2); }
 .session-facts dd { margin: 0; font-size: 12px; color: var(--ink-2); }
-.sheet-note { margin: 18px 0 0; font-size: 11px; line-height: 1.5; color: var(--ink-3); }
+.sheet-note, .sheet-intro { margin: 18px 0 0; font-size: 12px; line-height: 1.55; color: var(--ink-2); }
+.sheet-intro { margin: 0 54px 20px 0; max-width: 62ch; }
 .install-sheet ol { list-style: none; margin: 4px 0 18px; padding: 0; }
 .install-sheet li { display: flex; align-items: center; gap: 13px; min-height: 52px; border-bottom: 1px solid var(--rule); color: var(--ink-2); font-size: 12px; }
 .install-sheet li span { font: 500 10px/1 var(--mono); color: var(--signal); }
-.sheet-primary { width: 100%; min-height: 48px; border: 1px solid var(--signal); border-radius: 7px; background: rgba(var(--signal-rgb),.1); color: var(--signal); font: 600 9px/1 var(--mono); letter-spacing: .18em; }
+.sheet-primary { width: 100%; min-height: 48px; border: 1px solid var(--signal); border-radius: 7px; background: rgba(var(--signal-rgb),.1); color: var(--signal); font: 600 10px/1 var(--mono); letter-spacing: .15em; }
+.sheet-primary:not(:disabled):hover { background: rgba(var(--signal-rgb),.16); box-shadow: inset 0 0 0 1px rgba(var(--signal-rgb),.16); }
+.sheet-primary:disabled { opacity: .42; }
 
 /* Appearance chooser */
-.appearance-sheet { width: min(820px, 100%); max-height: min(88vh, 820px); overflow: auto; }
+.appearance-sheet { width: min(820px, 100%); }
+.appearance-section-heading { margin: 20px 0 9px; display: flex; align-items: baseline; justify-content: space-between; }
+.appearance-section-heading .eyebrow { color: var(--ink-2); }
+.appearance-section-heading > span { font: 600 10px/1 var(--mono); letter-spacing: .1em; color: var(--ink-2); text-transform: uppercase; }
 .mode-options { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
 .mode-option { min-width: 0; min-height: 82px; padding: 9px; display: grid; grid-template-columns: 104px minmax(0, 1fr); align-items: center; gap: 13px; text-align: left; border: 1px solid var(--rule); border-radius: 9px; background: rgba(255,255,255,.022); }
+.mode-option:not(:disabled):hover { border-color: var(--rule-strong); background: rgba(var(--ink-rgb),.045); transform: translateY(-1px); }
 .mode-option[data-selected="true"] { border-color: rgba(var(--signal-rgb),.68); background: rgba(var(--signal-rgb),.08); box-shadow: inset 3px 0 0 var(--signal); }
 .mode-option > span:last-child { min-width: 0; display: flex; flex-direction: column; gap: 6px; }
 .mode-option strong { font: 600 9px/1 var(--mono); letter-spacing: .12em; color: var(--ink); text-transform: uppercase; }
-.mode-option small { font-size: 10px; line-height: 1.25; color: var(--ink-3); }
+.mode-option small { font-size: 11px; line-height: 1.35; color: var(--ink-2); }
 .mode-preview { height: 60px; padding: 5px; display: grid; grid-template-columns: repeat(3, 1fr); grid-template-rows: repeat(3, 1fr); gap: 3px; border: 1px solid var(--rule); border-radius: 5px; background: var(--void); overflow: hidden; }
 .mode-preview i { display: block; border: 1px solid var(--rule-strong); border-radius: 2px; }
 .mode-preview[data-preview="console"] { grid-template-columns: 38% 1fr; }
@@ -430,30 +439,49 @@ button:disabled { cursor: not-allowed; }
 .mode-preview[data-preview="pfd"] i:nth-child(2) { border-color: var(--signal); }
 .mode-preview[data-preview="micro"] { background: #dfe5e3; border-color: #fff; }
 .mode-preview[data-preview="micro"] i { border-color: rgba(24,45,41,.2); background: linear-gradient(#fff,#d6dedb); box-shadow: 0 2px 2px rgba(22,38,35,.15); }
-.finish-label { margin-top: 20px; display: flex; align-items: baseline; justify-content: space-between; }
-.finish-label span { font: 500 8px/1 var(--mono); letter-spacing: .1em; color: var(--ink-3); text-transform: uppercase; }
 .finish-options { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-top: 9px; }
-.finish-options button { min-height: 44px; padding: 0 14px; display: flex; align-items: center; justify-content: center; gap: 9px; border: 1px solid var(--rule); border-radius: 7px; background: rgba(255,255,255,.022); font: 600 8px/1 var(--mono); letter-spacing: .13em; text-transform: uppercase; }
+.finish-options button { min-height: 64px; padding: 8px 10px; display: grid; grid-template-columns: 72px minmax(0,1fr); align-items: center; gap: 10px; text-align: left; border: 1px solid var(--rule); border-radius: 8px; background: rgba(255,255,255,.022); font: 600 10px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; }
+.finish-options button:not(:disabled):hover { border-color: var(--rule-strong); background: rgba(var(--ink-rgb),.045); transform: translateY(-1px); }
 .finish-options button[data-selected="true"] { color: var(--signal); border-color: rgba(var(--signal-rgb),.62); background: rgba(var(--signal-rgb),.07); }
-.finish-options i { width: 13px; height: 13px; border-radius: 50%; box-shadow: 0 0 0 1px rgba(255,255,255,.18); display: grid; place-items: center; font: 600 10px/1 var(--mono); font-style: normal; }
-.finish-options .finish-new { border-style: dashed; color: var(--ink-3); }
-.finish-options .finish-new i { border-radius: 0; box-shadow: none; color: var(--signal); }
+.theme-preview { height: 44px; padding: 4px; display: grid; grid-template-columns: 40% 1fr; gap: 4px; overflow: hidden; border: 1px solid rgba(255,255,255,.12); border-radius: 5px; background: #071013; }
+.theme-preview[data-preview-scheme="light"] { border-color: rgba(20,45,40,.18); background: #e5ebe8; }
+.theme-preview > i { min-width: 0; padding: 3px; display: grid; gap: 2px; border: 1px solid color-mix(in srgb, var(--preview-accent), transparent 54%); border-radius: 3px; background: color-mix(in srgb, var(--preview-accent), transparent 91%); box-shadow: none; }
+.theme-preview > i:first-child { grid-template-columns: repeat(2,1fr); }
+.theme-preview > i:last-child { grid-template-rows: repeat(2,1fr); }
+.theme-preview b { display: block; min-width: 0; min-height: 0; border-radius: 1px; background: color-mix(in srgb, var(--preview-accent), transparent 68%); }
+.theme-preview > i:first-child b:last-child { grid-column: 1 / -1; background: var(--preview-accent); }
+.finish-options .finish-new { border-style: dashed; color: var(--ink-2); }
+.finish-options .finish-new > i { width: 44px; height: 44px; display: grid; place-items: center; border: 1px solid var(--rule); border-radius: 5px; color: var(--signal); font: 400 24px/1 var(--display); font-style: normal; }
+.finish-options .finish-new > span { display: flex; flex-direction: column; gap: 5px; }
+.finish-options .finish-new small { color: var(--ink-2); font: 500 10px/1 var(--mono); letter-spacing: .06em; text-transform: none; }
 .finish-options .finish-new:not(:disabled):hover { color: var(--signal); border-color: rgba(var(--signal-rgb),.5); }
 
 .theme-edit-row { margin-top: 9px; padding: 9px 11px; display: flex; align-items: center; gap: 9px; border: 1px solid var(--rule); border-radius: 7px; background: rgba(255,255,255,.02); }
-.theme-edit-row > span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 7.5px/1 var(--mono); letter-spacing: .12em; color: var(--ink-3); }
-.theme-edit-row button { min-height: 30px; padding: 0 11px; border: 1px solid var(--rule); border-radius: 6px; background: transparent; font: 600 7px/1 var(--mono); letter-spacing: .12em; color: var(--ink-2); }
+.theme-edit-row > span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 10px/1 var(--mono); letter-spacing: .1em; color: var(--ink-2); }
+.theme-edit-row button { min-height: 36px; padding: 0 11px; border: 1px solid var(--rule); border-radius: 6px; background: transparent; font: 600 9px/1 var(--mono); letter-spacing: .1em; color: var(--ink-2); }
 .theme-edit-row button:hover { color: var(--signal); border-color: rgba(var(--signal-rgb),.5); }
 .theme-edit-row .theme-delete[data-armed="true"] { color: var(--danger); border-color: var(--danger); background: rgba(255,102,92,.08); }
 
-.theme-editor .sheet-note b { color: var(--ink-2); font-weight: 600; }
+.appearance-actions { position: sticky; bottom: -28px; margin: 22px -28px -28px; padding: 14px 28px; display: grid; grid-template-columns: minmax(0,1fr) auto minmax(180px,auto); align-items: center; gap: 8px; border-top: 1px solid var(--rule); background: color-mix(in srgb, var(--plate) 94%, transparent); backdrop-filter: blur(16px); }
+.appearance-actions p { margin: 0; font: 500 11px/1.3 var(--mono); color: var(--ink-2); }
+.appearance-actions .sheet-primary { min-width: 180px; }
+.theme-contract-details { margin-top: 14px; border: 1px solid var(--rule); border-radius: 8px; color: var(--ink-2); font-size: 12px; }
+.theme-contract-details summary { min-height: 42px; padding: 0 13px; display: flex; align-items: center; cursor: pointer; font-weight: 600; }
+.theme-contract-details p { margin: 0; padding: 0 13px 13px; line-height: 1.5; }
 .theme-manifest { width: 100%; min-height: 260px; margin-top: 14px; padding: 13px; resize: vertical; border: 1px solid var(--rule-strong); border-radius: 9px; background: rgba(3,9,10,.55); color: var(--ink); font: 400 11px/1.55 var(--mono); tab-size: 2; }
 .theme-manifest:focus { outline: 2px solid var(--signal); outline-offset: 1px; }
 .pad[data-scheme="light"] .theme-manifest { background: rgba(255,255,255,.75); }
-.theme-editor-errors { margin: 10px 0 0; padding: 10px 13px 10px 26px; border: 1px solid rgba(255,102,92,.5); border-radius: 8px; background: rgba(255,102,92,.07); color: var(--danger); font: 500 10px/1.6 var(--mono); }
+.theme-editor-errors { margin: 10px 0 0; padding: 10px 13px 10px 26px; border: 1px solid rgba(255,102,92,.5); border-radius: 8px; background: rgba(255,102,92,.07); color: var(--danger); font: 500 11px/1.6 var(--mono); }
 .theme-editor-actions { margin-top: 13px; display: grid; grid-template-columns: 1fr auto auto; gap: 8px; }
-.sheet-secondary { min-height: 48px; padding: 0 16px; border: 1px solid var(--rule); border-radius: 7px; background: transparent; color: var(--ink-2); font: 600 9px/1 var(--mono); letter-spacing: .18em; }
-.sheet-secondary:hover { color: var(--signal); border-color: rgba(var(--signal-rgb),.5); }
+.theme-editor-warning { margin-top: 10px; padding: 10px; display: grid; grid-template-columns: minmax(0,1fr) auto auto; align-items: center; gap: 8px; border: 1px solid rgba(255,102,92,.45); border-radius: 8px; background: rgba(255,102,92,.07); }
+.theme-editor-warning > span { font-size: 12px; color: var(--ink-2); }
+.theme-editor-warning .sheet-secondary { min-height: 38px; }
+.sheet-secondary { min-height: 48px; padding: 0 16px; border: 1px solid var(--rule); border-radius: 7px; background: transparent; color: var(--ink-2); font: 600 10px/1 var(--mono); letter-spacing: .14em; }
+.sheet-secondary:not(:disabled):hover { color: var(--signal); border-color: rgba(var(--signal-rgb),.5); background: rgba(var(--signal-rgb),.05); }
+.danger-action:not(:disabled) { color: var(--danger); }
+.danger-action[data-armed="true"] { border-color: var(--danger); background: rgba(255,102,92,.08); }
+.link-actions { margin-top: 18px; display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 8px; }
+.link-action-warning { margin: 10px 0 0; padding: 10px 12px; border: 1px solid rgba(255,102,92,.4); border-radius: 7px; background: rgba(255,102,92,.07); color: var(--ink-2); font-size: 12px; line-height: 1.45; }
 
 /* Six complete Studio operating layouts. */
 .studio-surface { flex: 1; min-height: 0; position: relative; z-index: 1; border-left: 1px solid var(--rule); border-right: 1px solid var(--rule); overflow: hidden; }
@@ -597,37 +625,37 @@ button:disabled { cursor: not-allowed; }
 .pfd-commands .rail-button { min-height: 0; border-right: 0; border-bottom: 1px solid var(--rule); flex-direction: column; font-size: 5px; }
 
 /* Micro Deck */
-.micro-surface { padding: 12px; display: grid; grid-template-columns: minmax(480px, .95fr) minmax(320px, 1.05fr); gap: 14px; background: linear-gradient(145deg,#dfe4e7,#bcc4c8); color: #172127; --signal: #0b6f63; --signal-rgb: 11,111,99; --ink: #172127; --ink-2: #526168; --ink-3: #718086; --rule: rgba(26,48,57,.14); --rule-strong: rgba(26,48,57,.27); }
-.micro-housing { min-height: 0; padding: 15px; position: relative; display: grid; grid-template-rows: 66px minmax(0,1fr) 61px 46px; gap: 7px; border: 1px solid rgba(31,53,61,.22); border-radius: 20px; background: linear-gradient(140deg,rgba(255,255,255,.88),rgba(234,240,241,.68)); box-shadow: inset 0 0 0 6px rgba(255,255,255,.4), inset 0 0 24px rgba(255,255,255,.8), 0 12px 30px rgba(39,57,64,.2); }
+.micro-surface { padding: 12px; display: grid; grid-template-columns: minmax(480px, .95fr) minmax(320px, 1.05fr); gap: 14px; background: linear-gradient(145deg,var(--plate-2),var(--page)); color: var(--ink); }
+.micro-housing { min-height: 0; padding: 15px; position: relative; display: grid; grid-template-rows: 66px minmax(0,1fr) 61px 46px; gap: 7px; border: 1px solid var(--rule-strong); border-radius: 20px; background: linear-gradient(140deg,rgba(var(--ink-rgb),.09),transparent 45%),var(--plate); box-shadow: inset 0 0 0 6px rgba(var(--ink-rgb),.035), inset 0 0 24px rgba(var(--ink-rgb),.045), 0 12px 30px rgba(0,0,0,.2); }
 .micro-screw { width: 9px; height: 9px; position: absolute; z-index: 2; border-radius: 50%; background: radial-gradient(circle at 35% 30%,#d9e2e4 0 10%,#56666b 20% 52%,#18252a 55%); box-shadow: 0 1px 2px rgba(0,0,0,.35); }
 .ms-nw { left: 11px; top: 11px; }.ms-ne { right: 11px; top: 11px; }.ms-sw { left: 11px; bottom: 11px; }.ms-se { right: 11px; bottom: 11px; }
 .micro-controls { padding: 4px 3px; display: grid; grid-template-columns: 58px minmax(0,1fr) 58px; align-items: center; gap: 13px; }
 .micro-encoder { width: 54px; height: 54px; border-radius: 50%; background: conic-gradient(from 30deg,#e7edef,#bec8cc,#f7fafb,#c2cbce,#e7edef); box-shadow: inset 0 0 0 1px rgba(28,49,56,.18), 0 3px 7px rgba(43,59,65,.25); }
 .micro-touch { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 5px 10px; }
 .micro-touch span,.micro-touch small { font: 600 6px/1 var(--mono); letter-spacing: .17em; color: var(--ink-3); }
-.micro-touch i { grid-column: 1 / -1; height: 18px; padding: 3px; border: 1px solid rgba(36,59,67,.2); border-radius: 999px; background: rgba(215,224,226,.8); box-shadow: inset 0 1px 3px rgba(36,54,60,.15); }
+.micro-touch i { grid-column: 1 / -1; height: 18px; padding: 3px; border: 1px solid var(--rule-strong); border-radius: 999px; background: var(--plate-2); box-shadow: inset 0 1px 3px rgba(0,0,0,.15); }
 .micro-touch b { display: block; height: 100%; border-radius: inherit; background: var(--signal); box-shadow: 0 0 8px rgba(var(--signal-rgb),.25); }
 .micro-knob { width: 56px; height: 56px; border-radius: 50%; background: repeating-conic-gradient(#29363c 0 3deg,#111a1e 3deg 6deg); box-shadow: inset 0 0 0 9px #1c282e,0 4px 8px rgba(18,31,37,.35); }
 .micro-grid { min-height: 0; display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); grid-template-rows: repeat(3,minmax(0,1fr)); gap: 7px; }
-.micro-key { min-width: 0; min-height: 0; padding: 10px 11px; position: relative; display: flex; flex-direction: column; align-items: flex-start; justify-content: space-between; border: 1px solid rgba(30,54,61,.2); border-radius: 11px; background: linear-gradient(150deg,#fff,#e4eaec); box-shadow: inset 0 1px #fff,inset 0 -2px 2px rgba(50,68,74,.13),0 3px 5px rgba(44,61,67,.18); }
+.micro-key { min-width: 0; min-height: 0; padding: 10px 11px; position: relative; display: flex; flex-direction: column; align-items: flex-start; justify-content: space-between; border: 1px solid var(--rule-strong); border-radius: 11px; background: linear-gradient(150deg,rgba(var(--ink-rgb),.08),transparent),var(--plate-2); box-shadow: inset 0 1px rgba(var(--ink-rgb),.12),inset 0 -2px 2px rgba(0,0,0,.13),0 3px 5px rgba(0,0,0,.18); }
 .micro-key > span { font: 500 21px/1 var(--display); }
 .micro-key > small { max-width: 100%; overflow: hidden; text-overflow: ellipsis; font: 600 6px/1 var(--mono); letter-spacing: .1em; color: var(--ink-3); text-transform: uppercase; }
-.micro-key > i { width: 6px; height: 6px; position: absolute; right: 10px; top: 10px; border-radius: 50%; background: #b2bdc1; }
-.micro-key[data-active="true"] { border-color: rgba(var(--signal-rgb),.65); background: linear-gradient(150deg,#fff,rgba(var(--signal-rgb),.12)); box-shadow: inset 0 1px #fff,0 0 13px rgba(var(--signal-rgb),.25),0 4px 6px rgba(44,61,67,.18); }
+.micro-key > i { width: 6px; height: 6px; position: absolute; right: 10px; top: 10px; border-radius: 50%; background: var(--ink-3); }
+.micro-key[data-active="true"] { border-color: rgba(var(--signal-rgb),.65); background: linear-gradient(150deg,rgba(var(--ink-rgb),.1),rgba(var(--signal-rgb),.12)),var(--plate-2); box-shadow: inset 0 1px rgba(var(--ink-rgb),.12),0 0 13px rgba(var(--signal-rgb),.25),0 4px 6px rgba(0,0,0,.18); }
 .micro-key[data-active="true"] > i { display: none; }
 .micro-key[data-empty="true"] { opacity: .42; }
 .micro-primary { display: grid; grid-template-columns: 58px minmax(0,1fr) 76px; gap: 8px; }
 .micro-joystick { width: 38px; height: 38px; place-self: center; border-radius: 50%; background: radial-gradient(circle at 36% 31%,#45555b,#10191d 64%); box-shadow: inset 0 0 5px #000,0 4px 7px rgba(27,43,49,.32); }
-.micro-ptt { width: 100%; min-height: 58px; grid-template-columns: 34px 1fr; padding: 6px 12px; border-color: rgba(4,69,62,.9); background: linear-gradient(180deg,#137b6f,#07574f); box-shadow: inset 0 1px rgba(255,255,255,.24),inset 0 -3px 5px rgba(0,0,0,.22),0 5px 10px rgba(28,69,63,.28); }
-.micro-ptt .ptt-icon { width: 31px; height: 31px; background: rgba(255,255,255,.12); color: #fff; }
-.micro-ptt .ptt-copy strong { color: #fff; font-size: 14px; }
-.micro-ptt .ptt-copy small { color: rgba(255,255,255,.78); }
+.micro-ptt { width: 100%; min-height: 58px; grid-template-columns: 34px 1fr; padding: 6px 12px; border-color: var(--signal); background: linear-gradient(180deg,color-mix(in srgb,var(--signal),white 12%),color-mix(in srgb,var(--signal),black 20%)); box-shadow: inset 0 1px rgba(255,255,255,.24),inset 0 -3px 5px rgba(0,0,0,.22),0 5px 10px rgba(var(--signal-rgb),.2); }
+.micro-ptt .ptt-icon { width: 31px; height: 31px; background: rgba(0,0,0,.11); color: var(--page); }
+.micro-ptt .ptt-copy strong { color: var(--page); font-size: 14px; }
+.micro-ptt .ptt-copy small { color: color-mix(in srgb,var(--page),transparent 24%); }
 .micro-ptt .ptt-key { display: none; }
 .micro-aux { display: grid; grid-template-rows: 1fr 1fr; gap: 6px; }
-.micro-aux .rail-button { min-height: 0; border: 1px solid rgba(30,54,61,.18); border-radius: 8px; background: linear-gradient(#fff,#e3e9eb); font-size: 0; }
+.micro-aux .rail-button { min-height: 0; border: 1px solid var(--rule-strong); border-radius: 8px; background: linear-gradient(rgba(var(--ink-rgb),.08),transparent),var(--plate-2); font-size: 0; }
 .micro-aux .rail-icon svg { width: 16px; height: 16px; }
 .micro-commands { min-height: 0; border: 0; gap: 7px; }
-.micro-commands .rail-button { min-height: 0; border: 1px solid rgba(30,54,61,.18); border-radius: 8px; background: linear-gradient(#fff,#e3e9eb); box-shadow: 0 2px 4px rgba(43,58,64,.16); font-size: 6px; }
+.micro-commands .rail-button { min-height: 0; border: 1px solid var(--rule-strong); border-radius: 8px; background: linear-gradient(rgba(var(--ink-rgb),.08),transparent),var(--plate-2); box-shadow: 0 2px 4px rgba(0,0,0,.16); font-size: 6px; }
 .micro-readout { min-width: 0; min-height: 0; display: grid; grid-template-rows: auto auto auto auto minmax(210px,1fr) auto; gap: 7px; }
 .micro-readout > header { min-height: 59px; display: flex; justify-content: space-between; align-items: center; gap: 14px; }
 .micro-lane-lock { min-width: 0; display: flex; align-items: center; gap: 13px; }
@@ -638,13 +666,13 @@ button:disabled { cursor: not-allowed; }
 .micro-link-state strong { max-width: 230px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 8px/1 var(--mono); letter-spacing: .08em; color: var(--ink); }
 .micro-link-state small { max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 500 7px/1 var(--mono); color: var(--ink-3); }
 .micro-link-state[data-health="offline"] strong { color: var(--danger); }
-.micro-task,.micro-audio,.micro-confirmation { padding: 11px 13px; border: 1px solid rgba(31,54,62,.14); border-radius: 10px; background: rgba(255,255,255,.65); box-shadow: 0 3px 8px rgba(44,61,67,.07); }
+.micro-task,.micro-audio,.micro-confirmation { padding: 11px 13px; border: 1px solid var(--rule); border-radius: 10px; background: color-mix(in srgb,var(--plate) 91%,var(--ink) 9%); box-shadow: 0 3px 8px rgba(0,0,0,.08); }
 .micro-task { display: grid; gap: 6px; }
 .micro-task-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .micro-task-head p { margin: 0; }
 .micro-task-head > span { font: 600 7px/1 var(--mono); letter-spacing: .14em; color: var(--ink-3); }
 .micro-task > strong { overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; font: 600 14px/1.15 var(--display); letter-spacing: -.02em; }
-.micro-audio { min-height: 0; display: grid; grid-template-rows: repeat(6, auto); align-content: start; gap: 7px; background: linear-gradient(135deg,rgba(255,255,255,.76),rgba(246,249,248,.48)); }
+.micro-audio { min-height: 0; display: grid; grid-template-rows: repeat(6, auto); align-content: start; gap: 7px; background: linear-gradient(135deg,rgba(var(--ink-rgb),.09),transparent),var(--plate); }
 .micro-audio-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .micro-audio-head p { margin: 0; }
 .micro-audio-head > span { font: 600 7px/1 var(--mono); letter-spacing: .16em; color: var(--ink-2); }
@@ -656,8 +684,8 @@ button:disabled { cursor: not-allowed; }
 .micro-audio-input p { margin: 0; font: 600 6px/1 var(--mono); letter-spacing: .16em; color: var(--ink-3); }
 .micro-audio-input strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 11px/1.15 var(--display); color: var(--ink); }
 .micro-audio-input > span { flex: 0 0 auto; font: 500 6px/1 var(--mono); letter-spacing: .12em; color: var(--ink-3); }
-.micro-audio-params { min-height: 38px; margin: 0; display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); border: 1px solid rgba(31,54,62,.11); border-radius: 7px; overflow: hidden; background: rgba(255,255,255,.4); }
-.micro-audio-params > div { min-width: 0; padding: 6px 9px; display: flex; flex-direction: column; justify-content: center; gap: 4px; border-right: 1px solid rgba(31,54,62,.11); }
+.micro-audio-params { min-height: 38px; margin: 0; display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); border: 1px solid var(--rule); border-radius: 7px; overflow: hidden; background: rgba(var(--ink-rgb),.035); }
+.micro-audio-params > div { min-width: 0; padding: 6px 9px; display: flex; flex-direction: column; justify-content: center; gap: 4px; border-right: 1px solid var(--rule); }
 .micro-audio-params > div:last-child { border-right: 0; }
 .micro-audio-params dt { font: 600 6px/1 var(--mono); letter-spacing: .14em; color: var(--ink-3); }
 .micro-audio-params dd { margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 9px/1 var(--mono); letter-spacing: .04em; color: var(--ink); }
@@ -665,51 +693,51 @@ button:disabled { cursor: not-allowed; }
 .micro-audio-title-row,.micro-audio-times { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 .micro-audio-title-row { justify-content: flex-start; gap: 8px; }
 .micro-audio-title-row span { margin-left: auto; }
-.micro-tape-toggle { width: 21px; height: 21px; flex: 0 0 auto; background: linear-gradient(180deg, #fff, rgba(190,200,196,.4)); }
+.micro-tape-toggle { width: 21px; height: 21px; flex: 0 0 auto; background: linear-gradient(180deg,rgba(var(--ink-rgb),.1),transparent),var(--plate-2); }
 .micro-tape-toggle svg { width: 8px; height: 8px; }
 .micro-audio-title-row b { flex: 0 0 auto; font: 600 6px/1 var(--mono); letter-spacing: .15em; color: var(--ink-3); }
 .micro-audio-title-row span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 500 8px/1 var(--mono); color: var(--ink-2); }
-.micro-audio-bar { height: 5px; overflow: hidden; border-radius: 999px; background: rgba(31,54,62,.1); }
+.micro-audio-bar { height: 5px; overflow: hidden; border-radius: 999px; background: var(--rule); }
 .micro-audio-bar > i { display: block; height: 100%; border-radius: inherit; background: var(--ink-2); transition: width .3s linear; }
 .micro-audio[data-tone="live"] .micro-audio-bar > i,.micro-audio[data-tone="speak"] .micro-audio-bar > i { background: var(--signal); }
 .micro-audio-times { font: 500 6px/1 var(--mono); color: var(--ink-3); }
 .micro-output-meter { min-width: 0; display: grid; grid-template-columns: auto minmax(60px,1fr) 28px; align-items: center; gap: 9px; }
 .micro-output-meter > span,.micro-output-meter > strong { font: 600 6px/1 var(--mono); letter-spacing: .12em; color: var(--ink-3); }
 .micro-output-meter > strong { text-align: right; }
-.micro-output-meter > i { height: 3px; overflow: hidden; background: rgba(31,54,62,.11); }
+.micro-output-meter > i { height: 3px; overflow: hidden; background: var(--rule); }
 .micro-output-meter > i > b { display: block; height: 100%; background: var(--ink-2); }
 .micro-audio[data-tone="speak"] .micro-output-meter > i > b { background: var(--signal); }
 .micro-audio-volume { min-width: 0; display: grid; grid-template-columns: auto minmax(80px, 1fr) 30px; align-items: center; gap: 9px; }
 .micro-audio-volume > span, .micro-audio-volume > strong { font: 600 6px/1 var(--mono); letter-spacing: .12em; color: var(--ink-3); }
 .micro-audio-volume > strong { text-align: right; font-variant-numeric: tabular-nums; }
 .micro-audio-volume input[type="range"] { -webkit-appearance: none; appearance: none; width: 100%; height: 12px; margin: 0; background: transparent; cursor: pointer; }
-.micro-audio-volume input[type="range"]::-webkit-slider-runnable-track { height: 3px; border-radius: 999px; background: linear-gradient(90deg, var(--signal) var(--fill, 80%), rgba(31,54,62,.14) var(--fill, 80%)); }
-.micro-audio-volume input[type="range"]::-webkit-slider-thumb { -webkit-appearance: none; width: 12px; height: 12px; margin-top: -4.5px; border: 1px solid rgba(31,54,62,.34); border-radius: 50%; background: linear-gradient(150deg, #fff, #dde4e6); box-shadow: 0 1px 3px rgba(31,54,62,.32); }
+.micro-audio-volume input[type="range"]::-webkit-slider-runnable-track { height: 3px; border-radius: 999px; background: linear-gradient(90deg, var(--signal) var(--fill, 80%), var(--rule) var(--fill, 80%)); }
+.micro-audio-volume input[type="range"]::-webkit-slider-thumb { -webkit-appearance: none; width: 12px; height: 12px; margin-top: -4.5px; border: 1px solid var(--rule-strong); border-radius: 50%; background: var(--ink); box-shadow: 0 1px 3px rgba(0,0,0,.32); }
 .micro-audio-volume input[type="range"]:disabled { cursor: not-allowed; opacity: .45; }
-.micro-quality { min-height: 43px; margin: 0; display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); border: 1px solid rgba(31,54,62,.14); border-radius: 10px; background: rgba(255,255,255,.43); overflow: hidden; }
-.micro-quality > div { min-width: 0; padding: 7px 12px; display: flex; flex-direction: column; justify-content: center; gap: 4px; border-right: 1px solid rgba(31,54,62,.11); }
+.micro-quality { min-height: 43px; margin: 0; display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); border: 1px solid var(--rule); border-radius: 10px; background: rgba(var(--ink-rgb),.035); overflow: hidden; }
+.micro-quality > div { min-width: 0; padding: 7px 12px; display: flex; flex-direction: column; justify-content: center; gap: 4px; border-right: 1px solid var(--rule); }
 .micro-quality > div:last-child { border-right: 0; }
 .micro-quality dt { font: 600 6px/1 var(--mono); letter-spacing: .16em; color: var(--ink-3); }
 .micro-quality dd { margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 9px/1 var(--mono); letter-spacing: .06em; color: var(--ink); }
-.micro-activity { min-height: 0; overflow: hidden; display: flex; flex-direction: column; border: 1px solid rgba(7,34,34,.32); border-radius: 11px; background: linear-gradient(150deg,#122323,#0a1517 68%,#0d1b1d); box-shadow: inset 0 1px rgba(255,255,255,.05),0 5px 13px rgba(36,52,57,.13); color: #e7f0ed; }
-.micro-activity > header { min-height: 34px; padding: 6px 10px; display: flex; align-items: center; justify-content: space-between; gap: 10px; border-bottom: 1px solid rgba(205,231,224,.11); }
+.micro-activity { min-height: 0; overflow: hidden; display: flex; flex-direction: column; border: 1px solid var(--rule-strong); border-radius: 11px; background: linear-gradient(150deg,var(--plate-2),var(--void) 68%,var(--page)); box-shadow: inset 0 1px rgba(var(--ink-rgb),.05),0 5px 13px rgba(0,0,0,.13); color: var(--ink); }
+.micro-activity > header { min-height: 34px; padding: 6px 10px; display: flex; align-items: center; justify-content: space-between; gap: 10px; border-bottom: 1px solid var(--rule); }
 .micro-activity > header > div { display: flex; align-items: baseline; gap: 9px; }
-.micro-activity > header p { margin: 0; color: #8aa29d; }
-.micro-activity > header strong { font: 600 8px/1 var(--mono); letter-spacing: .15em; color: #a5b6b2; }
-.micro-activity > header > span { font: 500 7px/1 var(--mono); letter-spacing: .12em; color: #60746f; }
+.micro-activity > header p { margin: 0; color: var(--ink-2); }
+.micro-activity > header strong { font: 600 8px/1 var(--mono); letter-spacing: .15em; color: var(--ink-2); }
+.micro-activity > header > span { font: 500 7px/1 var(--mono); letter-spacing: .12em; color: var(--ink-3); }
 .micro-activity ol { min-height: 0; margin: 0; padding: 0; overflow: hidden; list-style: none; }
-.micro-activity li { min-height: 27px; padding: 3px 10px; display: grid; grid-template-columns: 49px 16px minmax(0,1fr); align-items: center; gap: 7px; border-bottom: 1px solid rgba(205,231,224,.07); }
+.micro-activity li { min-height: 27px; padding: 3px 10px; display: grid; grid-template-columns: 49px 16px minmax(0,1fr); align-items: center; gap: 7px; border-bottom: 1px solid var(--rule); }
 .micro-activity li:last-child { border-bottom: 0; }
-.micro-activity time { font: 500 7px/1 var(--mono); color: #5f7570; }
-.micro-activity li > b { font: 500 7px/1 var(--mono); color: #526862; }
+.micro-activity time { font: 500 7px/1 var(--mono); color: var(--ink-3); }
+.micro-activity li > b { font: 500 7px/1 var(--mono); color: var(--ink-3); }
 .micro-activity li > span { min-width: 0; display: flex; align-items: baseline; gap: 8px; }
-.micro-activity li strong { flex: 0 0 auto; font: 600 8px/1 var(--mono); letter-spacing: .08em; color: #dce9e5; }
-.micro-activity li small { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 500 8px/1 var(--mono); color: #829691; }
+.micro-activity li strong { flex: 0 0 auto; font: 600 8px/1 var(--mono); letter-spacing: .08em; color: var(--ink); }
+.micro-activity li small { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 500 8px/1 var(--mono); color: var(--ink-2); }
 .micro-activity li[data-tone="error"] > b,.micro-activity li[data-tone="error"] strong { color: #ff8b83; }
 .micro-confirmation { min-height: 48px; display: grid; grid-template-columns: minmax(165px,.55fr) minmax(0,1fr); align-items: center; gap: 14px; }
 .micro-confirmation > div { min-width: 0; display: flex; flex-direction: column; gap: 5px; }
 .micro-confirmation p { margin: 0; }
-.micro-confirmation strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 9px/1 var(--mono); letter-spacing: .08em; color: #163a35; }
+.micro-confirmation strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 9px/1 var(--mono); letter-spacing: .08em; color: var(--ink); }
 .micro-confirmation > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 500 8px/1.3 var(--mono); color: var(--ink-2); }
 .micro-confirmation[data-tone="ok"] { border-color: rgba(var(--signal-rgb),.32); box-shadow: inset 3px 0 var(--signal),0 4px 10px rgba(44,61,67,.08); }
 .micro-confirmation[data-tone="pending"] { border-color: rgba(168,102,12,.32); box-shadow: inset 3px 0 var(--warning),0 4px 10px rgba(44,61,67,.08); }
@@ -735,6 +763,11 @@ button:disabled { cursor: not-allowed; }
 @container pad (max-width: 620px) {
   .mode-options { grid-template-columns: 1fr; }
   .mode-option { grid-template-columns: 88px 1fr; }
+  .finish-options { grid-template-columns: 1fr; }
+  .appearance-actions { grid-template-columns: 1fr 1fr; }
+  .appearance-actions p { grid-column: 1 / -1; }
+  .appearance-actions .sheet-primary { min-width: 0; }
+  .theme-editor-actions, .theme-editor-warning, .link-actions { grid-template-columns: 1fr; }
   .cluster-surface { overflow-y: auto; grid-template-columns: 1fr; grid-template-rows: auto minmax(360px,1fr) auto; }
   .cluster-flank { padding: 5px; flex-direction: row; justify-content: space-between; }
   .cluster-flank > div:nth-child(n+3) { display: none; }

--- a/pad/src/transport.ts
+++ b/pad/src/transport.ts
@@ -14,6 +14,7 @@ export interface PadTransport {
   connect(): Promise<void>;
   disconnect(): void;
   resume?(): void;
+  forgetPairing?(): void;
   subscribe(listener: (event: TransportEvent) => void): () => void;
   send(command: PadCommand, baseRevision: number): Promise<CommandAck>;
 }
@@ -276,6 +277,14 @@ interface SessionAcceptedMessage {
 
 const LAN_SESSION_KEY = "speakeasy.pad.lan-session.v1";
 
+export function forgetStoredLANSession(storage: Pick<Storage, "removeItem"> = localStorage): void {
+  try {
+    storage.removeItem(LAN_SESSION_KEY);
+  } catch {
+    // Pairing cleanup should still allow the UI to return to its unpaired state.
+  }
+}
+
 export function makePadSocketURL(location: Pick<Location, "protocol" | "host">): string {
   const scheme = location.protocol === "https:" ? "wss:" : "ws:";
   return `${scheme}//${location.host}/pad`;
@@ -486,6 +495,12 @@ export class LANPadTransport implements PadTransport {
     this.#reconnectTimer = undefined;
     this.#socket?.close(1000, "Pad closed");
     this.#socket = undefined;
+  }
+
+  forgetPairing(): void {
+    this.disconnect();
+    this.#session = undefined;
+    forgetStoredLANSession();
   }
 
   send(command: PadCommand, baseRevision: number): Promise<CommandAck> {

--- a/pad/tests/transport.test.ts
+++ b/pad/tests/transport.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PadSnapshot } from "../src/model.ts";
-import { claimNextSequence, MockPadTransport, linkAllowsCommands, makeCommandEnvelope, makeLANBootstrapMessage, makePadSocketURL, makeRequestId, reconnectDecision, requestIdKey, socketCloseDetail } from "../src/transport.ts";
+import { claimNextSequence, forgetStoredLANSession, MockPadTransport, linkAllowsCommands, makeCommandEnvelope, makeLANBootstrapMessage, makePadSocketURL, makeRequestId, reconnectDecision, requestIdKey, socketCloseDetail } from "../src/transport.ts";
 
 describe("MockPadTransport", () => {
   test("acknowledges lane activation with a newer authoritative snapshot", async () => {
@@ -39,6 +39,14 @@ describe("linkAllowsCommands", () => {
     expect(linkAllowsCommands("suspect")).toBe(true);
     expect(linkAllowsCommands("degraded")).toBe(false);
     expect(linkAllowsCommands("offline")).toBe(false);
+  });
+});
+
+describe("pairing cleanup", () => {
+  test("removes only the resumable LAN session", () => {
+    const removed: string[] = [];
+    forgetStoredLANSession({ removeItem: (key) => removed.push(key) });
+    expect(removed).toEqual(["speakeasy.pad.lan-session.v1"]);
   });
 });
 


### PR DESCRIPTION
## What changed

- Rework the Appearance sheet around independent control-surface and theme selection.
- Add miniature theme previews, clearer dirty-state handling, and persistent Apply actions.
- Improve compact responsive behavior and theme-aware component styling.
- Add explicit pairing forget/reconnect controls without clearing unrelated browser state.
- Restore viewport zoom behavior instead of globally disabling it.

## Why

The Pad's layout and color system are separate choices, and the settings flow should make that relationship visible without hiding the primary action below the fold.

## User impact

Appearance changes are easier to preview and apply on iPad and iPhone, connection recovery is clearer, and compact layouts avoid awkward wrapping.

## Checks

- 41 Bun Pad tests passed across model, mode, push-to-talk, transport, bootstrap, and theme suites.

## Relationship

Independent from the native Deck stack and targets `master` directly.