### PR TITLE
🔧 ignore local Xcode build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ out/
 .playwright-cli/
 /output/
 *.app.zip
+.derived-data*/
+.device-id.local
 
 # Local QA media
 app/Sources/SpeakEasy/Resources/Pad/demo-response.*


### PR DESCRIPTION
## What changed

- ignore local Xcode `.derived-data*` directories
- ignore the local simulator `.device-id.local` marker

## Why

These files are machine-local build state and must never enter source control. Ignoring them first protects the remaining untracked iPad work while it is preserved in follow-up PRs.

## Validation

- `git check-ignore -v deck/ipad/.derived-data-sim/CompilationCache.noindex/generic/lock`
- `git check-ignore -v deck/ipad/.device-id.local`
