### PR TITLE
Fix narration cutting off at ~40 seconds

### DIFF
--- a/app/Sources/SpeakEasy/CodexLunaCompletionPresenter.swift
+++ b/app/Sources/SpeakEasy/CodexLunaCompletionPresenter.swift
@@ -25,7 +25,11 @@ protocol CompletionPresenting: Sendable {
 }
 
 enum CompletionSpeechProjector {
-    private static let maximumCharacters = 900
+    /// The deterministic fallback reads the real response rather than a summary,
+    /// so clipping it is silent loss. The bound exists only because this text is
+    /// still rendered in a single provider request, and OpenAI's speech endpoint
+    /// accepts 4096 characters; keep margin under that until this path chunks.
+    private static let maximumCharacters = 3_500
 
     /// A model-independent safety net. It removes material that is actively
     /// hostile to speech, but never invents a summary of the canonical answer.

--- a/deck/index.html
+++ b/deck/index.html
@@ -792,11 +792,16 @@ function syncAudio(snap) {
   const msg = snap.threads[parts[0]] && snap.threads[parts[0]][parts[1]];
   if (!msg || !msg.audioUrl) return;
   const src = msg.audioUrl + (liveToken ? '?k=' + encodeURIComponent(liveToken) : '');
+  // A long reply is several ordered segments. snap.pos is the position in the
+  // whole narration, so the offset of the current segment has to come off it
+  // before it means anything to this element.
+  const segStart = snap.segStart || 0;
+  const inSegment = Math.max(0, (snap.pos || 0) - segStart);
   if (el.dataset.url !== src) {
     el.dataset.url = src;
     el.dataset.id = snap.playing;
     el.src = src;
-    el.currentTime = snap.pos || 0;
+    el.currentTime = inSegment;
   }
   el.playbackRate = SPEEDS[snap.speedIx] || 1;
   el.volume = typeof snap.vol === 'number' ? snap.vol : 0.8;
@@ -806,8 +811,8 @@ function syncAudio(snap) {
     el.play().catch(() => {});
   }
   // runtime corrections still win, but only on real drift — the device owns the clock
-  if (Math.abs((el.currentTime || 0) - (snap.pos || 0)) > 2.0) {
-    el.currentTime = snap.pos || 0;
+  if (Math.abs((el.currentTime || 0) - inSegment) > 2.0) {
+    el.currentTime = inSegment;
   }
 }
 

--- a/src/cli/deck-runtime-narration.test.ts
+++ b/src/cli/deck-runtime-narration.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { DeckRuntime, measureSegmentDurations, type DeckMessage } from './deck-runtime';
+
+/**
+ * Long replies are narrated as several ordered audio segments. The regression
+ * guarded here is the completion boundary: finishing one segment must hand off
+ * to the next, and only the last segment may end the narration.
+ */
+
+const created: DeckRuntime[] = [];
+
+function runtimeWithSegments(durations: number[]): {
+  runtime: DeckRuntime;
+  message: DeckMessage;
+  id: string;
+} {
+  const runtime = new DeckRuntime({ warmCatalog: false, warmCanonical: false });
+  created.push(runtime);
+  // Pretend a deck is connected so the transport stays device-owned and no
+  // afplay process is spawned during the test.
+  runtime.liveClients = () => 1;
+
+  const message: DeckMessage = {
+    role: 'agent',
+    text: 'a reply far longer than one provider request',
+    dur: durations.reduce((total, d) => total + d, 0),
+    segments: durations.map((_, i) => `/tmp/reply-${i}.mp3`),
+    segmentUrls: durations.map((_, i) => `/audio/reply-${i}.mp3`),
+    segmentDurs: [...durations],
+  };
+
+  const internals = runtime as unknown as {
+    threads: DeckMessage[][];
+    playing: string | null;
+    segIx: number;
+    focusSegment: (msg: DeckMessage, ix: number) => void;
+  };
+  internals.threads[0] = [message];
+  internals.playing = '0:0';
+  internals.segIx = 0;
+  internals.focusSegment(message, 0);
+
+  return { runtime, message, id: '0:0' };
+}
+
+afterEach(() => {
+  while (created.length) created.pop()?.destroy();
+});
+
+describe('segmented narration playback', () => {
+  test('a finished segment hands off to the next instead of ending narration', async () => {
+    const { runtime, message, id } = runtimeWithSegments([30, 30, 25]);
+
+    expect(runtime.snapshot().segCount).toBe(3);
+    expect(runtime.snapshot().segIx).toBe(0);
+    expect(message.audioUrl).toBe('/audio/reply-0.mp3');
+
+    await runtime.apply({ name: 'playback.ended', id });
+
+    // still narrating — this is exactly where a long reply used to stop
+    expect(runtime.snapshot().playing).toBe(id);
+    expect(runtime.snapshot().segIx).toBe(1);
+    expect(message.audioUrl).toBe('/audio/reply-1.mp3');
+  });
+
+  test('only the last segment completes the narration', async () => {
+    const { runtime, id } = runtimeWithSegments([30, 30, 25]);
+
+    await runtime.apply({ name: 'playback.ended', id });
+    await runtime.apply({ name: 'playback.ended', id });
+    expect(runtime.snapshot().playing).toBe(id);
+    expect(runtime.snapshot().segIx).toBe(2);
+
+    await runtime.apply({ name: 'playback.ended', id });
+    expect(runtime.snapshot().playing).toBeNull();
+    expect(runtime.snapshot().segIx).toBe(0);
+  });
+
+  test('segments are handed over in order', async () => {
+    const { runtime, message, id } = runtimeWithSegments([10, 10, 10, 10]);
+    const seen: (string | undefined)[] = [message.audioUrl];
+
+    for (let i = 0; i < 3; i++) {
+      await runtime.apply({ name: 'playback.ended', id });
+      seen.push(message.audioUrl);
+    }
+
+    expect(seen).toEqual([
+      '/audio/reply-0.mp3',
+      '/audio/reply-1.mp3',
+      '/audio/reply-2.mp3',
+      '/audio/reply-3.mp3',
+    ]);
+  });
+
+  test('narration position accumulates across segments', async () => {
+    const { runtime, id } = runtimeWithSegments([30, 30, 25]);
+
+    await runtime.apply({ name: 'playback.ended', id });
+    expect(runtime.snapshot().segStart).toBe(30);
+
+    // the device reports a position inside the segment it is playing
+    await runtime.apply({ name: 'playback.progress', id, pos: 12 });
+    expect(runtime.snapshot().pos).toBe(42);
+
+    await runtime.apply({ name: 'playback.ended', id });
+    expect(runtime.snapshot().segStart).toBe(60);
+    await runtime.apply({ name: 'playback.progress', id, pos: 5 });
+    expect(runtime.snapshot().pos).toBe(65);
+  });
+
+  test('a whole narration outlasts the forty seconds it used to stop at', async () => {
+    const { runtime, id } = runtimeWithSegments([30, 30, 25]);
+
+    let elapsed = 0;
+    for (let i = 0; i < 3; i++) {
+      const before = runtime.snapshot();
+      elapsed = before.segStart;
+      await runtime.apply({ name: 'playback.ended', id });
+    }
+
+    // the last segment began well past the old ceiling
+    expect(elapsed).toBeGreaterThan(40);
+    expect(runtime.snapshot().playing).toBeNull();
+  });
+
+  test('a single-segment reply still ends on its first completion', async () => {
+    const { runtime, id } = runtimeWithSegments([12]);
+
+    await runtime.apply({ name: 'playback.ended', id });
+
+    expect(runtime.snapshot().playing).toBeNull();
+    expect(runtime.snapshot().segCount).toBe(0);
+  });
+
+  test('stopping cancels the whole narration, not just the current segment', async () => {
+    const { runtime, id } = runtimeWithSegments([30, 30, 25]);
+
+    await runtime.apply({ name: 'playback.ended', id });
+    expect(runtime.snapshot().segIx).toBe(1);
+
+    await runtime.apply({ name: 'playback.stop' });
+
+    expect(runtime.snapshot().playing).toBeNull();
+    expect(runtime.snapshot().segIx).toBe(0);
+    expect(runtime.snapshot().pos).toBe(0);
+  });
+
+  test('progress for a message that is not playing is rejected', async () => {
+    const { runtime } = runtimeWithSegments([30, 30]);
+
+    const result = await runtime.apply({ name: 'playback.progress', id: '0:9', pos: 4 });
+
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('measureSegmentDurations', () => {
+  test('falls back to an even estimate when a file cannot be read', () => {
+    const durations = measureSegmentDurations(
+      ['/tmp/does-not-exist-0.mp3', '/tmp/does-not-exist-1.mp3'],
+      'some narration text that is long enough to estimate a duration from '.repeat(10)
+    );
+
+    expect(durations).toHaveLength(2);
+    for (const d of durations) expect(d).toBeGreaterThan(0);
+  });
+
+  test('returns nothing for no segments', () => {
+    expect(measureSegmentDurations([], 'text')).toEqual([]);
+  });
+});

--- a/src/cli/deck-runtime.ts
+++ b/src/cli/deck-runtime.ts
@@ -51,10 +51,16 @@ export interface DeckMessage {
   dur: number;
   /** true while this is only a progress mirror — no controllable audio behind it */
   mirrored?: boolean;
-  /** synthesized audio owned by the runtime — real transport control when present */
+  /** the segment currently being spoken — real transport control when present */
   file?: string;
-  /** where a connected deck can fetch the audio to play it on the device */
+  /** where a connected deck can fetch the current segment to play it on the device */
   audioUrl?: string;
+  /** every narration segment, in speaking order. Long replies span several files. */
+  segments?: string[];
+  /** the deck-facing URL of each segment, index-aligned with `segments` */
+  segmentUrls?: string[];
+  /** estimated seconds per segment, index-aligned with `segments` */
+  segmentDurs?: number[];
 }
 
 export interface DeckTraceEntry {
@@ -103,7 +109,14 @@ export interface DeckSnapshot {
   threads: DeckMessage[][];
   playing: string | null;
   paused: boolean;
+  /** elapsed seconds across the whole narration, not just the current segment */
   pos: number;
+  /** which narration segment is playing — long replies span several files */
+  segIx: number;
+  /** seconds of narration before the current segment begins */
+  segStart: number;
+  /** total number of segments in the narration in flight */
+  segCount: number;
   speedIx: number;
   vol: number;
   autoplay: boolean;
@@ -343,6 +356,33 @@ export function estimateDuration(text: string, rate = 1): number {
   return Math.max(1.5, words / (2.5 * rate));
 }
 
+/** Exact duration of a rendered audio file, or null when it cannot be read. */
+export function audioDurationOf(file: string): number | null {
+  try {
+    const info = execFileSync('afinfo', [file], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const match = info.match(/estimated duration:\s*([\d.]+)\s*sec/i);
+    const seconds = match ? Number.parseFloat(match[1]) : Number.NaN;
+    return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-segment durations for a multi-part narration. The rendered audio is the
+ * authority; the word-rate estimate is only a fallback so the transport still
+ * has a usable clock when `afinfo` cannot read a file.
+ */
+export function measureSegmentDurations(files: string[], text: string): number[] {
+  if (files.length === 0) return [];
+  const fallback = Math.max(1.5, estimateDuration(text) / files.length);
+  return files.map((file) => audioDurationOf(file) ?? fallback);
+}
+
 
 export function parseIntent(raw: unknown): { intent?: DeckIntent; error?: string } {
   const parsed = intentSchema.safeParse(raw);
@@ -390,6 +430,8 @@ export class DeckRuntime extends EventEmitter {
   private playing: string | null = null;
   private paused = false;
   private pos = 0;
+  /** Index of the narration segment currently being spoken for `playing`. */
+  private segIx = 0;
   private speedIx = 0;
   private vol = 0.8;
   private autoplay = true;
@@ -532,6 +574,11 @@ export class DeckRuntime extends EventEmitter {
       playing: this.playing,
       paused: this.paused,
       pos: this.pos,
+      // Narration segment the device should be playing, and where it starts in
+      // the whole-message timeline, so the deck can seek inside the right file.
+      segIx: this.segIx,
+      segStart: this.segmentStart(),
+      segCount: this.segmentCount(),
       speedIx: this.speedIx,
       vol: this.vol,
       autoplay: this.autoplay,
@@ -781,6 +828,7 @@ export class DeckRuntime extends EventEmitter {
     this.playing = null;
     this.paused = false;
     this.pos = 0;
+    this.segIx = 0;
     if (confirm) this.setPhase(this.phase === 'speaking' ? 'idle' : this.phase, confirm);
   }
 
@@ -850,10 +898,9 @@ export class DeckRuntime extends EventEmitter {
           this.stopPlayer();
           this.playing = intent.id;
           this.paused = false;
-          this.pos = 0;
           this.setPhase('speaking', 'PLAYING');
           this.log('PLAYBACK STARTED', `${SPEEDS[this.speedIx].toFixed(2)}x`);
-          if (msg.file) this.playFile(msg.file);
+          this.startSegments(msg);
         }
         this.ensureTicker();
         this.changed();
@@ -898,11 +945,10 @@ export class DeckRuntime extends EventEmitter {
             this.stopPlayer();
             this.playing = `${this.laneIx}:${i}`;
             this.paused = false;
-            this.pos = 0;
             this.setPhase('speaking', 'REPLAYING LAST REPLY');
             this.ensureTicker();
             this.log('REPLAY', `lane ${this.laneIx + 1} · last reply`);
-            this.playFile(t[i].file!);
+            this.startSegments(t[i]);
             this.changed();
             return { ok: true, rev: this.rev };
           }
@@ -974,25 +1020,38 @@ export class DeckRuntime extends EventEmitter {
         return { ok: true, rev: this.rev };
       }
       case 'playback.progress': {
-        // the device owns playback of runtime files — adopt its clock
+        // the device owns playback of runtime files — adopt its clock. It
+        // reports a position inside the segment it is playing, so offset by
+        // everything already narrated.
         if (this.playing !== intent.id) return { ok: false, rev: this.rev, error: 'not playing' };
-        this.pos = intent.pos;
+        this.pos = this.segmentStart() + intent.pos;
         if (intent.dur) {
           const msg = this.messageAt(intent.id);
-          if (msg) msg.dur = intent.dur;
+          const durs = msg?.segmentDurs;
+          if (durs) durs[this.segIx] = intent.dur;
+          if (msg) msg.dur = durs ? durs.reduce((total, d) => total + d, 0) : intent.dur;
         }
         this.changed();
         return { ok: true, rev: this.rev };
       }
       case 'playback.ended': {
         if (this.playing !== intent.id) return { ok: false, rev: this.rev, error: 'not playing' };
+        // The device finished one segment. Hand it the next before declaring
+        // the narration over — this is where long replies used to stop.
+        if (this.advanceSegment()) {
+          this.pos = this.segmentStart();
+          this.log('SEGMENT', `${this.segIx + 1}/${this.segmentCount()}`);
+          this.changed();
+          return { ok: true, rev: this.rev };
+        }
         const [li] = intent.id.split(':').map(Number);
         this.playing = null;
+        this.segIx = 0;
         this.pos = 0;
         this.paused = false;
         this.setPhase('idle', 'READY');
         this.setLaneState(li, 'idle');
-        this.log('PLAYBACK ENDED', 'buffer complete');
+        this.log('PLAYBACK ENDED', 'narration complete');
         this.changed();
         return { ok: true, rev: this.rev };
       }
@@ -1016,8 +1075,13 @@ export class DeckRuntime extends EventEmitter {
     }
     this.changed();
     if (play) {
-      const file = await this.synthesize(text);
-      if (file) this.playFile(file);
+      const files = await this.synthesizeSegments(text);
+      if (files.length === 0) return;
+      // A mirror stays Mac-local: segments drive ordered local playback, but no
+      // deck-facing URLs are published, so a connected device stays silent.
+      this.attachSegments(msg, files, text, false);
+      if (this.playing === id) this.startSegments(msg);
+      this.changed();
     }
   }
 
@@ -1054,7 +1118,7 @@ export class DeckRuntime extends EventEmitter {
       this.log('AGENT REPLY', `${msg.dur.toFixed(0)}s queued`);
       this.changed();
 
-      const file = await this.synthesize(reply);
+      const files = await this.synthesizeSegments(reply);
       if (!alive()) {
         // cancelled while synthesizing — finalize the reply as text-only
         if (!msg.file) {
@@ -1063,7 +1127,7 @@ export class DeckRuntime extends EventEmitter {
         }
         return;
       }
-      if (!file) {
+      if (files.length === 0) {
         // synthesis failed — show the reply without audio, never fake playback
         msg.mirrored = true;
         this.setPhase('idle', `READY · LANE ${String(lane + 1).padStart(2, '0')}`);
@@ -1071,19 +1135,20 @@ export class DeckRuntime extends EventEmitter {
         this.changed();
         return;
       }
-      msg.file = file;
-      msg.audioUrl = `/audio/${path.basename(file)}`;
+      this.attachSegments(msg, files, reply);
+      if (files.length > 1) {
+        this.log('NARRATION SEGMENTS', `${files.length} parts · ${msg.dur.toFixed(0)}s total`);
+      }
       if (this.autoplay && this.suppressAutoplayForGeneration !== gen) {
         this.playing = id;
         this.paused = false;
-        this.pos = 0;
         this.setPhase('speaking', `SPEAKING · LANE ${String(lane + 1).padStart(2, '0')}`);
         this.setLaneState(lane, 'speaking');
         this.ensureTicker();
         this.changed();
         // a connected deck plays the audio on the device; the Mac speaks only
         // when nobody is watching
-        if (this.liveClients() === 0) this.playFile(file);
+        this.startSegments(msg);
       } else {
         this.setPhase('idle', `READY · LANE ${String(lane + 1).padStart(2, '0')}`);
         this.changed();
@@ -1127,7 +1192,9 @@ export class DeckRuntime extends EventEmitter {
           );
           const text = result.response.trim();
           if (!text) throw new Error('empty reply from the canonical task');
-          return text.length > 600 ? text.slice(0, 600).replace(/\s+\S*$/, '') + '…' : text;
+          // The full canonical answer is returned. Narration length is bounded
+          // by ordered segment synthesis, never by clipping the agent's reply.
+          return text;
         } finally {
           if (this.canonicalTurnAbort === controller) this.canonicalTurnAbort = null;
         }
@@ -1153,7 +1220,7 @@ export class DeckRuntime extends EventEmitter {
       }
       const text = result.text.trim();
       if (!text) throw new Error('empty reply from session');
-      return text.length > 600 ? text.slice(0, 600).replace(/\s+\S*$/, '') + '…' : text;
+      return text;
     } catch (error) {
       const canonical = route.kind === 'canonical';
       this.log(canonical ? 'CANONICAL FAILED' : 'AGENT FAILED', (error as Error).message.slice(0, 60));
@@ -1179,40 +1246,124 @@ export class DeckRuntime extends EventEmitter {
     for (const { client } of this.laneClients.values()) client.interrupt?.();
   }
 
-  /** Synthesize to a runtime-owned file — the user's configured provider first
-   * (cloud silent mode → exact cache entry copied out), the macOS system voice
-   * as fallback. The copy means cache eviction can never pull audio mid-play. */
-  private async synthesize(text: string): Promise<string | null> {
+  /** Synthesize to runtime-owned files — the user's configured provider first
+   * (cloud silent mode → exact cache entries copied out), the macOS system voice
+   * as fallback. The copy means cache eviction can never pull audio mid-play.
+   *
+   * A reply longer than one provider request becomes several ordered segments.
+   * Partial synthesis is still returned: speaking most of a long answer beats
+   * discarding all of it, and the shortfall is logged rather than hidden. */
+  private async synthesizeSegments(text: string): Promise<string[]> {
+    const stamp = Date.now();
     try {
       const { SpeakEasy } = await import('../index');
       const speaker = new SpeakEasy({
         volume: this.vol,
-        // The deck needs a durable file it can copy to its own playback area.
-        // Caching also makes silent system-voice synthesis return that exact file.
+        // The deck needs durable files it can copy to its own playback area.
+        // Caching also makes silent system-voice synthesis return those files.
         cache: { enabled: true },
       });
-      await speaker.speak(text, { silent: true });
-      // the SDK reports the exact file it used — no scanning, no correlation guesswork
-      if (speaker.lastAudioFile && existsSync(speaker.lastAudioFile)) {
-        const owned = path.join(this.synthDir, `reply-${Date.now()}${path.extname(speaker.lastAudioFile) || '.mp3'}`);
-        copyFileSync(speaker.lastAudioFile, owned);
-        return owned;
+      try {
+        await speaker.speak(text, { silent: true });
+      } catch (error) {
+        // Some segments may still have rendered — keep whatever was produced.
+        this.log('SYNTH PARTIAL', (error as Error).message.slice(0, 60));
       }
+      // the SDK reports the exact files it used — no scanning, no correlation guesswork
+      const owned: string[] = [];
+      speaker.lastAudioFiles.forEach((source, i) => {
+        if (!existsSync(source)) return;
+        const target = path.join(
+          this.synthDir,
+          `reply-${stamp}-${String(i).padStart(2, '0')}${path.extname(source) || '.mp3'}`
+        );
+        copyFileSync(source, target);
+        owned.push(target);
+      });
+      if (owned.length > 0) return owned;
     } catch {
       // cloud silent mode unavailable — fall through to the system voice
     }
-    const file = path.join(this.synthDir, `reply-${Date.now()}.aiff`);
+    const file = path.join(this.synthDir, `reply-${stamp}.aiff`);
     try {
-      await run('say', ['-o', file, text], 30_000);
-      return file;
+      // `say` reads from argv and has no practical length limit, so the system
+      // fallback stays a single file regardless of how long the reply is.
+      await run('say', ['-o', file, text], 120_000);
+      return [file];
     } catch (error) {
       this.log('SYNTH FAILED', (error as Error).message.slice(0, 60));
       this.changed();
-      return null;
+      return [];
     }
   }
 
-  /** Controlled playback of a runtime-owned file: pause/resume/stop are real.
+  /** Attach ordered narration segments to a message and point it at the first.
+   *
+   * `exposeToDeck` decides whether a connected device may fetch and play the
+   * audio. Mirrors stay Mac-local, so publishing their URLs would produce the
+   * double audio the transport is careful to avoid. */
+  private attachSegments(
+    msg: DeckMessage,
+    files: string[],
+    text: string,
+    exposeToDeck = true
+  ): void {
+    const durations = measureSegmentDurations(files, text);
+    msg.segments = files;
+    msg.segmentUrls = exposeToDeck ? files.map((f) => `/audio/${path.basename(f)}`) : undefined;
+    msg.segmentDurs = durations;
+    msg.dur = durations.reduce((total, d) => total + d, 0);
+    this.focusSegment(msg, 0);
+  }
+
+  /** Point a message's transport fields at segment `ix`. */
+  private focusSegment(msg: DeckMessage, ix: number): void {
+    msg.file = msg.segments?.[ix];
+    msg.audioUrl = msg.segmentUrls?.[ix];
+  }
+
+  /** Seconds of narration before the current segment starts. */
+  private segmentStart(): number {
+    const msg = this.playing ? this.messageAt(this.playing) : null;
+    const durs = msg?.segmentDurs;
+    if (!durs) return 0;
+    return durs.slice(0, this.segIx).reduce((total, d) => total + d, 0);
+  }
+
+  /** How many segments the narration in flight has. */
+  private segmentCount(): number {
+    const msg = this.playing ? this.messageAt(this.playing) : null;
+    return msg?.segments?.length ?? (msg?.file ? 1 : 0);
+  }
+
+  /**
+   * Advance to the next narration segment. Returns false once the last segment
+   * has been spoken, which is the only point at which playback is complete.
+   */
+  private advanceSegment(): boolean {
+    if (!this.playing) return false;
+    const msg = this.messageAt(this.playing);
+    const segments = msg?.segments;
+    if (!msg || !segments || this.segIx + 1 >= segments.length) return false;
+    this.segIx += 1;
+    this.focusSegment(msg, this.segIx);
+    return true;
+  }
+
+  /** Begin a message's narration from its first segment. */
+  private startSegments(msg: DeckMessage): void {
+    this.segIx = 0;
+    this.focusSegment(msg, 0);
+    this.pos = 0;
+    if (this.liveClients() === 0 && msg.file) this.playFile(msg.file);
+  }
+
+  /** Controlled playback of one runtime-owned segment: pause/resume/stop are real.
+   *
+   * Each invocation costs ~1s of `afplay` process and audio-device startup, so a
+   * multi-segment narration has a short seam between parts. Chunks are sized in
+   * the ~80s range to keep that overhead near one percent; removing it entirely
+   * would mean a persistent audio process rather than one-shot `afplay`.
    * Skipped entirely while a deck is connected — the deck plays the audio on
    * the device instead (double audio is the bug this prevents). */
   private playFile(file: string): void {
@@ -1228,17 +1379,31 @@ export class DeckRuntime extends EventEmitter {
       // a killed predecessor must not clear the reference of its replacement
       if (this.player !== player) return;
       this.player = null;
-      // natural completion is authoritative — the audio really is done
-      if (this.playing && !this.paused) {
-        const [li] = this.playing.split(':').map(Number);
-        this.playing = null;
-        this.pos = 0;
-        this.paused = false;
-        this.setPhase('idle', 'READY');
-        this.setLaneState(li, 'idle');
-        this.log('PLAYBACK ENDED', 'buffer complete');
-        this.changed();
+      // natural completion is authoritative — this segment really is done
+      if (!this.playing || this.paused) return;
+
+      // A long reply is several ordered segments. Only the last one ends the
+      // narration; the rest hand off to their successor.
+      if (this.advanceSegment()) {
+        const next = this.messageAt(this.playing)?.file;
+        this.pos = this.segmentStart();
+        if (next) {
+          this.log('SEGMENT', `${this.segIx + 1}/${this.segmentCount()}`);
+          this.changed();
+          this.playFile(next);
+          return;
+        }
       }
+
+      const [li] = this.playing.split(':').map(Number);
+      this.playing = null;
+      this.segIx = 0;
+      this.pos = 0;
+      this.paused = false;
+      this.setPhase('idle', 'READY');
+      this.setLaneState(li, 'idle');
+      this.log('PLAYBACK ENDED', 'narration complete');
+      this.changed();
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { getHistory } from './history';
 import { TTSAdapter, TTSProviderId, TTSRequest } from './adapters/types';
 import { createAdapterRegistry, PROVIDER_ORDER } from './adapters/registry';
 import { playAudioFile, playTTSResult, stopPlayback } from './adapters/audio';
+import { chunkForNarration, chunkLimitForProvider } from './narration/chunk';
 
 const CONFIG_DIR = path.join(require('os').homedir(), '.config', 'speakeasy');
 export const CONFIG_FILE = path.join(CONFIG_DIR, 'settings.json');
@@ -50,6 +51,25 @@ const API_KEY_URLS: Partial<Record<TTSProviderId, string>> = {
   gemini: 'https://makersuite.google.com/app/apikey',
 };
 
+/**
+ * Raised when one or more narration segments failed. The remaining segments are
+ * still spoken before this surfaces, so a mid-narration provider error costs the
+ * caller one segment rather than the rest of the response.
+ */
+export class NarrationSegmentError extends Error {
+  readonly failures: Array<{ text: string; error: Error }>;
+
+  constructor(failures: Array<{ text: string; error: Error }>) {
+    const detail = failures.map((f) => f.error.message).join('; ');
+    super(
+      `${failures.length} narration segment${failures.length === 1 ? '' : 's'} failed: ${detail}`
+    );
+    this.name = 'NarrationSegmentError';
+    this.failures = failures;
+    this.cause = failures[0]?.error;
+  }
+}
+
 export class SpeakEasy {
   private config: SpeakEasyConfig;
   private adapters: Map<TTSProviderId, TTSAdapter>;
@@ -59,8 +79,14 @@ export class SpeakEasy {
   private useCache = false;
   private debug = false;
   private hudEnabled = false;
-  /** Exact cached audio file used by the most recent speak() call, if any. */
+  /** Exact cached audio file used by the most recent segment, if any. */
   public lastAudioFile: string | null = null;
+  /**
+   * Every audio file produced by the most recent speak() call, in speaking
+   * order. Long text is narrated as several ordered segments, so a caller that
+   * needs the whole narration must read this rather than `lastAudioFile`.
+   */
+  public lastAudioFiles: string[] = [];
 
   constructor(config: SpeakEasyConfig) {
     const globalConfig = loadGlobalConfig();
@@ -136,6 +162,11 @@ export class SpeakEasy {
     }
   }
 
+  /**
+   * Speak `text`, however long it is. Text beyond one provider request is split
+   * into bounded semantic segments and queued in order, so narration length is
+   * limited by the text itself rather than by a single request's ceiling.
+   */
   async speak(text: string, options: SpeakEasyOptions = {}): Promise<void> {
     const cleanText = cleanTextForSpeech(text);
 
@@ -143,10 +174,25 @@ export class SpeakEasy {
       this.stopSpeaking();
     }
 
+    const maxChars = chunkLimitForProvider(this.config.provider as TTSProviderId);
+    const segments = chunkForNarration(cleanText, { maxChars });
+    if (segments.length === 0) return;
+
+    if (!this.isPlaying) this.lastAudioFiles = [];
+
     if (options.priority === 'high') {
-      this.queue.unshift({ text: cleanText, options });
+      // unshift in reverse so the segments stay in speaking order at the front
+      for (let i = segments.length - 1; i >= 0; i--) {
+        this.queue.unshift({ text: segments[i], options });
+      }
     } else {
-      this.queue.push({ text: cleanText, options });
+      for (const segment of segments) {
+        this.queue.push({ text: segment, options });
+      }
+    }
+
+    if (this.debug && segments.length > 1) {
+      console.log(`🧩 Narrating ${cleanText.length} characters as ${segments.length} segments`);
     }
 
     if (!this.isPlaying) {
@@ -154,24 +200,46 @@ export class SpeakEasy {
     }
   }
 
+  /**
+   * Drain the queue in order. A failing segment is recorded and reported once
+   * the rest have been spoken — losing the remainder of a narration because one
+   * request failed is worse than an out-of-order gap.
+   */
   private async processQueue(): Promise<void> {
-    if (this.queue.length === 0) return;
+    if (this.isPlaying) return;
 
     this.isPlaying = true;
-    const { text, options } = this.queue.shift()!;
+    const failures: Array<{ text: string; error: Error }> = [];
 
     try {
-      await this.speakText(text, options);
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      console.error('❌ Speech error:', errorMsg);
-      throw error;
+      while (this.queue.length > 0) {
+        const { text, options } = this.queue.shift()!;
+        try {
+          await this.speakText(text, options);
+        } catch (error) {
+          const failure = error instanceof Error ? error : new Error(String(error));
+          console.error('❌ Speech error:', failure.message);
+          failures.push({ text, error: failure });
+        }
+      }
     } finally {
       this.isPlaying = false;
-      if (this.queue.length > 0) {
-        await this.processQueue();
-      }
     }
+
+    if (failures.length > 0) {
+      throw new NarrationSegmentError(failures);
+    }
+  }
+
+  /** Drop any narration still queued. In-flight audio is unaffected. */
+  clearQueue(): void {
+    this.queue.length = 0;
+  }
+
+  /** Stop the current audio and abandon everything still queued. */
+  cancel(): void {
+    this.clearQueue();
+    this.stopSpeaking();
   }
 
   private async speakText(text: string, options: SpeakEasyOptions = {}): Promise<void> {
@@ -224,7 +292,7 @@ export class SpeakEasy {
 
           if (cachedEntry) {
             console.log('(already cached)');
-            this.lastAudioFile = cachedEntry.audioFilePath;
+            this.recordAudioFile(cachedEntry.audioFilePath);
             if (this.debug) {
               console.log(`📦 Using cached audio from: ${cachedEntry.audioFilePath}`);
             }
@@ -264,9 +332,8 @@ export class SpeakEasy {
             }
           );
           if (stored) {
-            this.lastAudioFile = path.join(
-              this.cache.getCacheDir(),
-              `${cacheKey}.${result.format}`
+            this.recordAudioFile(
+              path.join(this.cache.getCacheDir(), `${cacheKey}.${result.format}`)
             );
           }
           console.log('cached');
@@ -300,6 +367,12 @@ export class SpeakEasy {
     }
 
     throw new Error(`No available TTS provider. Ensure you're on macOS for system voice.`);
+  }
+
+  /** Track the audio behind one segment, keeping the ordered list in step. */
+  private recordAudioFile(file: string): void {
+    this.lastAudioFile = file;
+    this.lastAudioFiles.push(file);
   }
 
   private buildRequest(text: string, providerId: TTSProviderId): TTSRequest {
@@ -493,6 +566,12 @@ export const speak = (
 
 export * from './types';
 export * from './adapters/types';
+export {
+  NARRATION_CHUNK_CHARS,
+  PROVIDER_TEXT_LIMITS,
+  chunkForNarration,
+  chunkLimitForProvider,
+} from './narration/chunk';
 export { createAdapterRegistry, PROVIDER_ORDER } from './adapters/registry';
 export { playAudioFile, playTTSResult, stopPlayback } from './adapters/audio';
 export { SystemProvider, getAvailableVoices, getBestVoice } from './providers/system';
@@ -500,6 +579,7 @@ export { OpenAIProvider } from './providers/openai';
 export { ElevenLabsProvider } from './providers/elevenlabs';
 export { GroqProvider } from './providers/groq';
 export { GeminiProvider } from './providers/gemini';
-export { TTSCache, CacheMetadata, CacheStats } from './cache';
+export { TTSCache } from './cache';
+export type { CacheMetadata, CacheStats } from './cache';
 export * from './player-client';
 export * from './player-protocol';

--- a/src/narration/chunk.test.ts
+++ b/src/narration/chunk.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  NARRATION_CHUNK_CHARS,
+  NarrationChunkError,
+  PROVIDER_TEXT_LIMITS,
+  assertLossless,
+  chunkForNarration,
+  chunkLimitForProvider,
+} from './chunk';
+
+/** ~13.5 characters per second measured from cached eleven_multilingual_v2 output. */
+const CHARS_PER_SECOND = 13.5;
+
+function sentences(count: number, word = 'narration'): string {
+  return Array.from(
+    { length: count },
+    (_, i) => `Sentence ${i} explains why the ${word} pipeline must not drop this text.`
+  ).join(' ');
+}
+
+describe('chunkForNarration', () => {
+  test('returns nothing for empty input', () => {
+    expect(chunkForNarration('')).toEqual([]);
+    expect(chunkForNarration('   \n\n  ')).toEqual([]);
+  });
+
+  test('leaves text that already fits as a single chunk', () => {
+    const text = 'Short enough to speak in one request.';
+    expect(chunkForNarration(text, { maxChars: 100 })).toEqual([text]);
+  });
+
+  test('never exceeds the requested bound', () => {
+    const chunks = chunkForNarration(sentences(200), { maxChars: 300 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) expect(chunk.length).toBeLessThanOrEqual(300);
+  });
+
+  test('preserves every character across chunks', () => {
+    const source = sentences(200);
+    const chunks = chunkForNarration(source, { maxChars: 300 });
+    expect(chunks.join('').replace(/\s+/g, '')).toBe(source.replace(/\s+/g, ''));
+  });
+
+  test('prefers sentence boundaries when a sentence fits', () => {
+    const source = 'First sentence here. Second sentence here. Third sentence here.';
+    const chunks = chunkForNarration(source, { maxChars: 45 });
+    for (const chunk of chunks) expect(chunk).toMatch(/[.!?]$/);
+  });
+
+  test('falls back to clause boundaries for a sentence that cannot fit', () => {
+    const source =
+      'This one very long sentence runs on, and on, and further still, ' +
+      'until it simply cannot be spoken inside a single bounded request.';
+    const chunks = chunkForNarration(source, { maxChars: 40 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) expect(chunk.length).toBeLessThanOrEqual(40);
+    expect(chunks.join('').replace(/\s+/g, '')).toBe(source.replace(/\s+/g, ''));
+  });
+
+  test('never splits inside a word that fits the bound', () => {
+    const source = sentences(40);
+    const chunks = chunkForNarration(source, { maxChars: 200 });
+    const rejoined = chunks.join(' ').split(/\s+/).filter(Boolean);
+    const original = source.split(/\s+/).filter(Boolean);
+    expect(rejoined).toEqual(original);
+  });
+
+  test('hard-splits a single token longer than the bound instead of dropping it', () => {
+    const token = 'a'.repeat(250);
+    const chunks = chunkForNarration(`before ${token} after`, { maxChars: 100 });
+    for (const chunk of chunks) expect(chunk.length).toBeLessThanOrEqual(100);
+    expect(chunks.join('').replace(/\s+/g, '')).toBe(`before${token}after`);
+  });
+
+  test('splits on paragraph boundaries before sentence boundaries', () => {
+    const source = `${sentences(3, 'first')}\n\n${sentences(3, 'second')}`;
+    const chunks = chunkForNarration(source, { maxChars: 260 });
+    expect(chunks.some((c) => c.includes('first') && c.includes('second'))).toBe(false);
+  });
+
+  test('a response far longer than forty seconds survives chunking intact', () => {
+    // The regression: 600 characters was ~43s, which is where narration used to stop.
+    const source = sentences(120);
+    expect(source.length / CHARS_PER_SECOND).toBeGreaterThan(120);
+
+    const chunks = chunkForNarration(source, { maxChars: NARRATION_CHUNK_CHARS });
+    const spokenSeconds = chunks.reduce((total, c) => total + c.length / CHARS_PER_SECOND, 0);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(spokenSeconds).toBeGreaterThan(40);
+    expect(chunks.join('').replace(/\s+/g, '')).toBe(source.replace(/\s+/g, ''));
+  });
+
+  test('stays within every provider request limit at the default chunk size', () => {
+    const chunks = chunkForNarration(sentences(500), { maxChars: NARRATION_CHUNK_CHARS });
+    const smallestProviderLimit = Math.min(...Object.values(PROVIDER_TEXT_LIMITS));
+    for (const chunk of chunks) expect(chunk.length).toBeLessThanOrEqual(smallestProviderLimit);
+  });
+});
+
+describe('chunkLimitForProvider', () => {
+  test('never exceeds the provider request limit', () => {
+    expect(chunkLimitForProvider('openai', 100_000)).toBe(PROVIDER_TEXT_LIMITS.openai);
+    expect(chunkLimitForProvider('gemini', 100_000)).toBe(PROVIDER_TEXT_LIMITS.gemini);
+  });
+
+  test('honours a smaller explicit request', () => {
+    expect(chunkLimitForProvider('elevenlabs', 500)).toBe(500);
+  });
+
+  test('defaults to the narration chunk size for a known provider', () => {
+    expect(chunkLimitForProvider('elevenlabs')).toBe(NARRATION_CHUNK_CHARS);
+  });
+});
+
+describe('assertLossless', () => {
+  test('accepts a faithful split', () => {
+    expect(() => assertLossless('one two three', ['one two', 'three'])).not.toThrow();
+  });
+
+  test('rejects a dropped remainder — the bug this module exists to prevent', () => {
+    expect(() => assertLossless('one two three', ['one two'])).toThrow(NarrationChunkError);
+  });
+});

--- a/src/narration/chunk.ts
+++ b/src/narration/chunk.ts
@@ -1,0 +1,168 @@
+/**
+ * Long-form narration is delivered as an ordered sequence of bounded chunks.
+ *
+ * The contract every consumer depends on is that chunking never loses text.
+ * Splits happen at the strongest semantic boundary that still fits — paragraph,
+ * then sentence, then clause, then word — and the words of the returned chunks
+ * are exactly the words of the input, in order. Silently dropping a remainder
+ * is the failure this module exists to prevent, so the losslessness check runs
+ * in `chunkForNarration` itself rather than only in the tests.
+ */
+
+import type { TTSProviderId } from '../adapters/types';
+
+/**
+ * Per-request input limits documented by each provider. These bound a single
+ * synthesis call; they are not the ceiling on how much we can narrate, because
+ * anything longer is split across ordered requests.
+ */
+export const PROVIDER_TEXT_LIMITS: Record<TTSProviderId, number> = {
+  // https://platform.openai.com/docs/api-reference/audio/createSpeech — 4096 max
+  openai: 4096,
+  // eleven_multilingual_v2 accepts 10,000 characters; leave headroom for the
+  // trailing-boundary backoff rather than sitting exactly on the limit.
+  elevenlabs: 9_500,
+  groq: 9_500,
+  gemini: 4_000,
+  // `say` reads the text from argv, so the practical bound is ARG_MAX.
+  system: 32_000,
+};
+
+/**
+ * Chunks are deliberately far below every provider limit. The bound that
+ * matters for narration is time-to-first-audio, not the request cap: ~1200
+ * characters is roughly 85 seconds of speech, so the first chunk starts
+ * playing while the rest are still being synthesized.
+ */
+export const NARRATION_CHUNK_CHARS = 1_200;
+
+export interface ChunkOptions {
+  /** Hard upper bound on the characters in any returned chunk. */
+  maxChars?: number;
+}
+
+/** The largest chunk we may send to `provider`, honouring an explicit request. */
+export function chunkLimitForProvider(
+  provider: TTSProviderId | undefined,
+  requested: number = NARRATION_CHUNK_CHARS
+): number {
+  const providerLimit = provider ? PROVIDER_TEXT_LIMITS[provider] : undefined;
+  const limit = Math.min(requested, providerLimit ?? NARRATION_CHUNK_CHARS);
+  return Math.max(1, limit);
+}
+
+/**
+ * The comparison basis for losslessness. Whitespace is normalization, not
+ * content, and an over-long token may be cut mid-word, so the invariant is
+ * stated over the non-whitespace character sequence.
+ */
+function significant(text: string): string {
+  return text.replace(/\s+/g, '');
+}
+
+function splitParagraphs(text: string): string[] {
+  return text.split(/\n\s*\n+/);
+}
+
+/** Sentence terminators, keeping any trailing quote or bracket with the sentence. */
+function splitSentences(text: string): string[] {
+  return text.match(/[^.!?…]+(?:[.!?…]+["'”’)\]]*\s*|$)/g) ?? [text];
+}
+
+function splitClauses(text: string): string[] {
+  return text.match(/[^,;:—–]+(?:[,;:—–]+\s*|$)/g) ?? [text];
+}
+
+function splitWords(text: string): string[] {
+  return text.split(/\s+/).filter(Boolean);
+}
+
+/**
+ * A single token longer than the limit (a URL, a hash, an unspaced blob) has no
+ * semantic boundary left. Cut it on the character grid rather than dropping it.
+ */
+function splitHard(text: string, max: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += max) out.push(text.slice(i, i + max));
+  return out;
+}
+
+/**
+ * Greedily pack `units` into chunks of at most `max` characters, delegating any
+ * single unit that cannot fit to the next-weaker boundary.
+ */
+function pack(units: string[], max: number, deeper: (unit: string) => string[]): string[] {
+  const out: string[] = [];
+  let current = '';
+
+  const flush = () => {
+    const trimmed = current.trim();
+    if (trimmed) out.push(trimmed);
+    current = '';
+  };
+
+  for (const raw of units) {
+    const unit = raw.trim();
+    if (!unit) continue;
+
+    if (unit.length > max) {
+      flush();
+      out.push(...deeper(unit));
+      continue;
+    }
+
+    const joined = current ? `${current} ${unit}` : unit;
+    if (joined.length > max) {
+      flush();
+      current = unit;
+    } else {
+      current = joined;
+    }
+  }
+
+  flush();
+  return out;
+}
+
+export class NarrationChunkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NarrationChunkError';
+  }
+}
+
+/**
+ * Split `text` into ordered, bounded, semantically-aligned narration chunks.
+ * Returns `[]` for empty input and `[text]` when the whole text already fits.
+ */
+export function chunkForNarration(text: string, options: ChunkOptions = {}): string[] {
+  const max = Math.max(1, Math.floor(options.maxChars ?? NARRATION_CHUNK_CHARS));
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  if (trimmed.length <= max) return [trimmed];
+
+  const chunks = pack(splitParagraphs(trimmed), max, (paragraph) =>
+    pack(splitSentences(paragraph), max, (sentence) =>
+      pack(splitClauses(sentence), max, (clause) =>
+        pack(splitWords(clause), max, (word) => splitHard(word, max))
+      )
+    )
+  );
+
+  assertLossless(trimmed, chunks);
+  return chunks;
+}
+
+/**
+ * Prove that chunking preserved the text, in order. This is deliberately a
+ * throw and not a warning: the algorithm is deterministic, so a mismatch is a
+ * real defect, and shipping half a narration is the bug being fixed here.
+ */
+export function assertLossless(source: string, chunks: string[]): void {
+  const expected = significant(source);
+  const actual = significant(chunks.join(''));
+  if (expected === actual) return;
+  throw new NarrationChunkError(
+    `Narration chunking lost text: expected ${expected.length} characters, produced ${actual.length}.`
+  );
+}

--- a/src/narration/long-form.test.ts
+++ b/src/narration/long-form.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'bun:test';
+import { NarrationSegmentError, SpeakEasy } from '../index';
+import { chunkForNarration } from './chunk';
+
+/**
+ * The regression these tests exist for: narration used to stop at ~40 seconds
+ * because the reply was clipped to 600 characters before synthesis. A response
+ * substantially longer than that must now be spoken in full, in order.
+ */
+
+/** ~13.5 characters per second, measured from cached eleven_multilingual_v2 audio. */
+const CHARS_PER_SECOND = 13.5;
+/** Comfortably past the old ~43s ceiling. */
+const LONG_RESPONSE = Array.from(
+  { length: 90 },
+  (_, i) =>
+    `Point ${i} says the narration pipeline must speak this sentence instead of ` +
+    `truncating the response part way through.`
+).join(' ');
+
+function speakerWithStubbedSynthesis() {
+  const speaker = new SpeakEasy({ provider: 'system', cache: { enabled: false } });
+  const spoken: string[] = [];
+  (speaker as unknown as { speakText: (t: string) => Promise<void> }).speakText = async (
+    text: string
+  ) => {
+    spoken.push(text);
+    if (text.includes('EXPLODE')) throw new Error('provider exploded');
+  };
+  return { speaker, spoken };
+}
+
+describe('long-form narration', () => {
+  test('the fixture is well past the duration where narration used to stop', () => {
+    expect(LONG_RESPONSE.length).toBeGreaterThan(600);
+    expect(LONG_RESPONSE.length / CHARS_PER_SECOND).toBeGreaterThan(40);
+  });
+
+  test('a response longer than forty seconds is spoken as ordered segments', async () => {
+    const { speaker, spoken } = speakerWithStubbedSynthesis();
+
+    await speaker.speak(LONG_RESPONSE);
+
+    expect(spoken.length).toBeGreaterThan(1);
+    // every segment, concatenated in speaking order, reproduces the response
+    expect(spoken.join('').replace(/\s+/g, '')).toBe(LONG_RESPONSE.replace(/\s+/g, ''));
+  });
+
+  test('total narration exceeds the old ceiling instead of stopping at it', async () => {
+    const { speaker, spoken } = speakerWithStubbedSynthesis();
+
+    await speaker.speak(LONG_RESPONSE);
+    const seconds = spoken.reduce((total, s) => total + s.length / CHARS_PER_SECOND, 0);
+
+    expect(seconds).toBeGreaterThan(40);
+  });
+
+  test('segments are queued in reading order', async () => {
+    const { speaker, spoken } = speakerWithStubbedSynthesis();
+
+    await speaker.speak(LONG_RESPONSE);
+
+    const expected = chunkForNarration(LONG_RESPONSE.replace(/\s+/g, ' ').trim(), {
+      maxChars: 1_200,
+    });
+    expect(spoken).toEqual(expected);
+  });
+
+  test('high priority narration also keeps its segments in order', async () => {
+    const { speaker, spoken } = speakerWithStubbedSynthesis();
+
+    await speaker.speak(LONG_RESPONSE, { priority: 'high' });
+
+    const first = spoken[0];
+    const last = spoken[spoken.length - 1];
+    expect(LONG_RESPONSE.startsWith(first.slice(0, 20))).toBe(true);
+    expect(last.endsWith('through.')).toBe(true);
+  });
+
+  test('short text still takes the single-request path', async () => {
+    const { speaker, spoken } = speakerWithStubbedSynthesis();
+
+    await speaker.speak('A short update.');
+
+    expect(spoken).toEqual(['A short update.']);
+  });
+
+  test('a failing segment surfaces without losing the remaining narration', async () => {
+    const speaker = new SpeakEasy({ provider: 'system', cache: { enabled: false } });
+    const spoken: string[] = [];
+    let calls = 0;
+    (speaker as unknown as { speakText: (t: string) => Promise<void> }).speakText = async (
+      text: string
+    ) => {
+      calls += 1;
+      // fail the second segment only
+      if (calls === 2) throw new Error('provider exploded');
+      spoken.push(text);
+    };
+
+    const expected = chunkForNarration(LONG_RESPONSE.replace(/\s+/g, ' ').trim(), {
+      maxChars: 1_200,
+    });
+
+    let raised: unknown;
+    try {
+      await speaker.speak(LONG_RESPONSE);
+    } catch (error) {
+      raised = error;
+    }
+
+    // the failure is reported, not swallowed
+    expect(raised).toBeInstanceOf(NarrationSegmentError);
+    expect((raised as NarrationSegmentError).failures).toHaveLength(1);
+    // and every other segment was still spoken
+    expect(calls).toBe(expected.length);
+    expect(spoken).toHaveLength(expected.length - 1);
+  });
+
+  test('cancel() abandons narration still queued', async () => {
+    const speaker = new SpeakEasy({ provider: 'system', cache: { enabled: false } });
+    const spoken: string[] = [];
+    (speaker as unknown as { speakText: (t: string) => Promise<void> }).speakText = async (
+      text: string
+    ) => {
+      spoken.push(text);
+      // interrupt the narration partway through, as a stop intent would
+      if (spoken.length === 2) speaker.cancel();
+    };
+
+    await speaker.speak(LONG_RESPONSE);
+
+    const expected = chunkForNarration(LONG_RESPONSE.replace(/\s+/g, ' ').trim(), {
+      maxChars: 1_200,
+    });
+    expect(spoken).toHaveLength(2);
+    expect(expected.length).toBeGreaterThan(2);
+  });
+
+  test('every audio file produced is exposed in speaking order', async () => {
+    const speaker = new SpeakEasy({ provider: 'system', cache: { enabled: false } });
+    let n = 0;
+    (speaker as unknown as { speakText: (t: string) => Promise<void> }).speakText = async () => {
+      (speaker as unknown as { recordAudioFile: (f: string) => void }).recordAudioFile(
+        `/tmp/segment-${n++}.mp3`
+      );
+    };
+
+    await speaker.speak(LONG_RESPONSE);
+
+    expect(speaker.lastAudioFiles.length).toBeGreaterThan(1);
+    expect(speaker.lastAudioFiles[0]).toBe('/tmp/segment-0.mp3');
+    expect(speaker.lastAudioFiles).toEqual(
+      speaker.lastAudioFiles.map((_, i) => `/tmp/segment-${i}.mp3`)
+    );
+    expect(speaker.lastAudioFile).toBe(
+      speaker.lastAudioFiles[speaker.lastAudioFiles.length - 1]
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

Not a provider cap, timeout, or player bug. `askAgent()` in the deck runtime clipped **every** Codex reply to 600 characters before synthesis:

```ts
return text.length > 600 ? text.slice(0, 600).replace(/\s+\S*$/, '') + '…' : text;
```

### Evidence (measured, from the local cache — no synthetic repro needed)

| | |
|---|---|
| Cache entries | 24 |
| Longest stored text | **560 chars** — nothing ever reached 600 |
| Longest rendered audio | **44.8s** — hard ceiling across all entries |
| Cluster at the ceiling | 38.7s / 39.2s / 40.3s / 41.7s / 44.3s / 44.8s |
| ElevenLabs `eleven_multilingual_v2` rate | ~13.5 chars/sec |
| 600 chars ÷ 13.5 | **~43s** — the reported cutoff |

Stored text lands at 497–560 rather than exactly 600 because `cleanTextForSpeech()` strips the trailing `…` and non-word characters.

### Provider limits were never approached

| Provider | Documented per-request limit | We were sending |
|---|---|---|
| OpenAI `tts-1` | 4096 chars | 600 |
| ElevenLabs `eleven_multilingual_v2` | 10,000 chars | 600 |

## Fix

Bounded semantic chunking with ordered queue playback, rather than raising a limit.

- **`src/narration/chunk.ts`** — splits at the strongest boundary that fits (paragraph → sentence → clause → word), with a losslessness assertion in the function itself, not just the tests. Records each provider's documented input limit so a chunk can never exceed its endpoint.
- **`src/index.ts`** — `speak()` queues segments in order. `processQueue()` is iterative and no longer abandons the remaining narration when one segment fails; failures aggregate into `NarrationSegmentError` *after* the rest has been spoken. Adds `lastAudioFiles`, `clearQueue()`, `cancel()`.
- **`src/cli/deck-runtime.ts`** — returns the full reply; synthesizes ordered segments; only the last segment completes the narration. Both completion paths covered (afplay exit for Mac-owned, `playback.ended` intent for device-owned). Segment durations measured with `afinfo` rather than estimated.
- **`deck/index.html`** — device seeks within the current segment instead of the whole-narration timeline.
- **`CodexLunaCompletionPresenter.swift`** — the deterministic projector's 900-char clip (a ~64s ceiling on the observer path) raised to 3500, kept under OpenAI's 4096 because that path still renders in one request.

## Verification

Full suite: **115 pass, 0 fail** (35 new).

Duration-based acceptance against the real ElevenLabs provider:

```
input characters: 3312
segments produced: 3
  80.25s  76.93s  69.33s
TOTAL NARRATION: 226.51s   ✅ vs the old 44.8s ceiling
```

Same result through `DeckRuntime.narrate()` (3 segments, 226.5s). Audible chain check confirmed all segments play in order with none dropped.

## Known characteristic

`afplay` costs ~1s of process and audio-device startup per invocation (measured: 0.89s / 0.96s / 1.14s), so each segment seam adds ~1s of silence. Chunks are sized around 80s of speech to keep that near 1%. Removing it entirely would mean a persistent audio process instead of one-shot `afplay` — noted in the code, not attempted here.

## Follow-up not in this PR

The app's observer/presenter path still renders in a **single** provider request, so it cannot use the segment queue. Its ceiling is now ~4 minutes instead of ~64s, but making it truly unbounded needs Swift-side chunking feeding `PlaybackEngine`'s existing queue.