### PR TITLE
✨ add Micro Deck design studies

### DIFF
--- a/design/studio/src/studio/AudioInstrumentStudy.tsx
+++ b/design/studio/src/studio/AudioInstrumentStudy.tsx
@@ -1,0 +1,717 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { PageHeader } from "@/studio/PageHeader";
+import type { StudioAppPage } from "@/studio/studioRegistry";
+
+/**
+ * Audio instrument study — the bottom-right panel of the Micro Deck surface.
+ *
+ * This is a working replica, not a screenshot. The SwiftUI original lives at
+ * deck/ipad/Sources/DeckAudioInstrument.swift and can only be evaluated by
+ * building, installing to a simulator, and rotating a framebuffer — a loop far
+ * too slow to design in. Everything here is driveable: pick a state, drag the
+ * position, push the input level, and watch the figure respond.
+ *
+ * Palette is the Flight theme, lifted from deck/ipad/Sources/DeckTheme.swift.
+ * Geometry follows the shipped component: 1U idle, 2U while playing, where a
+ * unit is one key-bank row so the panel always lands on the pad's grid.
+ */
+
+const FLIGHT = {
+  page: "#05090b",
+  panel: "#0c161a",
+  pad: "#142328",
+  padBottom: "#0d171b",
+  line: "#1f333a",
+  lineSoft: "#1a2b31",
+  ink: "#e8f0ee",
+  ink2: "#a9bcb8",
+  ink3: "#6c7f7b",
+  ink4: "#4d605c",
+  accent: "#74f2ce",
+  amber: "#e0a83f",
+} as const;
+
+/** One key-bank row. The shipped panel derives this from the pad height. */
+const UNIT = 78;
+const GAP = 7;
+
+type Figure = "flat" | "live" | "sweep" | "travel" | "fill" | "dashes";
+
+type PanelState = {
+  key: string;
+  word: string;
+  detail: string;
+  tint: string;
+  figure: Figure;
+  /** Playing states grow to 2U and gain transport. */
+  playing?: boolean;
+  progress?: number;
+};
+
+const STATES: PanelState[] = [
+  { key: "ready", word: "READY", detail: "IDLE", tint: FLIGHT.ink3, figure: "flat" },
+  { key: "listening", word: "LISTENING", detail: "LANE 05", tint: FLIGHT.accent, figure: "live" },
+  { key: "arming", word: "ARMING", detail: "MIC", tint: FLIGHT.amber, figure: "sweep" },
+  { key: "transcribing", word: "TRANSCRIBING", detail: "ON DEVICE", tint: FLIGHT.amber, figure: "sweep" },
+  { key: "model", word: "MODEL", detail: "38%", tint: FLIGHT.amber, figure: "fill", progress: 0.38 },
+  { key: "speaking", word: "SPEAKING", detail: "LANE 05", tint: FLIGHT.accent, figure: "travel", playing: true },
+  { key: "macbusy", word: "SUBMITTING", detail: "MAC", tint: FLIGHT.amber, figure: "sweep" },
+  { key: "sending", word: "SENDING", detail: "3 QUEUED", tint: FLIGHT.amber, figure: "dashes" },
+  { key: "held", word: "HELD", detail: "2 AUDIO", tint: FLIGHT.amber, figure: "dashes" },
+  { key: "unsent", word: "UNSENT", detail: "4 WAITING", tint: FLIGHT.amber, figure: "dashes" },
+];
+
+/** Frames sampled across one cycle for the filmstrip. */
+const FRAMES = [0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875];
+
+const MOVING: { figure: Figure; tint: string; blurb: string }[] = [
+  { figure: "sweep", tint: FLIGHT.amber, blurb: "a band of light crosses a dim baseline — work with no progress to report" },
+  { figure: "dashes", tint: FLIGHT.amber, blurb: "dashes drift — a queue being worked, not stuck" },
+  { figure: "travel", tint: FLIGHT.accent, blurb: "played span fills behind the playhead; unplayed stays at baseline" },
+];
+
+const NARRATION =
+  "Yes — this repo is worth studying, but I would not replace Linea's PDF pipeline with it. " +
+  "The extraction layer is stronger than ours on tables. " +
+  "The layout model is weaker and would cost us the two-column handling we already have.";
+
+/** Deterministic pseudo-envelope so the study renders identically every load. */
+function envelope(count: number, seed = 7) {
+  let s = seed;
+  const rand = () => {
+    s = (s * 1103515245 + 12345) % 2147483648;
+    return s / 2147483648;
+  };
+  return Array.from({ length: count }, (_, i) => {
+    const t = i / count;
+    const speech = Math.abs(Math.sin(t * 11) * 0.5 + Math.sin(t * 27) * 0.3);
+    const gate = t % 0.31 < 0.05 ? 0.08 : 1; // breaths between phrases
+    return Math.round(Math.min(1, (speech * 0.75 + rand() * 0.25) * gate) * 1000) / 1000;
+  });
+}
+
+export function AudioInstrumentStudyPage({ page }: { page: StudioAppPage }) {
+  const [stateKey, setStateKey] = useState("speaking");
+  const [level, setLevel] = useState(0.6);
+  const [pos, setPos] = useState(0.34);
+  const [volume, setVolume] = useState(0.8);
+  const [paused, setPaused] = useState(false);
+  const [seekable, setSeekable] = useState(true);
+  const [width, setWidth] = useState(565);
+  const [animate, setAnimate] = useState(true);
+  const [manualPhase, setManualPhase] = useState(0);
+
+  // One clock for the whole page. Each Track used to run its own rAF loop,
+  // which meant the stacked states drifted out of step with each other and
+  // none of them could be stopped to look at.
+  const [speed, setSpeed] = useState(1);
+  const runningPhase = useAnimationPhase(animate, speed);
+  const phase = animate ? runningPhase : manualPhase;
+
+  const state = STATES.find((s) => s.key === stateKey) ?? STATES[0];
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+
+      <section className="max-w-[1100px] space-y-10 py-8">
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">Playground</h2>
+          <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            Every parameter the shipped panel reacts to, on a control. The panel is 1U when idle and
+            2U while playing — a unit is one key-bank row, so it always starts and ends on the pad&apos;s
+            grid. Drag <em>position</em> in a playing state to watch the played span fill and the
+            sentence estimate move.
+          </p>
+
+          <div className="mb-5 flex flex-wrap gap-1.5">
+            {STATES.map((s) => (
+              <button
+                key={s.key}
+                onClick={() => setStateKey(s.key)}
+                className="rounded px-2.5 py-1 text-[10px] font-medium tracking-wide transition"
+                style={{
+                  background: s.key === stateKey ? FLIGHT.pad : "transparent",
+                  color: s.key === stateKey ? s.tint : FLIGHT.ink4,
+                  border: `1px solid ${s.key === stateKey ? s.tint + "66" : FLIGHT.line}`,
+                }}
+              >
+                {s.word}
+              </button>
+            ))}
+          </div>
+
+          <div
+            className="rounded-lg p-6"
+            style={{ background: FLIGHT.page, border: `1px solid ${FLIGHT.lineSoft}` }}
+          >
+            <div style={{ width }}>
+              <Panel
+                state={state}
+                level={level}
+                pos={pos}
+                volume={volume}
+                paused={paused}
+                seekable={seekable}
+                phase={phase}
+                onSeek={setPos}
+                onVolume={setVolume}
+                onTogglePlay={() => setPaused((p) => !p)}
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-3 text-[11px] text-studio-ink-faint">
+            <button
+              onClick={() => {
+                if (animate) setManualPhase(runningPhase); // freeze where it is
+                setAnimate((a) => !a);
+              }}
+              className="rounded px-3 py-1 font-medium transition"
+              style={{
+                border: `1px solid ${animate ? FLIGHT.line : FLIGHT.accent}`,
+                color: animate ? FLIGHT.ink2 : FLIGHT.accent,
+                background: animate ? "transparent" : FLIGHT.accent + "18",
+              }}
+            >
+              {animate ? "❚❚  Pause animation" : "▶  Play animation"}
+            </button>
+            <span className="w-[86px] shrink-0">Frame</span>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.005}
+              value={phase}
+              disabled={animate}
+              onChange={(e) => setManualPhase(Number(e.target.value))}
+              className="flex-1 accent-[#74f2ce] disabled:opacity-30"
+              style={{ maxWidth: 320 }}
+            />
+            <span className="w-[46px] shrink-0 text-right tabular-nums">{phase.toFixed(3)}</span>
+            <button
+              onClick={() => setManualPhase((v) => (v + 0.02) % 1)}
+              disabled={animate}
+              className="rounded px-2 py-1 transition disabled:opacity-30"
+              style={{ border: `1px solid ${FLIGHT.line}`, color: FLIGHT.ink2 }}
+            >
+              Step ›
+            </button>
+          </div>
+
+          <div className="mt-4 grid max-w-[720px] grid-cols-1 gap-3 sm:grid-cols-2">
+            <Slider label="Input level" value={level} onChange={setLevel} />
+            <Slider label="Position" value={pos} onChange={setPos} />
+            <Slider label="Volume" value={volume} onChange={setVolume} />
+            <Slider label="Animation speed" value={speed} min={0.1} max={2} step={0.05} onChange={setSpeed} />
+            <Slider label="Panel width" value={width} min={360} max={900} step={5} unit="pt" onChange={setWidth} />
+            <Toggle label="Paused" checked={paused} onChange={setPaused} />
+            <Toggle
+              label="Device owns audio (seekable)"
+              checked={seekable}
+              onChange={setSeekable}
+            />
+          </div>
+        </div>
+
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">Motion, unrolled</h2>
+          <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            A loop that never stops is hard to read — you cannot see the shape of the motion while it
+            is moving. Each animated figure below is one full cycle laid out as frames, left to
+            right. Read a row like a filmstrip: that is the entire animation, all at once.
+          </p>
+          <div
+            className="space-y-5 rounded-lg p-5"
+            style={{ background: FLIGHT.page, border: `1px solid ${FLIGHT.lineSoft}` }}
+          >
+            {MOVING.map((m) => (
+              <div key={m.figure}>
+                <div className="mb-1.5 flex items-baseline gap-2">
+                  <span className="text-[10px] font-medium tracking-widest" style={{ color: m.tint }}>
+                    {m.figure.toUpperCase()}
+                  </span>
+                  <span className="text-[10px]" style={{ color: FLIGHT.ink4 }}>
+                    {m.blurb}
+                  </span>
+                </div>
+                <div className="flex gap-1.5">
+                  {FRAMES.map((f) => (
+                    <div key={f} className="flex-1">
+                      <div
+                        className="rounded"
+                        style={{
+                          height: 34,
+                          background: FLIGHT.pad,
+                          border: `1px solid ${FLIGHT.line}`,
+                          padding: "0 6px",
+                        }}
+                      >
+                        <Track
+                          figure={m.figure}
+                          tint={m.tint}
+                          level={0.6}
+                          pos={f}
+                          phase={f}
+                        />
+                      </div>
+                      <div
+                        className="mt-1 text-center text-[8px] tabular-nums"
+                        style={{ color: FLIGHT.ink4 }}
+                      >
+                        {f.toFixed(2)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">Every state</h2>
+          <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            States designed one at a time drift apart; the failure only shows up stacked. This is
+            where the shipped component was caught reusing one figure for three different states.
+          </p>
+          <div
+            className="space-y-2 rounded-lg p-5"
+            style={{ background: FLIGHT.page, border: `1px solid ${FLIGHT.lineSoft}` }}
+          >
+            {STATES.map((s) => (
+              <div key={s.key}>
+                <div className="mb-1 text-[9px] tracking-widest" style={{ color: FLIGHT.ink4 }}>
+                  {s.key.toUpperCase()}
+                </div>
+                <Panel
+                  state={s}
+                  level={level}
+                  pos={pos}
+                  volume={volume}
+                  paused={paused}
+                  seekable={seekable}
+                  phase={phase}
+                  compact
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function Panel({
+  state,
+  level,
+  pos,
+  volume,
+  paused,
+  seekable,
+  phase,
+  compact,
+  onSeek,
+  onVolume,
+  onTogglePlay,
+}: {
+  state: PanelState;
+  level: number;
+  pos: number;
+  volume: number;
+  paused: boolean;
+  seekable: boolean;
+  phase: number;
+  compact?: boolean;
+  onSeek?: (v: number) => void;
+  onVolume?: (v: number) => void;
+  onTogglePlay?: () => void;
+}) {
+  const playing = !!state.playing;
+  const height = playing ? UNIT * 2 + GAP : UNIT;
+  const tint = playing && paused ? FLIGHT.ink3 : state.tint;
+
+  return (
+    <div
+      className="flex flex-col justify-center rounded-lg"
+      style={{
+        height,
+        background: `linear-gradient(${FLIGHT.pad}, ${FLIGHT.padBottom})`,
+        border: `1px solid ${state.figure === "flat" ? FLIGHT.line : tint + "59"}`,
+        padding: "8px 14px",
+        gap: 8,
+      }}
+    >
+      <div className="flex items-center" style={{ gap: 14 }}>
+        <Status word={state.word} detail={state.detail} tint={tint} level={level} figure={state.figure} />
+        <div className="flex-1" style={{ height: playing ? 30 : 40 }}>
+          <Track figure={state.figure} tint={tint} level={level} pos={pos} progress={state.progress} phase={phase} />
+        </div>
+        <Dial value={volume} tint={FLIGHT.accent} onChange={onVolume} />
+      </div>
+
+      {playing && (
+        <div className="flex items-center" style={{ gap: 14 }}>
+          <div style={{ width: 112 }} className="flex items-center">
+            <button
+              onClick={onTogglePlay}
+              className="flex items-center justify-center rounded transition"
+              style={{
+                width: 44,
+                height: 30,
+                border: `1px solid ${paused ? FLIGHT.accent : FLIGHT.line}`,
+                color: paused ? FLIGHT.accent : FLIGHT.ink2,
+                background: paused ? FLIGHT.accent + "18" : "transparent",
+                fontSize: 11,
+              }}
+            >
+              {paused ? "▶" : "❚❚"}
+            </button>
+          </div>
+
+          <div className="flex-1">
+            <Scrubber pos={pos} tint={tint} seekable={seekable} onSeek={onSeek} />
+            <div
+              className="mt-1.5 truncate"
+              style={{ fontSize: 9.5, color: FLIGHT.ink3, fontFamily: "ui-monospace, monospace" }}
+            >
+              ≈ {sentenceAt(NARRATION, pos)}
+            </div>
+          </div>
+
+          <div style={{ width: 46 }} className="text-right">
+            <div style={{ fontSize: 10, color: FLIGHT.ink2, fontFamily: "ui-monospace, monospace" }}>
+              {clock(pos)}
+            </div>
+            <div style={{ fontSize: 7, color: FLIGHT.ink4, letterSpacing: 0.8 }}>
+              {seekable ? "LOCAL" : "ON MAC"}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Status({
+  word,
+  detail,
+  tint,
+  level,
+  figure,
+}: {
+  word: string;
+  detail: string;
+  tint: string;
+  level: number;
+  figure: Figure;
+}) {
+  return (
+    <div className="flex items-center" style={{ width: 112, gap: 8 }}>
+      <div
+        style={{
+          width: 7,
+          height: 7,
+          borderRadius: 99,
+          background: tint,
+          opacity: figure === "live" ? 0.35 + level * 0.65 : 1,
+          boxShadow: figure === "live" ? `0 0 6px ${tint}` : "none",
+        }}
+      />
+      <div className="min-w-0">
+        <div
+          className="truncate"
+          style={{ fontSize: 9.5, fontWeight: 600, letterSpacing: 1.2, color: tint, fontFamily: "ui-monospace, monospace" }}
+        >
+          {word}
+        </div>
+        <div style={{ fontSize: 7, letterSpacing: 0.9, color: FLIGHT.ink4, fontFamily: "ui-monospace, monospace" }}>
+          {detail}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Track({
+  figure,
+  tint,
+  level,
+  pos,
+  progress,
+  phase,
+}: {
+  figure: Figure;
+  tint: string;
+  level: number;
+  pos: number;
+  progress?: number;
+  phase: number;
+}) {
+  const wave = useMemo(() => envelope(96), []);
+
+  if (figure === "fill") {
+    return (
+      <div className="flex h-full items-center">
+        <div className="h-[5px] w-full rounded-full" style={{ background: FLIGHT.line }}>
+          <div
+            className="h-full rounded-full"
+            style={{ width: `${(progress ?? 0) * 100}%`, background: tint }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (figure === "sweep") {
+    return (
+      <div className="relative flex h-full items-center overflow-hidden">
+        <div className="h-[3px] w-full rounded-full" style={{ background: tint + "24" }} />
+        <div
+          className="absolute h-[3px] rounded-full"
+          style={{
+            width: "32%",
+            left: `${phase * 132 - 32}%`,
+            background: `linear-gradient(90deg, transparent, ${tint}, transparent)`,
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (figure === "dashes") {
+    return (
+      <div className="flex h-full items-center" style={{ gap: 3 }}>
+        {Array.from({ length: 26 }).map((_, i) => {
+          const lit = (i / 26 + phase) % 0.25 < 0.12;
+          return (
+            <div
+              key={i}
+              className="flex-1 rounded-full"
+              style={{ height: 3, background: tint, opacity: lit ? 0.85 : 0.2 }}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  // live / flat / travel all draw the same bar field; what differs is the data.
+  return (
+    <div className="flex h-full items-center" style={{ gap: 1.5 }}>
+      {wave.map((v, i) => {
+        const t = i / wave.length;
+        const isTravel = figure === "travel";
+        const played = isTravel && t <= pos;
+        const amplitude = figure === "flat" ? 0 : isTravel ? (played ? v : 0) : v * level;
+        const opacity = figure === "flat" ? 0.16 : isTravel ? (played ? 0.9 : 0.14) : 0.9;
+        return (
+          <div
+            key={i}
+            className="flex-1 rounded-full"
+            style={{
+              // Rounded so SSR and the client serialize identically — a raw
+              // float renders as "4.12674px" on the server and 4.1267435...
+              // on the client, which trips React's hydration check.
+              height: Math.round(Math.max(2, amplitude * 30)),
+              background: tint,
+              opacity,
+              minWidth: 1,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function Scrubber({
+  pos,
+  tint,
+  seekable,
+  onSeek,
+}: {
+  pos: number;
+  tint: string;
+  seekable: boolean;
+  onSeek?: (v: number) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const seek = (clientX: number) => {
+    const el = ref.current;
+    if (!el || !onSeek || !seekable) return;
+    const r = el.getBoundingClientRect();
+    onSeek(Math.min(1, Math.max(0, (clientX - r.left) / r.width)));
+  };
+
+  return (
+    <div
+      ref={ref}
+      className="relative flex items-center"
+      style={{ height: 14, cursor: seekable && onSeek ? "pointer" : "default" }}
+      onPointerDown={(e) => seek(e.clientX)}
+      onPointerMove={(e) => e.buttons === 1 && seek(e.clientX)}
+    >
+      <div className="h-[4px] w-full rounded-full" style={{ background: FLIGHT.line }}>
+        <div className="h-full rounded-full" style={{ width: `${pos * 100}%`, background: tint }} />
+      </div>
+      {seekable && (
+        <div
+          className="absolute rounded-full"
+          style={{
+            left: `calc(${pos * 100}% - 5px)`,
+            width: 10,
+            height: 10,
+            background: tint,
+            boxShadow: `0 0 6px ${tint}88`,
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function Dial({
+  value,
+  tint,
+  onChange,
+}: {
+  value: number;
+  tint: string;
+  onChange?: (v: number) => void;
+}) {
+  const r = 19;
+  const c = 2 * Math.PI * r;
+  return (
+    <svg
+      width={46}
+      height={46}
+      style={{ cursor: onChange ? "ns-resize" : "default", flexShrink: 0 }}
+      onWheel={(e) => onChange?.(Math.min(1, Math.max(0, value - e.deltaY / 500)))}
+    >
+      <circle cx={23} cy={23} r={r} fill="none" stroke={FLIGHT.line} strokeWidth={4} />
+      <circle
+        cx={23}
+        cy={23}
+        r={r}
+        fill="none"
+        stroke={tint}
+        strokeWidth={4}
+        strokeLinecap="round"
+        strokeDasharray={`${Math.round(Math.max(0.02, value) * c * 100) / 100} ${Math.round(c * 100) / 100}`}
+        transform="rotate(-90 23 23)"
+      />
+      <text
+        x={23}
+        y={27}
+        textAnchor="middle"
+        style={{ fontSize: 10, fill: FLIGHT.ink2, fontFamily: "ui-monospace, monospace", fontWeight: 600 }}
+      >
+        {Math.round(value * 100)}
+      </text>
+    </svg>
+  );
+}
+
+/* ── helpers ─────────────────────────────────────────────────────────────── */
+
+function useAnimationPhase(active: boolean, speed = 1) {
+  const originRef = useRef<number | null>(null);
+  const [, setBeat] = useState(0);
+  useEffect(() => {
+    if (!active) {
+      originRef.current = null;
+      return;
+    }
+    originRef.current = performance.now();
+    const id = window.setInterval(() => setBeat((n) => (n + 1) % 1_000_000), 80);
+    return () => window.clearInterval(id);
+  }, [active, speed]);
+  if (!active || originRef.current == null) return 0;
+  const elapsed = (performance.now() - originRef.current) / 1000;
+  return ((elapsed * speed) / 1.6) % 1;
+}
+
+/**
+ * Sentence containing the playhead, estimated by character position. There is
+ * no word-level timing anywhere in the pipeline — duration and position is all
+ * we get — so this assumes speech is spread evenly. Sentence granularity is
+ * deliberate: a tighter window is wrong by a word constantly and reads as
+ * broken, where this is wrong by a sentence occasionally and merely reads early.
+ */
+function sentenceAt(text: string, pos: number) {
+  const parts = text.match(/[^.!?]+[.!?]*/g) ?? [text];
+  const target = Math.floor(text.length * Math.min(0.999, Math.max(0, pos)));
+  let seen = 0;
+  for (const part of parts) {
+    seen += part.length;
+    if (seen > target) return part.trim();
+  }
+  return parts[parts.length - 1].trim();
+}
+
+function clock(pos: number, total = 47) {
+  const s = Math.floor(pos * total);
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function Slider({
+  label,
+  value,
+  onChange,
+  min = 0,
+  max = 1,
+  step = 0.01,
+  unit,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+}) {
+  return (
+    <label className="flex items-center gap-3 text-[11px] text-studio-ink-faint">
+      <span className="w-[112px] shrink-0">{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="flex-1 accent-[#74f2ce]"
+      />
+      <span className="w-[46px] shrink-0 text-right tabular-nums">
+        {unit ? `${Math.round(value)}${unit}` : value.toFixed(2)}
+      </span>
+    </label>
+  );
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-3 text-[11px] text-studio-ink-faint">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="accent-[#74f2ce]"
+      />
+      <span>{label}</span>
+    </label>
+  );
+}

--- a/design/studio/src/studio/LaneConsoleStudy.tsx
+++ b/design/studio/src/studio/LaneConsoleStudy.tsx
@@ -1,0 +1,1140 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { PageHeader } from "@/studio/PageHeader";
+import type { StudioAppPage } from "@/studio/studioRegistry";
+
+/**
+ * Lane console study — one surface, two textures.
+ *
+ * Identity + exchange (panel) sit over the player foot (plate). Same outer
+ * border, no gap, no second rounded card. Ring lives in the numeral gutter so
+ * TURN / caption share the identity text edge. Figure is the scrub surface —
+ * no separate rail under the wave. Player height stays 2U (pad grid).
+ */
+
+// Flight: void graphite + mint signal (matches DeckTheme.swift)
+const F = {
+  page: "#06080a",
+  panel: "#0d1114",
+  panelHead: "#12171b",
+  cell: "#161c22",
+  trace: "#0a0d10",
+  line: "#2c343c",
+  lineSoft: "#1c2329",
+  ink: "#f2f5f6",
+  ink2: "#a8b2ba",
+  ink3: "#6b7680",
+  ink4: "#4a545c",
+  accent: "#74f2ce",
+  accentDark: "#0a1f1a",
+  accentEdge: "#1a4a3e",
+  amber: "#e8b04a",
+  pad: "#161c22",
+  padBottom: "#0f1317",
+  plateTop: "#141a1f",
+  plateBottom: "#080b0d",
+} as const;
+
+/** One key-bank row — the pad grid unit. */
+const U = 78;
+const PLAYER_H = U * 2; // exactly 2U, always
+
+type Mode =
+  | "ready"
+  | "listening"
+  | "transcribing"
+  | "submitting"
+  | "speaking"
+  | "paused";
+
+const MODES: { key: Mode; word: string; detail: string; tint: string }[] = [
+  { key: "ready", word: "READY", detail: "LANE 02", tint: F.ink2 },
+  { key: "listening", word: "LISTENING", detail: "LANE 02", tint: F.accent },
+  { key: "transcribing", word: "TRANSCRIBING", detail: "ON DEVICE", tint: F.amber },
+  { key: "submitting", word: "SUBMITTING", detail: "MAC", tint: F.amber },
+  { key: "speaking", word: "SPEAKING", detail: "LANE 02", tint: F.accent },
+  { key: "paused", word: "PAUSED", detail: "LANE 02", tint: F.ink3 },
+];
+
+const YOU = "Mock turn — walk the full lifecycle without Codex.";
+const AGENT =
+  "Lifecycle walkthrough complete. Listening, transcription, Mac work, and narration all lit in sequence. The radio never resized.";
+
+/** Speech-shaped envelope: phrase humps with breaths — not a sine toy. */
+function speechEnvelope(count: number, seed = 11) {
+  let s = seed;
+  const rand = () => {
+    s = (s * 1103515245 + 12345) % 2147483648;
+    return s / 2147483648;
+  };
+  return Array.from({ length: count }, (_, i) => {
+    const t = i / count;
+    // Three phrases of different lengths
+    const phrase = Math.sin(t * Math.PI * 3.2);
+    const formant = Math.abs(Math.sin(t * 47)) * 0.35 + Math.abs(Math.sin(t * 19)) * 0.25;
+    const breath = phrase > 0.12 ? 1 : 0.06;
+    const attack = t < 0.04 ? t / 0.04 : t > 0.94 ? (1 - t) / 0.06 : 1;
+    // Quantize so SSR and client never disagree on the ladder.
+    return Math.round(
+      Math.min(1, Math.max(0.04, (Math.abs(phrase) * 0.55 + formant) * breath * attack * (0.85 + rand() * 0.15))) *
+        100,
+    ) / 100;
+  });
+}
+
+function clock(frac: number, dur = 4.2) {
+  const s = Math.floor(frac * dur);
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+export function LaneConsoleStudyPage({ page }: { page: StudioAppPage }) {
+  const [mode, setMode] = useState<Mode>("speaking");
+  const [pos, setPos] = useState(0.38);
+  const [level, setLevel] = useState(0.62);
+  const [volume, setVolume] = useState(0.8);
+  const [speedIx, setSpeedIx] = useState(0);
+  const [autoplay, setAutoplay] = useState(true);
+  const [width, setWidth] = useState(420);
+  const [animate, setAnimate] = useState(true);
+
+  // Faster clock so listen/playback feel snappy, not lethargic.
+  const phase = useAnimationPhase(animate, 1.65);
+  // Dense enough for wide bays; bars stay thin rectangles, not sparse posts.
+  const env = useMemo(() => speechEnvelope(96), []);
+  const meta = MODES.find((m) => m.key === mode) ?? MODES[0];
+
+  // Defer animated values until after mount so SSR HTML matches the first
+  // client paint (phase/level-driven bar styles used to hydrate-mismatch).
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  const livePhase = hydrated ? phase : 0;
+
+  // Derive from phase — avoid phase→setPos useEffect (update-depth thrash).
+  const livePos =
+    hydrated && animate && mode === "speaking" ? phase : pos;
+  const liveLevel =
+    hydrated && mode === "listening"
+      ? Math.round(
+          (0.18 +
+            Math.abs(Math.sin(phase * Math.PI * 2.4)) * 0.42 +
+            Math.abs(Math.sin(phase * Math.PI * 7.1)) * 0.22 +
+            Math.abs(Math.sin(phase * Math.PI * 13)) * 0.12) *
+            100,
+        ) / 100
+      : level;
+
+  const messages =
+    mode === "ready" || mode === "listening" || mode === "transcribing"
+      ? mode === "ready"
+        ? []
+        : [{ role: "you" as const, text: YOU }]
+      : [
+          { role: "you" as const, text: YOU },
+          { role: "agent" as const, text: AGENT },
+        ];
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+
+      <section className="max-w-[1100px] space-y-12 py-8">
+        {/* Thesis */}
+        <div className="grid gap-6 lg:grid-cols-[1fr_1fr]">
+          <div>
+            <h2 className="mb-2 text-[15px] font-medium text-studio-ink-strong">
+              Two pieces, not three
+            </h2>
+            <p className="max-w-[56ch] text-[13.5px] leading-relaxed text-studio-ink">
+              The lane used to be three competing objects: exchange, a radio that
+              grew when narration started, and a transport card with its own border
+              and gap. One story, three frames.
+            </p>
+            <p className="mt-3 max-w-[56ch] text-[13.5px] leading-relaxed text-studio-ink">
+              Target: <strong className="text-studio-ink-strong">one surface</strong>.
+              Identity + exchange keep the panel texture; the player is the plate
+              foot — same outer rim, different fill, hairline seam only. Ring sits
+              in the numeral gutter so TURN aligns with the announcement. The figure
+              is the scrub surface; no second rail under the wave. Height stays{" "}
+              <strong className="text-studio-ink-strong">exactly 2U</strong>.
+            </p>
+          </div>
+          <div
+            className="rounded-lg p-4 font-mono text-[11px] leading-relaxed"
+            style={{
+              background: F.page,
+              border: `1px solid ${F.line}`,
+              color: F.ink3,
+            }}
+          >
+            <div style={{ color: F.ink4 }} className="mb-2 tracking-widest">
+              LANE PANEL STACK
+            </div>
+            <StackRow label="01 · IDENTITY" detail="fixed · project / phase" />
+            <StackRow
+              label="02 · EXCHANGE"
+              detail="flexible · transcript / history"
+              accent
+            />
+            <StackRow
+              label="03 · PLAYER 2U"
+              detail="fixed · plate foot of same surface"
+              accent
+              last
+            />
+            <div className="mt-3 pt-3" style={{ borderTop: `1px solid ${F.lineSoft}` }}>
+              <div style={{ color: F.ink4 }} className="mb-1 tracking-widest">
+                HEIGHT · ALIGNMENT
+              </div>
+              <div>
+                Player = <span style={{ color: F.accent }}>2 × {U}pt</span> ={" "}
+                <span style={{ color: F.ink }}>{PLAYER_H}pt</span> always
+              </div>
+              <div className="mt-1">
+                Ring in numeral gutter · title = caption left edge
+              </div>
+              <div className="mt-1">Exchange absorbs leftover. Never pays for play.</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Playground */}
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">Playground</h2>
+          <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            Drive the lifecycle. Watch the exchange reflow content while the player
+            chassis stays put — only light and figures change inside the 2U bay.
+          </p>
+
+          <div className="mb-4 flex flex-wrap gap-1.5">
+            {MODES.map((m) => (
+              <button
+                key={m.key}
+                type="button"
+                onClick={() => setMode(m.key)}
+                className="rounded px-2.5 py-1 text-[10px] font-medium tracking-wide transition"
+                style={{
+                  background: m.key === mode ? F.pad : "transparent",
+                  color: m.key === mode ? m.tint : F.ink4,
+                  border: `1px solid ${m.key === mode ? m.tint + "66" : F.line}`,
+                }}
+              >
+                {m.word}
+              </button>
+            ))}
+          </div>
+
+          <div
+            className="rounded-xl p-6"
+            style={{ background: F.page, border: `1px solid ${F.lineSoft}` }}
+          >
+            <div className="mx-auto" style={{ width }}>
+              <LaneColumn
+                mode={mode}
+                meta={meta}
+                messages={messages}
+                pos={livePos}
+                level={liveLevel}
+                volume={volume}
+                speedIx={speedIx}
+                autoplay={autoplay}
+                env={env}
+                phase={livePhase}
+                onSeek={(v) => {
+                  setAnimate(false);
+                  setPos(v);
+                }}
+                onVolume={setVolume}
+                onCycleSpeed={() => setSpeedIx((i) => (i + 1) % 4)}
+                onToggleAuto={() => setAutoplay((a) => !a)}
+                onTogglePlay={() =>
+                  setMode((m) => (m === "speaking" ? "paused" : m === "paused" ? "speaking" : m))
+                }
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 grid max-w-[720px] grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="flex items-center gap-3 text-[11px] text-studio-ink-faint">
+              <span className="w-24 shrink-0">Width</span>
+              <input
+                type="range"
+                min={340}
+                max={560}
+                step={4}
+                value={width}
+                onChange={(e) => setWidth(Number(e.target.value))}
+                className="flex-1 accent-[#74f2ce]"
+              />
+              <span className="w-12 tabular-nums text-right">{width}</span>
+            </label>
+            <label className="flex items-center gap-3 text-[11px] text-studio-ink-faint">
+              <span className="w-24 shrink-0">Position</span>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={pos}
+                onChange={(e) => {
+                  setAnimate(false);
+                  setPos(Number(e.target.value));
+                }}
+                className="flex-1 accent-[#74f2ce]"
+              />
+              <span className="w-12 tabular-nums text-right">{pos.toFixed(2)}</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => setAnimate((a) => !a)}
+              className="rounded px-3 py-1.5 text-[11px] font-medium"
+              style={{
+                border: `1px solid ${animate ? F.line : F.accent}`,
+                color: animate ? F.ink2 : F.accent,
+                background: animate ? "transparent" : F.accent + "18",
+              }}
+            >
+              {animate ? "❚❚ Freeze" : "▶ Animate"}
+            </button>
+          </div>
+        </div>
+
+        {/* Anatomy */}
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">
+            Anatomy of the 2U player
+          </h2>
+          <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            Foot of the lane surface, two rack units. Ring in the identity gutter;
+            status + caption share the text column. Figure is the scrub surface
+            (lit span + thin playhead). Chips for speed / volume / auto. Hairline
+            under exchange is the only seam — not a second card.
+          </p>
+          <div
+            className="overflow-hidden rounded-lg"
+            style={{ background: F.page, border: `1px solid ${F.line}` }}
+          >
+            <div className="grid md:grid-cols-2">
+              <div className="p-5" style={{ borderRight: `1px solid ${F.lineSoft}` }}>
+                <div
+                  className="mb-3 font-mono text-[9px] tracking-[0.16em]"
+                  style={{ color: F.ink4 }}
+                >
+                  UPPER 1U · RADIO
+                </div>
+                <Bullet>Label + duration (always reserved)</Bullet>
+                <Bullet>Waveform / capture / at-rest window — one slot</Bullet>
+                <Bullet>Scrubber — always drawn, lit when narrating</Bullet>
+                <Bullet>Caption — two lines reserved, never reflows the bay</Bullet>
+              </div>
+              <div className="p-5">
+                <div
+                  className="mb-3 font-mono text-[9px] tracking-[0.16em]"
+                  style={{ color: F.ink4 }}
+                >
+                  LOWER 1U · TRANSPORT
+                </div>
+                <Bullet>PLAY / PAUSE key — works at rest when a reply exists</Bullet>
+                <Bullet>State word + detail + work figure</Bullet>
+                <Bullet>DEMO · SPEED · AUTO · VOL — settings cluster</Bullet>
+                <Bullet>Same plate gradient as the radio — one object</Bullet>
+              </div>
+            </div>
+            <div
+              className="px-5 py-3 font-mono text-[10px]"
+              style={{
+                borderTop: `1px solid ${F.lineSoft}`,
+                color: F.ink3,
+                background: F.trace,
+              }}
+            >
+              Exchange is <em style={{ color: F.ink2 }}>not</em> in this chassis. It sits
+              above as its own well — scrollable history, not a player surface.
+            </div>
+          </div>
+        </div>
+
+        {/* State strip */}
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">
+            Same 2U, every state
+          </h2>
+          <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            If two of these rows are different heights, the contract is broken.
+          </p>
+          <div
+            className="space-y-3 rounded-lg p-5"
+            style={{ background: F.page, border: `1px solid ${F.lineSoft}` }}
+          >
+            {MODES.map((m) => (
+              <div key={m.key}>
+                <div
+                  className="mb-1 font-mono text-[9px] tracking-widest"
+                  style={{ color: F.ink4 }}
+                >
+                  {m.key.toUpperCase()} · {PLAYER_H}pt
+                </div>
+                <PlayerConsole
+                  mode={m.key}
+                  meta={m}
+                  pos={m.key === "speaking" || m.key === "paused" ? 0.42 : 0}
+                  level={m.key === "listening" ? 0.7 : 0}
+                  volume={0.8}
+                  speedIx={0}
+                  autoplay
+                  env={env}
+                  phase={
+                    m.key === "transcribing" || m.key === "submitting" || m.key === "listening"
+                      ? livePhase
+                      : 0.35
+                  }
+                  compact
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function StackRow({
+  label,
+  detail,
+  accent,
+  last,
+}: {
+  label: string;
+  detail: string;
+  accent?: boolean;
+  last?: boolean;
+}) {
+  return (
+    <div
+      className="flex items-baseline justify-between gap-3 py-1.5"
+      style={{
+        borderBottom: last ? undefined : `1px solid ${F.lineSoft}`,
+        color: accent ? F.ink : F.ink3,
+      }}
+    >
+      <span style={{ color: accent ? F.accent : F.ink2 }}>{label}</span>
+      <span className="text-right text-[10px]" style={{ color: F.ink4 }}>
+        {detail}
+      </span>
+    </div>
+  );
+}
+
+function Bullet({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-1.5 flex gap-2 text-[12.5px] leading-snug text-studio-ink">
+      <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-studio-ink-faint" />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function LaneColumn({
+  mode,
+  meta,
+  messages,
+  pos,
+  level,
+  volume,
+  speedIx,
+  autoplay,
+  env,
+  phase,
+  onSeek,
+  onVolume,
+  onCycleSpeed,
+  onToggleAuto,
+  onTogglePlay,
+}: {
+  mode: Mode;
+  meta: (typeof MODES)[number];
+  messages: { role: "you" | "agent"; text: string }[];
+  pos: number;
+  level: number;
+  volume: number;
+  speedIx: number;
+  autoplay: boolean;
+  env: number[];
+  phase: number;
+  onSeek: (v: number) => void;
+  onVolume: (v: number) => void;
+  onCycleSpeed: () => void;
+  onToggleAuto: () => void;
+  onTogglePlay: () => void;
+}) {
+  const live =
+    mode === "listening" || mode === "speaking";
+
+  return (
+    <div
+      className="flex flex-col overflow-hidden rounded-[10px]"
+      style={{
+        background: F.panel,
+        border: `1px solid ${live ? meta.tint + "66" : F.line}`,
+        height: 560,
+      }}
+    >
+      {/* Identity — panel head of the same surface */}
+      <div
+        className="flex items-start gap-3 px-3.5 pb-2.5 pt-3"
+        style={{ borderBottom: `1px solid ${F.lineSoft}` }}
+      >
+        <div
+          className="font-mono text-[28px] font-semibold leading-none tabular-nums"
+          style={{ color: F.accent, width: 50 }}
+        >
+          02
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span
+              className="truncate font-mono text-[11px] font-semibold tracking-wide"
+              style={{ color: F.ink }}
+            >
+              USETALKIE.COM
+            </span>
+            <span className="ml-auto flex items-center gap-1.5">
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{
+                  background: meta.tint,
+                  boxShadow:
+                    mode === "listening" || mode === "speaking"
+                      ? `0 0 6px ${meta.tint}`
+                      : undefined,
+                }}
+              />
+              <span
+                className="font-mono text-[7px] font-bold tracking-[0.14em]"
+                style={{ color: meta.tint }}
+              >
+                {meta.word === "READY" ? "ACTIVE LANE" : meta.word}
+              </span>
+            </span>
+          </div>
+          <div className="mt-1 flex gap-2 font-mono text-[7.5px]" style={{ color: F.ink3 }}>
+            <span>main</span>
+            <span style={{ color: F.ink4 }}>5A83404D</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Ledger — role in numeral gutter, body on project-name / TURN rail */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-hidden px-3.5 py-2.5">
+          {messages.length === 0 ? (
+            <p
+              className="font-mono text-[9px] leading-relaxed"
+              style={{ color: F.ink3, paddingLeft: 50 + 12 }}
+            >
+              Check unmerged checkout changes
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {messages.map((m, i) => (
+                <div key={i} className="flex items-start gap-3">
+                  <div
+                    className="shrink-0 font-mono text-[6.5px] font-bold tracking-[0.09em]"
+                    style={{ width: 50, color: F.ink4 }}
+                  >
+                    {m.role === "you" ? "YOU" : "AGENT"}
+                  </div>
+                  <p
+                    className="min-w-0 flex-1 font-mono text-[9px] leading-snug"
+                    style={{ color: m.role === "agent" ? F.ink2 : F.ink3 }}
+                  >
+                    {m.text}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* PLAYER — plate foot of the same surface (no gap, no second card) */}
+      <PlayerConsole
+        mode={mode}
+        meta={meta}
+        pos={pos}
+        level={level}
+        volume={volume}
+        speedIx={speedIx}
+        autoplay={autoplay}
+        env={env}
+        phase={phase}
+        embedded
+        onSeek={onSeek}
+        onVolume={onVolume}
+        onCycleSpeed={onCycleSpeed}
+        onToggleAuto={onToggleAuto}
+        onTogglePlay={onTogglePlay}
+      />
+    </div>
+  );
+}
+
+function PlayerConsole({
+  mode,
+  meta,
+  pos,
+  level,
+  volume,
+  speedIx,
+  autoplay,
+  env,
+  phase = 0,
+  compact,
+  embedded,
+  onSeek,
+  onVolume,
+  onCycleSpeed,
+  onToggleAuto,
+  onTogglePlay,
+}: {
+  mode: Mode;
+  meta: (typeof MODES)[number];
+  pos: number;
+  level: number;
+  volume: number;
+  speedIx: number;
+  autoplay: boolean;
+  env: number[];
+  phase?: number;
+  compact?: boolean;
+  /** Foot of the lane surface — plate fill, hairline top, gutter-aligned. */
+  embedded?: boolean;
+  onSeek?: (v: number) => void;
+  onVolume?: (v: number) => void;
+  onCycleSpeed?: () => void;
+  onToggleAuto?: () => void;
+  onTogglePlay?: () => void;
+}) {
+  const narrating = mode === "speaking" || mode === "paused";
+  const live = mode === "listening";
+  const working = mode === "transcribing" || mode === "submitting";
+  const tint = meta.tint;
+  // Shared rail with identity numeral / ledger roles / player ring
+  const gutter = embedded ? 50 : 60;
+  const ring = embedded ? 48 : 56;
+  const gap = embedded ? 12 : 14;
+  const edge = 14;
+  const headInset = gutter + gap;
+  const restLabel =
+    mode === "ready" ? "READY" : mode === "paused" ? "AT REST" : "NO AUDIO";
+
+  // Face layout matches DeckPlayerConsole:
+  // head (status·caption) · transport band (ring + figure same H) · chips on floor
+  return (
+    <div
+      className="flex flex-col overflow-hidden"
+      style={{
+        height: PLAYER_H,
+        background: `linear-gradient(${F.plateTop}, ${F.plateBottom})`,
+        borderRadius: embedded ? 0 : 9,
+        border: embedded
+          ? undefined
+          : `1px solid ${live || mode === "speaking" ? tint + "4d" : F.line}`,
+        borderTop: embedded
+          ? `1px solid ${live || mode === "speaking" ? tint + "66" : F.lineSoft}`
+          : undefined,
+        paddingTop: embedded ? 10 : 12,
+        paddingBottom: embedded ? 9 : 11,
+        paddingLeft: edge,
+        paddingRight: edge,
+        boxSizing: "border-box",
+      }}
+    >
+      {/* Head — a bit lower so it balances the plate; indented to figure edge */}
+      <div style={{ paddingLeft: headInset }}>
+        <div
+          className="flex items-center gap-1.5 font-mono"
+          style={{
+            height: 12,
+            fontSize: 9.5,
+            fontWeight: 600,
+            letterSpacing: "0.05em",
+            color: mode === "ready" ? F.ink2 : tint,
+          }}
+        >
+          <span>{mode === "ready" || narrating || working || live ? "TURN 14" : meta.detail}</span>
+          <span style={{ color: F.ink4, opacity: 0.65 }}>·</span>
+          <span style={{ color: mode === "ready" ? F.ink2 : tint }}>{meta.word}</span>
+          {mode === "speaking" && (
+            <span
+              className="inline-block h-1 w-1 shrink-0 rounded-full"
+              style={{ background: F.accent }}
+            />
+          )}
+        </div>
+        <div
+          className="truncate"
+          style={{
+            marginTop: 2,
+            height: embedded ? 20 : 22,
+            fontSize: 12,
+            lineHeight: 1.35,
+            color: F.ink,
+          }}
+        >
+          {narrating || mode === "ready"
+            ? AGENT
+            : live
+              ? "Listening…"
+              : working
+                ? "Working…"
+                : ""}
+        </div>
+      </div>
+
+      {/* Free space mostly above transport — ring + bay a touch lower */}
+      <div style={{ flex: "1 1 8px", minHeight: 8 }} />
+
+      {/* Transport band — ring + figure same height; tape clock under bay only */}
+      <div>
+        <div className="flex items-center" style={{ gap }}>
+          <div
+            className="flex shrink-0 items-center justify-center"
+            style={{ width: gutter, height: ring }}
+          >
+            <button
+              type="button"
+              onClick={onTogglePlay}
+              className="relative flex items-center justify-center rounded-full"
+              style={{
+                width: ring,
+                height: ring,
+                background: F.trace,
+                border: `2px solid ${F.line}`,
+                color: narrating || mode === "ready" ? F.accent : F.ink3,
+              }}
+            >
+              {narrating && (
+                <span
+                  className="pointer-events-none absolute inset-0 rounded-full"
+                  style={{
+                    border: `2px solid ${tint}`,
+                    clipPath: `inset(0 ${100 - pos * 100}% 0 0)`,
+                    opacity: 0.9,
+                  }}
+                />
+              )}
+              <span style={{ fontSize: ring * 0.3, position: "relative" }}>
+                {mode === "speaking" ? "❚❚" : "▶"}
+              </span>
+            </button>
+          </div>
+
+          <div
+            className="relative min-w-0 flex-1"
+            style={{
+              height: ring,
+              borderRadius: 6,
+              background: F.trace,
+              border: `1px solid ${F.line}`,
+              cursor: narrating || mode === "ready" ? "pointer" : "default",
+            }}
+            onClick={(e) => {
+              if (!onSeek || !(narrating || mode === "ready")) return;
+              const r = e.currentTarget.getBoundingClientRect();
+              onSeek(Math.min(1, Math.max(0, (e.clientX - r.left) / r.width)));
+            }}
+          >
+            <div className="absolute inset-0 px-2 py-1.5">
+              {mode === "ready" ? (
+                <RestField label="READY" silhouette />
+              ) : mode === "listening" ||
+                mode === "speaking" ||
+                mode === "paused" ||
+                mode === "transcribing" ||
+                mode === "submitting" ? (
+                <RadioFigure
+                  mode={mode}
+                  env={env}
+                  pos={pos}
+                  level={level}
+                  phase={phase}
+                  tint={tint}
+                />
+              ) : (
+                <RestField label={restLabel} />
+              )}
+            </div>
+            {narrating && (
+              <span
+                className="pointer-events-none absolute top-1.5 bottom-1.5 w-[1.5px] rounded-full"
+                style={{
+                  left: `${pos * 100}%`,
+                  background: mode === "paused" ? F.ink2 : tint,
+                  transform: "translateX(-50%)",
+                }}
+              />
+            )}
+          </div>
+        </div>
+        {/* Tape clock under the bay: 0:00 · current · total — not under the ring */}
+        {(mode === "ready" || narrating) && (
+          <div
+            className="relative font-mono tabular-nums"
+            style={{
+              marginTop: 4,
+              marginLeft: gutter + gap,
+              fontSize: 9,
+              color: F.ink4,
+            }}
+          >
+            <div className="flex justify-between">
+              <span>0:00</span>
+              <span>0:04</span>
+            </div>
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              style={{ color: narrating ? F.ink2 : F.ink3 }}
+            >
+              {narrating ? clock(pos) : "0:00"}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div style={{ flex: "0 0 8px", minHeight: 4, maxHeight: 10 }} />
+
+      {/* Chips on the floor of the plate */}
+      <div className="flex items-center gap-1.5" style={{ height: 22 }}>
+        <button type="button" onClick={onCycleSpeed} className="appearance-none">
+          <Chip>
+            <span className="font-mono text-[10px]" style={{ color: F.ink3 }}>
+              {["1.00×", "1.25×", "1.50×", "0.75×"][speedIx]}
+            </span>
+          </Chip>
+        </button>
+        <Chip>
+          <span className="font-mono text-[10px]" style={{ color: F.ink4, opacity: 0.55 }}>
+            VOL
+          </span>
+          <span
+            className="ml-1.5 inline-block h-[2.5px] w-[26px] rounded-full"
+            style={{ background: F.line }}
+            onPointerDown={(e) => {
+              if (!onVolume) return;
+              const el = e.currentTarget;
+              const move = (ev: PointerEvent) => {
+                const r = el.getBoundingClientRect();
+                onVolume(Math.min(1, Math.max(0, (ev.clientX - r.left) / r.width)));
+              };
+              move(e.nativeEvent);
+              const up = () => {
+                window.removeEventListener("pointermove", move);
+                window.removeEventListener("pointerup", up);
+              };
+              window.addEventListener("pointermove", move);
+              window.addEventListener("pointerup", up);
+            }}
+          >
+            <span
+              className="block h-full rounded-full"
+              style={{ width: `${volume * 100}%`, background: F.ink3 }}
+            />
+          </span>
+        </Chip>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={onToggleAuto}
+          className="rounded px-2 py-0.5 font-mono text-[9.5px] font-semibold tracking-wide"
+          style={{
+            background: autoplay ? F.amber + "1f" : F.pad,
+            border: `1px solid ${autoplay ? F.amber + "66" : F.line}`,
+            color: autoplay ? F.amber : F.ink4,
+          }}
+        >
+          {autoplay ? "AUTOPLAY ON" : "AUTOPLAY OFF"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Chip({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      className="inline-flex items-center rounded px-1.5 py-0.5"
+      style={{
+        background: F.pad,
+        border: `1px solid ${F.line}`,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Integer px for stable SSR hydration. */
+function px(n: number) {
+  return Math.max(2, Math.round(n));
+}
+
+/** Two-decimal opacity — avoids 0.1800000001 vs "0.18" hydrate fights. */
+function op(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Bar stroke — nearly rectangular. rounded-full on a tall thin bar becomes a
+ * pill/dot; 1px radius keeps the meter-bar read without soft balloons.
+ */
+const BAR_RADIUS = 1;
+
+/**
+ * Radio figure genres — every one paints the full width of the slot.
+ * No quarter-width lodgers, no orphan slices.
+ */
+function RadioFigure({
+  mode,
+  env,
+  pos,
+  level,
+  phase,
+  tint,
+}: {
+  mode: Mode;
+  env: number[];
+  pos: number;
+  level: number;
+  phase: number;
+  tint: string;
+}) {
+  switch (mode) {
+    case "speaking":
+    case "paused":
+      return <PlaybackWave env={env} pos={pos} tint={mode === "paused" ? F.ink3 : F.accent} />;
+    case "listening":
+      return <CaptureWave level={level} phase={phase} />;
+    case "transcribing":
+    case "submitting":
+      return <ActivityField tint={tint} phase={phase} kind={mode === "transcribing" ? "sweep" : "pulse"} />;
+    default:
+      return <RestField />;
+  }
+}
+
+/** One vertical meter stroke — thin tall rectangle, not a capsule. */
+function Bar({
+  height,
+  color,
+  opacity,
+}: {
+  height: number;
+  color: string;
+  opacity: number;
+}) {
+  return (
+    <div className="flex flex-1 items-center justify-center" style={{ height: "100%", minWidth: 0 }}>
+      <div
+        style={{
+          // Fill most of the column so dense packs read continuous, not dotted.
+          width: "85%",
+          maxWidth: 2,
+          height,
+          borderRadius: BAR_RADIUS,
+          background: color,
+          opacity: op(opacity),
+        }}
+      />
+    </div>
+  );
+}
+
+/** Playback: full silhouette of the file + played span lit + playhead. */
+function PlaybackWave({ env, pos, tint }: { env: number[]; pos: number; tint: string }) {
+  const n = env.length;
+  const head = Math.min(n - 1, Math.floor(pos * n));
+  const left = `${(Math.round(pos * 1000) / 10).toFixed(1)}%`;
+  return (
+    <div className="relative flex h-full w-full items-center">
+      <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+        {env.map((v, i) => {
+          const played = i <= head;
+          return (
+            <Bar
+              key={i}
+              height={px(v * 28)}
+              color={played ? tint : F.line}
+              opacity={played ? 0.95 : 0.3}
+            />
+          );
+        })}
+      </div>
+      <div
+        className="pointer-events-none absolute top-0 bottom-0"
+        style={{
+          left,
+          width: 1,
+          background: tint,
+          boxShadow: `0 0 5px ${tint}`,
+          opacity: 0.95,
+        }}
+      />
+    </div>
+  );
+}
+
+/**
+ * Capture: dense rectangular strokes across the full width.
+ * Phase rolls the field so silence still scrolls (tape, not a freeze).
+ */
+function CaptureWave({ level, phase }: { level: number; phase: number }) {
+  const bars = 88;
+  // Quantize phase so the ladder is stable and not float-noisy.
+  const drift = (Math.round(phase * 100) / 100) * Math.PI * 2;
+  const heights = Array.from({ length: bars }, (_, i) => {
+    const t = i / bars;
+    const speech =
+      Math.abs(Math.sin(t * 14 + drift * 1.7)) * 0.45 +
+      Math.abs(Math.sin(t * 31 + drift * 2.3)) * 0.3 +
+      Math.abs(Math.sin(t * 53 - drift)) * 0.2;
+    const window = Math.sin(t * Math.PI);
+    const v = level * speech * (0.55 + window * 0.45);
+    return { h: px(Math.max(2, v * 28)), hot: v > 0.06 };
+  });
+  return (
+    <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+      {heights.map((bar, i) => (
+        <Bar key={i} height={bar.h} color={F.accent} opacity={bar.hot ? 0.92 : 0.14} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Working activity — the whole field is the figure.
+ * Sweep: full-width sheen travels edge to edge.
+ * Pulse: full-width amplitude breathes.
+ */
+function ActivityField({
+  tint,
+  phase,
+  kind,
+}: {
+  tint: string;
+  phase: number;
+  kind: "sweep" | "pulse";
+}) {
+  const bars = 80;
+  const p = Math.round(phase * 100) / 100;
+
+  if (kind === "pulse") {
+    const amp = 0.35 + Math.abs(Math.sin(p * Math.PI * 2)) * 0.55;
+    return (
+      <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+        {Array.from({ length: bars }, (_, i) => {
+          const t = i / bars;
+          const hump = Math.sin(t * Math.PI);
+          return (
+            <Bar
+              key={i}
+              height={px(2 + hump * amp * 26)}
+              color={tint}
+              opacity={op(0.25 + hump * 0.55)}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+      {Array.from({ length: bars }, (_, i) => {
+        const t = i / (bars - 1);
+        const d = Math.min(Math.abs(t - p), 1 - Math.abs(t - p));
+        const lobe = Math.max(0, 1 - d * 2.4);
+        return (
+          <Bar
+            key={i}
+            height={px(3 + lobe * 24)}
+            color={tint}
+            opacity={op(0.18 + lobe * 0.78)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Zero-state bay — same height as the transport ring.
+ * Ready: faint speech ghost. Empty: labelled baseline (not a failed graph).
+ */
+function RestField({
+  label = "AT REST",
+  silhouette = false,
+}: {
+  label?: string;
+  silhouette?: boolean;
+}) {
+  const n = 64;
+  return (
+    <div className="relative flex h-full w-full items-center justify-center">
+      {silhouette ? (
+        <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+          {Array.from({ length: n }, (_, i) => {
+            const t = i / (n - 1);
+            const phrase = Math.abs(Math.sin(t * Math.PI * 3.2));
+            const formant =
+              Math.abs(Math.sin(t * 47)) * 0.35 + Math.abs(Math.sin(t * 19)) * 0.25;
+            const breath = phrase > 0.12 ? 1 : 0.08;
+            const v = Math.min(1, Math.max(0.06, (phrase * 0.55 + formant) * breath));
+            return (
+              <Bar
+                key={i}
+                height={px(2 + v * 22)}
+                color={F.line}
+                opacity={op(0.28 + v * 0.22)}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mx-1 h-px w-full" style={{ background: F.lineSoft }} />
+      )}
+      <span
+        className="pointer-events-none absolute font-mono text-[8px] font-semibold tracking-[0.14em]"
+        style={{
+          color: F.ink4,
+          background: F.trace,
+          padding: "2px 8px",
+          borderRadius: 999,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/** Wall-clock phase — no per-frame setState of the phase value itself. */
+function useAnimationPhase(running: boolean, speed: number) {
+  const originRef = useRef<number | null>(null);
+  const [, setBeat] = useState(0);
+
+  useEffect(() => {
+    if (!running) {
+      originRef.current = null;
+      return;
+    }
+    originRef.current = performance.now();
+    const id = window.setInterval(() => setBeat((n) => (n + 1) % 1_000_000), 80);
+    return () => window.clearInterval(id);
+  }, [running, speed]);
+
+  if (!running || originRef.current == null) return 0;
+  const elapsed = (performance.now() - originRef.current) / 1000;
+  return (elapsed * 0.28 * speed) % 1;
+}

--- a/design/studio/src/studio/MicroDeckFullMock.tsx
+++ b/design/studio/src/studio/MicroDeckFullMock.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Activity,
+  ClipboardCopy,
+  ClipboardPaste,
+  Diff,
+  Grid3x3,
+  ListChecks,
+  MessageSquareText,
+  Mic,
+  Play,
+  Redo2,
+  RefreshCw,
+  Scissors,
+  Square,
+  X,
+} from "lucide-react";
+
+/**
+ * Full Micro Deck shell — fidelity to shipping iPad pad + picker.
+ * Premium craft is in proportion, type, and tokens — not a different product.
+ */
+
+export type FullMockTokens = {
+  page: string;
+  panel: string;
+  panelHead: string;
+  cell: string;
+  line: string;
+  lineSoft: string;
+  ink: string;
+  ink2: string;
+  ink3: string;
+  ink4: string;
+  accent: string;
+  accentDim: string;
+  amber: string;
+  pad: string;
+  padBottom: string;
+  plate: string;
+  plateTop: string;
+  plateBottom: string;
+  micTop: string;
+  micBottom: string;
+  empty: string;
+};
+
+export type FullMockMode =
+  | "ready"
+  | "listening"
+  | "transcribing"
+  | "submitting"
+  | "speaking"
+  | "paused";
+
+export type FullMockLane = {
+  index: number;
+  name: string;
+  task: string;
+  state: "active" | "armed" | "idle";
+};
+
+const DEFAULT_LANES: FullMockLane[] = [
+  { index: 0, name: "linea", task: "ask/graduate-to-the-sidebar · 1d ago", state: "active" },
+  { index: 1, name: "usetalkie.com", task: "main · 6h ago", state: "armed" },
+  { index: 2, name: "speakeasy", task: "codex/bounded-task-tail · 3d ago", state: "armed" },
+  { index: 3, name: "LANE 4", task: "codex thread", state: "armed" },
+  { index: 4, name: "Codex", task: "final bundle works · 6d ago", state: "armed" },
+];
+
+const PAD_ROWS: { label: string; caption: string; Icon: LucideIcon }[][] = [
+  [
+    { label: "STATUS", caption: "SAY", Icon: MessageSquareText },
+    { label: "GO", caption: "SAY", Icon: Play },
+    { label: "TESTS", caption: "SAY", Icon: ListChecks },
+    { label: "ESC", caption: "CANCEL", Icon: X },
+  ],
+  [
+    { label: "CUT", caption: "IN", Icon: Scissors },
+    { label: "DIFF", caption: "SAY", Icon: Diff },
+    { label: "COPY", caption: "CLIP", Icon: ClipboardCopy },
+    { label: "PASTE", caption: "SEND", Icon: ClipboardPaste },
+  ],
+  [
+    { label: "REPLAY", caption: "LAST", Icon: Redo2 },
+    { label: "STOP", caption: "AUDIO", Icon: Square },
+    { label: "AUTO", caption: "PLAY", Icon: RefreshCw },
+    { label: "ACTIVITY", caption: "LOG", Icon: Activity },
+  ],
+];
+
+const MONO =
+  'ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace';
+const UI =
+  'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+function rgba(hex: string, a: number) {
+  const h = hex.replace("#", "");
+  const full =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  const n = parseInt(full, 16);
+  if (Number.isNaN(n)) return `rgba(0,0,0,${a})`;
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+}
+
+export function MicroDeckFullMock({
+  tokens: t,
+  mode = "speaking",
+  lanes = DEFAULT_LANES,
+  handWidth = 320,
+  consoleWidth = 400,
+  height = 620,
+  children,
+  style,
+}: {
+  tokens: FullMockTokens;
+  mode?: FullMockMode;
+  lanes?: FullMockLane[];
+  handWidth?: number;
+  consoleWidth?: number;
+  height?: number;
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  const holdLabel =
+    mode === "listening"
+      ? "LISTENING…"
+      : mode === "transcribing"
+        ? "TRANSCRIBING…"
+        : mode === "submitting"
+          ? "WORKING…"
+          : "HOLD TO SPEAK";
+
+  return (
+    <div
+      className="flex overflow-hidden"
+      style={{
+        fontFamily: UI,
+        background: t.page,
+        border: `1px solid ${t.line}`,
+        borderRadius: 14,
+        height,
+        minWidth: handWidth + consoleWidth + 28,
+        boxShadow: `0 32px 64px ${rgba("#000000", 0.28)}`,
+        ...style,
+      }}
+    >
+      <div
+        className="flex shrink-0 flex-col gap-[7px] p-2.5"
+        style={{
+          width: handWidth,
+          borderRight: `1px solid ${t.lineSoft}`,
+          background: t.page,
+        }}
+      >
+        <LanePicker tokens={t} lanes={lanes} />
+        <PadBank tokens={t} />
+        <div className="grid grid-cols-4 gap-[7px]">
+          <HoldKey tokens={t} label={holdLabel} live={mode === "listening"} />
+          <PadKey tokens={t} label="LANES" caption="BIND" Icon={Grid3x3} />
+        </div>
+      </div>
+
+      <div className="min-h-0 min-w-0 flex-1 p-2.5" style={{ maxWidth: consoleWidth + 20 }}>
+        <div className="h-full min-h-0">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function LanePicker({
+  tokens: t,
+  lanes,
+}: {
+  tokens: FullMockTokens;
+  lanes: FullMockLane[];
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-[6px] overflow-auto">
+      {lanes.map((lane) => {
+        const selected = lane.state === "active";
+        return (
+          <div
+            key={lane.index}
+            className="flex items-center gap-2.5 px-2.5 py-[9px]"
+            style={{
+              borderRadius: 8,
+              background: selected ? rgba(t.accent, 0.1) : t.cell,
+              border: `1px solid ${selected ? rgba(t.accent, 0.45) : t.lineSoft}`,
+            }}
+          >
+            <span
+              style={{
+                fontFamily: MONO,
+                width: 28,
+                fontSize: 17,
+                fontWeight: 600,
+                letterSpacing: "-0.03em",
+                color: selected ? t.accent : t.ink3,
+                fontVariantNumeric: "tabular-nums",
+                lineHeight: 1,
+              }}
+            >
+              {String(lane.index + 1).padStart(2, "0")}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <span
+                  className="truncate"
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    letterSpacing: "0.02em",
+                    color: selected ? t.ink : t.ink2,
+                  }}
+                >
+                  {lane.name}
+                </span>
+                <span
+                  className="ml-auto shrink-0 rounded px-1.5 py-px"
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: 7.5,
+                    fontWeight: 700,
+                    letterSpacing: "0.1em",
+                    color: selected ? t.accent : t.ink4,
+                    border: `1px solid ${selected ? rgba(t.accent, 0.4) : t.lineSoft}`,
+                    background: selected ? rgba(t.accent, 0.08) : "transparent",
+                  }}
+                >
+                  {selected ? "ACTIVE" : lane.state === "armed" ? "ARMED" : "IDLE"}
+                </span>
+              </div>
+              <div
+                className="mt-0.5 truncate"
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 8.5,
+                  fontWeight: 500,
+                  color: t.ink4,
+                }}
+              >
+                {lane.task}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function PadBank({ tokens: t }: { tokens: FullMockTokens }) {
+  return (
+    <div className="flex flex-col gap-[7px]">
+      {PAD_ROWS.map((row, ri) => (
+        <div key={ri} className="grid grid-cols-4 gap-[7px]">
+          {row.map((key) => (
+            <PadKey
+              key={key.label}
+              tokens={t}
+              label={key.label}
+              caption={key.caption}
+              Icon={key.Icon}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PadKey({
+  tokens: t,
+  label,
+  caption,
+  Icon,
+}: {
+  tokens: FullMockTokens;
+  label: string;
+  caption: string;
+  Icon: LucideIcon;
+}) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center"
+      style={{
+        height: 58,
+        borderRadius: 8,
+        background: `linear-gradient(180deg, ${t.pad} 0%, ${t.padBottom} 100%)`,
+        border: `1px solid ${t.line}`,
+        boxShadow: `inset 0 1px 0 ${rgba("#ffffff", 0.045)}`,
+      }}
+    >
+      <Icon size={12} strokeWidth={2} style={{ color: t.ink2, marginBottom: 3 }} />
+      <span
+        style={{
+          fontFamily: MONO,
+          fontSize: 8.5,
+          fontWeight: 600,
+          letterSpacing: "0.06em",
+          color: t.ink,
+          lineHeight: 1.1,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontFamily: MONO,
+          fontSize: 6.5,
+          fontWeight: 500,
+          letterSpacing: "0.08em",
+          color: t.ink4,
+          marginTop: 2,
+        }}
+      >
+        {caption}
+      </span>
+    </div>
+  );
+}
+
+function HoldKey({
+  tokens: t,
+  label,
+  live,
+}: {
+  tokens: FullMockTokens;
+  label: string;
+  live: boolean;
+}) {
+  return (
+    <div
+      className="col-span-3 flex items-center gap-3 px-3.5"
+      style={{
+        height: 58,
+        borderRadius: 10,
+        background: `linear-gradient(180deg, ${t.micTop}, ${t.micBottom})`,
+        border: `1.5px solid ${t.accentDim}`,
+        boxShadow: live
+          ? `0 0 0 1px ${rgba(t.accent, 0.25)}, 0 0 20px ${rgba(t.accent, 0.2)}`
+          : `inset 0 1px 0 ${rgba("#ffffff", 0.1)}`,
+      }}
+    >
+      <div
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+        style={{
+          background: rgba("#000000", 0.25),
+          border: `1.5px solid ${rgba("#ffffff", 0.15)}`,
+        }}
+      >
+        <Mic size={13} strokeWidth={2.25} color="#fff" />
+      </div>
+      <span
+        style={{
+          fontFamily: MONO,
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: "0.14em",
+          color: "#fff",
+        }}
+      >
+        {label}
+      </span>
+      {live && (
+        <span className="ml-auto flex items-end gap-[3px]">
+          {[0.35, 0.75, 0.5, 0.95, 0.4].map((h, i) => (
+            <span
+              key={i}
+              className="rounded-full"
+              style={{
+                width: 2.5,
+                height: 5 + h * 11,
+                background: rgba("#ffffff", 0.9),
+              }}
+            />
+          ))}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/design/studio/src/studio/MicroThemesKimiStudy.tsx
+++ b/design/studio/src/studio/MicroThemesKimiStudy.tsx
@@ -1,0 +1,1717 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import { PageHeader } from "@/studio/PageHeader";
+import { MicroDeckFullMock } from "@/studio/MicroDeckFullMock";
+import type { StudioAppPage } from "@/studio/studioRegistry";
+
+/**
+ * Micro themes · Kimi — material studies for the Micro Deck lane column.
+ *
+ * Same ledger geometry as LaneConsoleStudy (50pt gutter, text rail at 76,
+ * fused player foot, tape clock under bay, chips on floor). What changes is
+ * the material each theme is made of: brushed anodized graphite (flight),
+ * phosphor terminal glass (obsidian), kiln-fired stoneware (ceramic),
+ * glazed porcelain (porcelain), bakelite + vacuum tube (amber). Every token
+ * is editable, material presets re-seed, export matches DeckThemePalette.
+ */
+
+// ---------------------------------------------------------------------------
+// Tokens — exact DeckThemePalette field names (deck/ipad/Sources/DeckTheme.swift)
+// ---------------------------------------------------------------------------
+
+const TOKEN_KEYS = [
+  "page", "panel", "panelHead", "cell", "trace", "line", "lineSoft",
+  "ink", "ink2", "ink3", "ink4",
+  "accent", "accentDim", "accentDark", "accentEdge", "amber",
+  "plate", "plateTop", "plateBottom",
+  "pad", "padBottom", "empty", "micTop", "micBottom",
+] as const;
+
+type TokenKey = (typeof TOKEN_KEYS)[number];
+type Palette = Record<TokenKey, string>;
+
+const TOKEN_GROUPS: { label: string; keys: TokenKey[] }[] = [
+  { label: "Chassis", keys: ["page", "panel", "panelHead", "cell", "trace", "line", "lineSoft"] },
+  { label: "Ink", keys: ["ink", "ink2", "ink3", "ink4"] },
+  { label: "Signal", keys: ["accent", "accentDim", "accentDark", "accentEdge", "amber"] },
+  { label: "Plate", keys: ["plate", "plateTop", "plateBottom"] },
+  { label: "Pad", keys: ["pad", "padBottom", "empty"] },
+  { label: "Mic", keys: ["micTop", "micBottom"] },
+];
+
+// ---------------------------------------------------------------------------
+// Material skin — texture + lighting descriptor layered over the token set
+// ---------------------------------------------------------------------------
+
+type TextureKind = "none" | "brushed" | "carbon" | "scanlines" | "glaze" | "grain";
+
+interface Skin {
+  name: string;
+  blurb: string;
+  chassisTex: TextureKind;
+  plateTex: TextureKind;
+  bayTex: TextureKind;
+  /** Top-light sheen 0..1 (gloss). */
+  sheen: number;
+  /** Rim highlight strength 0..1. */
+  rim: number;
+  /** Texture visibility 0..1. */
+  tex: number;
+  /** Translucent refractive surface. */
+  glass: boolean;
+}
+
+interface Preset {
+  id: string;
+  name: string;
+  skin: Skin;
+  tokens: Palette;
+}
+
+type ThemeId = "flight" | "obsidian" | "ceramic" | "porcelain" | "amber";
+
+interface ThemeDef {
+  id: ThemeId;
+  name: string;
+  thesis: string;
+  scheme: "dark" | "light";
+  presets: Preset[];
+}
+
+// ---------------------------------------------------------------------------
+// Palettes — seeded from DeckTheme.swift, re-voiced per material preset
+// ---------------------------------------------------------------------------
+
+const SKIN = {
+  anodized: { name: "Anodized graphite", blurb: "Brushed vertical grain, machined top light, mint LED only where live.", chassisTex: "brushed", plateTex: "brushed", bayTex: "none", sheen: 0.45, rim: 0.4, tex: 0.8, glass: false } as Skin,
+  carbon: { name: "Carbon weave", blurb: "Cross-laid composite chassis, dead-matte plate, tight mint trace.", chassisTex: "carbon", plateTex: "carbon", bayTex: "none", sheen: 0.15, rim: 0.25, tex: 0.9, glass: false } as Skin,
+  glassMint: { name: "Liquid glass mint", blurb: "Refractive smoked glass over the void, mint signal glowing through.", chassisTex: "glaze", plateTex: "glaze", bayTex: "none", sheen: 1, rim: 0.85, tex: 0.7, glass: true } as Skin,
+  phosphor: { name: "Phosphor terminal", blurb: "CRT bench console — scanline bay, cool blue phosphor, amber standby lamp.", chassisTex: "none", plateTex: "scanlines", bayTex: "scanlines", sheen: 0.3, rim: 0.3, tex: 0.75, glass: false } as Skin,
+  labSteel: { name: "Lab steel", blurb: "Bead-blasted instrument steel, engraved hairlines, chilled blue readouts.", chassisTex: "brushed", plateTex: "brushed", bayTex: "none", sheen: 0.6, rim: 0.55, tex: 0.55, glass: false } as Skin,
+  glassCobalt: { name: "Liquid glass cobalt", blurb: "Deep cobalt glass laminate, signal suspended inside the pane.", chassisTex: "glaze", plateTex: "glaze", bayTex: "none", sheen: 1, rim: 0.9, tex: 0.7, glass: true } as Skin,
+  stoneware: { name: "Kiln stoneware", blurb: "Fired clay body, mineral grain, iron-oxide stamp for signal.", chassisTex: "grain", plateTex: "grain", bayTex: "none", sheen: 0.2, rim: 0.2, tex: 0.8, glass: false } as Skin,
+  terracotta: { name: "Terracotta glaze", blurb: "Deeper clay dip with a glossy fired rim and warm oxide accent.", chassisTex: "glaze", plateTex: "glaze", bayTex: "none", sheen: 0.7, rim: 0.45, tex: 0.6, glass: false } as Skin,
+  bonePaper: { name: "Bone laminate", blurb: "Matte paper-laminate console, printed hairlines, flat daylight.", chassisTex: "none", plateTex: "none", bayTex: "none", sheen: 0.05, rim: 0.1, tex: 0, glass: false } as Skin,
+  glossPorcelain: { name: "Gloss porcelain", blurb: "High-fire white glaze, refractive top light, celadon ink signal.", chassisTex: "glaze", plateTex: "glaze", bayTex: "none", sheen: 0.95, rim: 0.6, tex: 0.65, glass: false } as Skin,
+  celadon: { name: "Celadon glaze", blurb: "Green-grey celadon wash over white, pooled glaze in the wells.", chassisTex: "glaze", plateTex: "glaze", bayTex: "none", sheen: 0.8, rim: 0.5, tex: 0.7, glass: false } as Skin,
+  bisque: { name: "Bisque matte", blurb: "Unfired matte porcelain, chalky grain, graphite pencil hairlines.", chassisTex: "grain", plateTex: "grain", bayTex: "none", sheen: 0.1, rim: 0.15, tex: 0.6, glass: false } as Skin,
+  bakelite: { name: "Bakelite tube amp", blurb: "Phenolic bakelite chassis, tube-glow signal, brass-lit hairlines.", chassisTex: "grain", plateTex: "grain", bayTex: "none", sheen: 0.3, rim: 0.35, tex: 0.85, glass: false } as Skin,
+  brass: { name: "Brass instrument", blurb: "Lacquered brass plate, horizontal brushing, hot filament accent.", chassisTex: "brushed", plateTex: "brushed", bayTex: "none", sheen: 0.65, rim: 0.6, tex: 0.7, glass: false } as Skin,
+  smokedGlass: { name: "Smoked glass", blurb: "Amber smoked glass over tube light, signal burning underneath.", chassisTex: "glaze", plateTex: "glaze", bayTex: "none", sheen: 1, rim: 0.8, tex: 0.65, glass: true } as Skin,
+};
+
+const THEMES: ThemeDef[] = [
+  {
+    id: "flight",
+    name: "Flight",
+    thesis: "Machined anodized graphite — brushed metal chassis, mint phosphor only where the circuit is live.",
+    scheme: "dark",
+    presets: [
+      {
+        id: "anodized", name: "Anodized graphite", skin: SKIN.anodized,
+        tokens: {
+          page: "#07090C", panel: "#10161B", panelHead: "#141A20", cell: "#1A222A", trace: "#06080A",
+          line: "#2A333C", lineSoft: "#1A2229",
+          ink: "#F1F4F6", ink2: "#A8B2BB", ink3: "#6A7580", ink4: "#4A5460",
+          accent: "#5EE9C2", accentDim: "#3AB894", accentDark: "#0A1F1A", accentEdge: "#1C4F42", amber: "#E0A83F",
+          plate: "#0A0E12", plateTop: "#141A20", plateBottom: "#0A0E12",
+          pad: "#1A222A", padBottom: "#0F1419", empty: "#06080A", micTop: "#14A07A", micBottom: "#0A6B50",
+        },
+      },
+      {
+        id: "carbon", name: "Carbon weave", skin: SKIN.carbon,
+        tokens: {
+          page: "#050708", panel: "#0B0F12", panelHead: "#0F1418", cell: "#141B20", trace: "#040608",
+          line: "#232C33", lineSoft: "#151C21",
+          ink: "#EDF2F2", ink2: "#9AA8AC", ink3: "#5E6C72", ink4: "#414D52",
+          accent: "#6FF5C8", accentDim: "#3DB18C", accentDark: "#08201A", accentEdge: "#17493C", amber: "#DDA63E",
+          plate: "#080B0D", plateTop: "#10151A", plateBottom: "#07090B",
+          pad: "#141B20", padBottom: "#0C1014", empty: "#040608", micTop: "#12A077", micBottom: "#09604A",
+        },
+      },
+      {
+        id: "glass-mint", name: "Liquid glass mint", skin: SKIN.glassMint,
+        tokens: {
+          page: "#04070A", panel: "#12201E", panelHead: "#182825", cell: "#1C2E2B", trace: "#060D0C",
+          line: "#2E423E", lineSoft: "#1D2C29",
+          ink: "#F0FAF7", ink2: "#A9C4BC", ink3: "#647F78", ink4: "#445A54",
+          accent: "#7DF5D4", accentDim: "#45C4A2", accentDark: "#0C2620", accentEdge: "#1F5748", amber: "#E8B252",
+          plate: "#0A1312", plateTop: "#16231F", plateBottom: "#080F0E",
+          pad: "#1C2E2B", padBottom: "#101B19", empty: "#060D0C", micTop: "#18AC82", micBottom: "#0C6E54",
+        },
+      },
+    ],
+  },
+  {
+    id: "obsidian",
+    name: "Obsidian",
+    thesis: "Retro-future phosphor terminal — scanline bay, cool blue CRT signal, engraved lab-steel hairlines.",
+    scheme: "dark",
+    presets: [
+      {
+        id: "phosphor", name: "Phosphor terminal", skin: SKIN.phosphor,
+        tokens: {
+          page: "#030405", panel: "#090B0D", panelHead: "#0D1013", cell: "#11151A", trace: "#07090B",
+          line: "#252C33", lineSoft: "#181E24",
+          ink: "#F1F4F6", ink2: "#B6C0C9", ink3: "#77838E", ink4: "#4D5862",
+          accent: "#79B8FF", accentDim: "#4B82B8", accentDark: "#091A2A", accentEdge: "#244968", amber: "#E8B85D",
+          plate: "#07090B", plateTop: "#11151A", plateBottom: "#06080A",
+          pad: "#14191F", padBottom: "#0D1116", empty: "#080B0E", micTop: "#256FA8", micBottom: "#184A72",
+        },
+      },
+      {
+        id: "lab-steel", name: "Lab steel", skin: SKIN.labSteel,
+        tokens: {
+          page: "#05070A", panel: "#0E1218", panelHead: "#131923", cell: "#18202B", trace: "#080B10",
+          line: "#2B3542", lineSoft: "#1B232E",
+          ink: "#EFF3F8", ink2: "#ADB9C6", ink3: "#6E7C8C", ink4: "#4A5666",
+          accent: "#86BDFC", accentDim: "#5488BE", accentDark: "#0B1D30", accentEdge: "#295075", amber: "#E2B055",
+          plate: "#0A0E13", plateTop: "#151C26", plateBottom: "#090C10",
+          pad: "#18202B", padBottom: "#0F151D", empty: "#080B10", micTop: "#2C78B5", micBottom: "#1B507A",
+        },
+      },
+      {
+        id: "glass-cobalt", name: "Liquid glass cobalt", skin: SKIN.glassCobalt,
+        tokens: {
+          page: "#02050A", panel: "#0C1622", panelHead: "#12202E", cell: "#16273A", trace: "#060C14",
+          line: "#2A3E55", lineSoft: "#1A283A",
+          ink: "#EDF4FC", ink2: "#A8BED6", ink3: "#647C96", ink4: "#41546A",
+          accent: "#8FC4FF", accentDim: "#5A8FC8", accentDark: "#0D2136", accentEdge: "#2B567E", amber: "#EFBE62",
+          plate: "#08101A", plateTop: "#14233A", plateBottom: "#070D15",
+          pad: "#16273A", padBottom: "#0D1826", empty: "#060C14", micTop: "#3280C4", micBottom: "#1F5688",
+        },
+      },
+    ],
+  },
+  {
+    id: "ceramic",
+    name: "Ceramic",
+    thesis: "Kiln-fired stoneware — warm clay body with mineral grain, iron-oxide stamp as the live signal.",
+    scheme: "light",
+    presets: [
+      {
+        id: "stoneware", name: "Kiln stoneware", skin: SKIN.stoneware,
+        tokens: {
+          page: "#E4DDD0", panel: "#F5F1EA", panelHead: "#FAF6EE", cell: "#FFFDF8", trace: "#F4EEE2",
+          line: "#D9CFB9", lineSoft: "#E2DAC7",
+          ink: "#1A1612", ink2: "#3B342B", ink3: "#6B6356", ink4: "#968B79",
+          accent: "#B5421C", accentDim: "#C9764F", accentDark: "#F7E9D6", accentEdge: "#E8D2B1", amber: "#B57B1B",
+          plate: "#EFEEE9", plateTop: "#FAF9F5", plateBottom: "#E8E7E2",
+          pad: "#FFFDF8", padBottom: "#EFEEE9", empty: "#E7E6E1", micTop: "#B5421C", micBottom: "#8F3A1C",
+        },
+      },
+      {
+        id: "terracotta", name: "Terracotta glaze", skin: SKIN.terracotta,
+        tokens: {
+          page: "#DFCFBA", panel: "#F3E8D7", panelHead: "#F9F0E2", cell: "#FEFAF1", trace: "#F1E4CF",
+          line: "#D6C3A4", lineSoft: "#E2D2B8",
+          ink: "#221510", ink2: "#4A342A", ink3: "#776154", ink4: "#A08B7A",
+          accent: "#A63A18", accentDim: "#C46340", accentDark: "#F6E2CE", accentEdge: "#E4C6A2", amber: "#AC7114",
+          plate: "#EDE3D3", plateTop: "#FAF2E4", plateBottom: "#E3D7C4",
+          pad: "#FEFAF1", padBottom: "#EDE3D3", empty: "#E6DAC8", micTop: "#A63A18", micBottom: "#7E2E14",
+        },
+      },
+      {
+        id: "bone", name: "Bone laminate", skin: SKIN.bonePaper,
+        tokens: {
+          page: "#E9E4D8", panel: "#F7F3EA", panelHead: "#FBF8F0", cell: "#FFFEFB", trace: "#F5F0E4",
+          line: "#CFC5B0", lineSoft: "#DFD8C6",
+          ink: "#201C16", ink2: "#453F34", ink3: "#736C5E", ink4: "#9E957F",
+          accent: "#8C4A1E", accentDim: "#B07A50", accentDark: "#F4E9D8", accentEdge: "#E0D0B4", amber: "#9A7018",
+          plate: "#F0EBE0", plateTop: "#FAF6EC", plateBottom: "#E8E2D4",
+          pad: "#FFFEFB", padBottom: "#F0EBE0", empty: "#EBE5D8", micTop: "#8C4A1E", micBottom: "#6C3A18",
+        },
+      },
+    ],
+  },
+  {
+    id: "porcelain",
+    name: "Porcelain",
+    thesis: "High-fire gloss glaze — refractive top light on white, celadon-teal signal pooled in the wells.",
+    scheme: "light",
+    presets: [
+      {
+        id: "gloss", name: "Gloss porcelain", skin: SKIN.glossPorcelain,
+        tokens: {
+          page: "#EEECE7", panel: "#FCFBF8", panelHead: "#F6F3ED", cell: "#FFFFFF", trace: "#F3F0E9",
+          line: "#D5D0C7", lineSoft: "#E3DED5",
+          ink: "#1E2328", ink2: "#4D555D", ink3: "#747C83", ink4: "#A0A5A8",
+          accent: "#245A74", accentDim: "#5A8396", accentDark: "#E4EEF2", accentEdge: "#B8CFD8", amber: "#9B6B22",
+          plate: "#F2F3F3", plateTop: "#FFFFFF", plateBottom: "#E6E8E8",
+          pad: "#FBFCFC", padBottom: "#EDEFEF", empty: "#E5E7E7", micTop: "#2F6D85", micBottom: "#204D60",
+        },
+      },
+      {
+        id: "celadon", name: "Celadon glaze", skin: SKIN.celadon,
+        tokens: {
+          page: "#E4E9E2", panel: "#F6F9F4", panelHead: "#FBFCF8", cell: "#FFFFFF", trace: "#EEF3EA",
+          line: "#C6D2C4", lineSoft: "#D8E0D4",
+          ink: "#18201C", ink2: "#3E4C46", ink3: "#6B7A72", ink4: "#97A49A",
+          accent: "#1F5C50", accentDim: "#548A7E", accentDark: "#DEEDE8", accentEdge: "#AECCC2", amber: "#8F6A1E",
+          plate: "#EDF2EC", plateTop: "#FBFDF9", plateBottom: "#E0E8DE",
+          pad: "#F8FBF6", padBottom: "#E7EEE4", empty: "#E2EAE0", micTop: "#276B5C", micBottom: "#1A4A40",
+        },
+      },
+      {
+        id: "bisque", name: "Bisque matte", skin: SKIN.bisque,
+        tokens: {
+          page: "#ECE9E2", panel: "#F8F6F1", panelHead: "#FCFAF5", cell: "#FFFEFC", trace: "#F4F1EA",
+          line: "#D4CFC4", lineSoft: "#E2DED4",
+          ink: "#23262B", ink2: "#4E545A", ink3: "#787E84", ink4: "#A4A8AB",
+          accent: "#3E6070", accentDim: "#6E8C99", accentDark: "#E6EDF0", accentEdge: "#BCCCD4", amber: "#96701F",
+          plate: "#F1F0EC", plateTop: "#FAF9F5", plateBottom: "#E7E5E0",
+          pad: "#FBFAF7", padBottom: "#EDEBE6", empty: "#E7E5E0", micTop: "#477084", micBottom: "#305364",
+        },
+      },
+    ],
+  },
+  {
+    id: "amber",
+    name: "Amber",
+    thesis: "Bakelite tube amp — phenolic brown chassis, vacuum-tube filament glow, brass-lit hairlines.",
+    scheme: "dark",
+    presets: [
+      {
+        id: "bakelite", name: "Bakelite tubes", skin: SKIN.bakelite,
+        tokens: {
+          page: "#171209", panel: "#211A12", panelHead: "#282017", cell: "#2B2218", trace: "#1E1710",
+          line: "#3D3122", lineSoft: "#332A1E",
+          ink: "#F3EAD9", ink2: "#D9C9B0", ink3: "#A1937A", ink4: "#776C5B",
+          accent: "#E0673A", accentDim: "#B25A3A", accentDark: "#35220F", accentEdge: "#54331F", amber: "#E0A83F",
+          plate: "#1E1710", plateTop: "#2E2417", plateBottom: "#251C12",
+          pad: "#2B2218", padBottom: "#21180F", empty: "#1E1710", micTop: "#C2521F", micBottom: "#93391A",
+        },
+      },
+      {
+        id: "brass", name: "Brass instrument", skin: SKIN.brass,
+        tokens: {
+          page: "#120D05", panel: "#1D1609", panelHead: "#271E0E", cell: "#2E2412", trace: "#181104",
+          line: "#57431F", lineSoft: "#3A2D15",
+          ink: "#F6EEDC", ink2: "#DCCBA6", ink3: "#A08F6C", ink4: "#74663F",
+          accent: "#E8863C", accentDim: "#B96A34", accentDark: "#3A2409", accentEdge: "#6B4420", amber: "#EDB84A",
+          plate: "#1C1407", plateTop: "#2E2410", plateBottom: "#211809",
+          pad: "#2E2412", padBottom: "#1E1608", empty: "#181104", micTop: "#D26A24", micBottom: "#9A4A16",
+        },
+      },
+      {
+        id: "smoked", name: "Smoked glass", skin: SKIN.smokedGlass,
+        tokens: {
+          page: "#0E0803", panel: "#201409", panelHead: "#2A1C0E", cell: "#332313", trace: "#160E06",
+          line: "#4A3420", lineSoft: "#332413",
+          ink: "#F8EEDD", ink2: "#DECBAC", ink3: "#A69273", ink4: "#75634C",
+          accent: "#F07A44", accentDim: "#C05E38", accentDark: "#40240F", accentEdge: "#6B3E22", amber: "#F2B94E",
+          plate: "#1B1108", plateTop: "#2E1F10", plateBottom: "#221508",
+          pad: "#332313", padBottom: "#211508", empty: "#160E06", micTop: "#D8622A", micBottom: "#A04418",
+        },
+      },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Color + texture helpers (deterministic — SSR safe)
+// ---------------------------------------------------------------------------
+
+function hexRgb(hex: string): [number, number, number] {
+  const v = hex.replace("#", "");
+  return [parseInt(v.slice(0, 2), 16), parseInt(v.slice(2, 4), 16), parseInt(v.slice(4, 6), 16)];
+}
+
+function hexA(hex: string, a: number): string {
+  const [r, g, b] = hexRgb(hex);
+  return `rgba(${r},${g},${b},${Math.round(Math.min(1, Math.max(0, a)) * 100) / 100})`;
+}
+
+/** t = 0 → a, t = 1 → b. */
+function mixHex(a: string, b: string, t: number): string {
+  const ca = hexRgb(a);
+  const cb = hexRgb(b);
+  const m = ca.map((v, i) => Math.round(v + (cb[i] - v) * Math.min(1, Math.max(0, t))));
+  return `#${m.map((v) => v.toString(16).padStart(2, "0")).join("")}`.toUpperCase();
+}
+
+function r2(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+/** Texture layers for a surface. strength/sheen are 0..1, already knob-adjusted. */
+function texImage(kind: TextureKind, scheme: "dark" | "light", s: number, sheen: number): string[] {
+  if (kind === "none" || s <= 0) {
+    if (sheen <= 0) return [];
+    return [`linear-gradient(180deg, rgba(255,255,255,${r2(sheen * (scheme === "light" ? 0.5 : 0.07))}), rgba(255,255,255,0) 30%)`];
+  }
+  const light = scheme === "light";
+  const hi = light ? 0.5 : 0.06; // highlight alpha unit
+  const lo = light ? 0.08 : 0.3; // shadow alpha unit
+  switch (kind) {
+    case "brushed":
+      return [
+        `repeating-linear-gradient(90deg, rgba(255,255,255,${r2(hi * 0.5 * s)}) 0px, rgba(255,255,255,${r2(hi * 0.5 * s)}) 1px, transparent 1px, transparent 4px)`,
+        `linear-gradient(180deg, rgba(255,255,255,${r2(hi * sheen)}), rgba(255,255,255,0) 26%, rgba(0,0,0,${r2(lo * 0.5 * sheen)}) 100%)`,
+      ];
+    case "carbon":
+      return [
+        `repeating-linear-gradient(45deg, rgba(0,0,0,${r2(lo * 0.7 * s)}) 0px, rgba(0,0,0,${r2(lo * 0.7 * s)}) 2px, transparent 2px, transparent 7px)`,
+        `repeating-linear-gradient(-45deg, rgba(255,255,255,${r2(hi * 0.4 * s)}) 0px, rgba(255,255,255,${r2(hi * 0.4 * s)}) 2px, transparent 2px, transparent 7px)`,
+        `linear-gradient(180deg, rgba(255,255,255,${r2(hi * sheen)}), rgba(255,255,255,0) 30%)`,
+      ];
+    case "scanlines":
+      return [
+        `repeating-linear-gradient(0deg, rgba(0,0,0,${r2(0.34 * s)}) 0px, rgba(0,0,0,${r2(0.34 * s)}) 1px, transparent 1px, transparent 3px)`,
+        `linear-gradient(180deg, rgba(255,255,255,${r2(hi * sheen)}), rgba(255,255,255,0) 22%)`,
+      ];
+    case "glaze":
+      return [
+        `radial-gradient(150% 110% at 22% -12%, rgba(255,255,255,${r2((light ? 0.85 : 0.16) * sheen)}), rgba(255,255,255,0) 55%)`,
+        `radial-gradient(130% 120% at 88% 112%, rgba(${light ? "120,100,80" : "0,0,0"},${r2(lo * sheen)}), rgba(0,0,0,0) 52%)`,
+      ];
+    case "grain":
+      return [
+        `radial-gradient(60% 45% at 30% 25%, rgba(255,255,255,${r2(hi * 0.7 * s)}), rgba(255,255,255,0) 70%)`,
+        `radial-gradient(55% 60% at 75% 65%, rgba(0,0,0,${r2(lo * 0.4 * s)}), rgba(0,0,0,0) 70%)`,
+        `radial-gradient(70% 50% at 55% 92%, rgba(${light ? "140,110,80" : "255,255,255"},${r2((light ? 0.08 : hi * 0.5) * s)}), rgba(0,0,0,0) 70%)`,
+      ];
+    default:
+      return [];
+  }
+}
+
+/** Integer px for stable SSR hydration. */
+function px(n: number) {
+  return Math.max(2, Math.round(n));
+}
+
+/** Two-decimal opacity — avoids 0.1800000001 vs "0.18" hydrate fights. */
+function op(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+// ---------------------------------------------------------------------------
+// Global tweak knobs
+// ---------------------------------------------------------------------------
+
+interface Knobs {
+  /** Outer surface + figure bay + chips corner radius. */
+  radius: number;
+  /** Border strength / line opacity multiplier 0..1.5. */
+  border: number;
+  /** Plate gradient strength 0..1. */
+  plateGrad: number;
+  /** Hairline weight px 0.5..2. */
+  hairline: number;
+  /** Type scale 0.85..1.25. */
+  typeScale: number;
+  /** Gutter width — default 50 (rail contract). */
+  gutter: number;
+  /** Lock player height to exactly 2U (156). */
+  lock2U: boolean;
+  /** Player height override when unlocked. */
+  playerH: number;
+  /** Spacing scale 0.8..1.3. */
+  spacing: number;
+  /** Live accent glow 0..1 (0 = crisp only). */
+  glow: number;
+  /** Kill all soft light + texture. */
+  crisp: boolean;
+}
+
+/** Quieter defaults — product maturity over workshop texture. */
+const DEFAULT_KNOBS: Knobs = {
+  radius: 10, border: 0.85, plateGrad: 0.5, hairline: 1, typeScale: 1,
+  gutter: 50, lock2U: true, playerH: 156, spacing: 1, glow: 0.15, crisp: false,
+};
+
+/** One key-bank row — the pad grid unit. */
+const U = 78;
+const PLAYER_2U = U * 2; // exactly 2U when locked
+
+// ---------------------------------------------------------------------------
+// Resolved material — palette + skin + knobs baked into style fragments
+// ---------------------------------------------------------------------------
+
+interface Mat {
+  p: Palette;
+  scheme: "dark" | "light";
+  knobs: Knobs;
+  /** Outer chassis background. */
+  chassis: CSSProperties;
+  /** Identity head background. */
+  head: CSSProperties;
+  /** Player plate background. */
+  plate: CSSProperties;
+  /** Figure bay background. */
+  bay: CSSProperties;
+  /** Chip background. */
+  chipBg: string;
+  /** Hard line color (border-strength applied). */
+  line: string;
+  lineSoft: string;
+  /** Inset rim light for machined surfaces. */
+  rimShadow?: string;
+  /** Live glow for a signal color; undefined when crisp/glow 0. */
+  glow: (color: string, amt?: number) => string | undefined;
+  /** Type scale. */
+  ts: (v: number) => number;
+  /** Spacing scale. */
+  sp: (v: number) => number;
+  /** Hairline px. */
+  hair: number;
+  /** Player height px (2U lock applied). */
+  playerH: number;
+  /** Gutter width px. */
+  gutter: number;
+}
+
+function resolveMat(p: Palette, skin: Skin, scheme: "dark" | "light", k: Knobs): Mat {
+  const glowAmt = k.crisp ? 0 : k.glow;
+  const sheen = k.crisp ? 0 : skin.sheen;
+  const texS = k.crisp ? 0 : skin.tex;
+  const rim = k.crisp ? 0 : skin.rim;
+  const light = scheme === "light";
+
+  const line = hexA(p.line, Math.min(1, 0.35 + k.border * 0.65));
+  const lineSoft = hexA(p.lineSoft, Math.min(1, 0.35 + k.border * 0.65));
+
+  const panelTop = mixHex(p.panel, "#FFFFFF", light ? 0.5 * sheen : 0.05 + sheen * 0.04);
+  const chassisLayers = [
+    ...texImage(skin.chassisTex, scheme, texS, sheen),
+    skin.glass
+      ? `linear-gradient(180deg, ${hexA(panelTop, 0.82)}, ${hexA(p.panel, 0.74)})`
+      : `linear-gradient(180deg, ${panelTop}, ${p.panel})`,
+  ];
+  const headLayers = [
+    ...texImage("none", scheme, 0, sheen * 0.5),
+    skin.glass
+      ? `linear-gradient(180deg, ${hexA(p.panelHead, 0.7)}, ${hexA(p.panelHead, 0.45)})`
+      : `linear-gradient(180deg, ${mixHex(p.panelHead, "#FFFFFF", light ? 0.4 * sheen : sheen * 0.05)}, ${hexA(p.panelHead, skin.glass ? 0.6 : 0)})`,
+  ];
+  const plateTop = mixHex(p.plate, p.plateTop, k.plateGrad);
+  const plateBottom = mixHex(p.plate, p.plateBottom, k.plateGrad);
+  const plateLayers = [
+    ...texImage(skin.plateTex, scheme, texS, sheen),
+    skin.glass
+      ? `linear-gradient(180deg, ${hexA(plateTop, 0.8)}, ${hexA(plateBottom, 0.72)})`
+      : `linear-gradient(180deg, ${plateTop}, ${plateBottom})`,
+  ];
+  const bayLayers = [
+    ...texImage(skin.bayTex, scheme, texS, sheen * 0.6),
+    skin.glass ? `linear-gradient(180deg, ${hexA(p.trace, 0.7)}, ${hexA(p.trace, 0.6)})` : `linear-gradient(180deg, ${p.trace}, ${p.trace})`,
+  ];
+
+  const rimAlpha = r2(rim * (light ? 0.65 : 0.14));
+  const rimShadow = rimAlpha > 0 ? `inset 0 1px 0 rgba(255,255,255,${rimAlpha})` : undefined;
+
+  return {
+    p, scheme, knobs: k,
+    chassis: { backgroundColor: skin.glass ? "transparent" : p.panel, backgroundImage: chassisLayers.join(", ") },
+    head: { backgroundColor: skin.glass ? "transparent" : p.panelHead, backgroundImage: headLayers.join(", ") },
+    plate: { backgroundColor: skin.glass ? "transparent" : p.plate, backgroundImage: plateLayers.join(", ") },
+    bay: { backgroundColor: skin.glass ? "transparent" : p.trace, backgroundImage: bayLayers.join(", ") },
+    chipBg: skin.glass ? hexA(p.pad, 0.65) : p.pad,
+    line, lineSoft, rimShadow,
+    glow: (color, amt = 1) => {
+      const a = glowAmt * amt;
+      if (a <= 0.01) return undefined;
+      return `0 0 ${Math.round(10 * a)}px ${hexA(color, r2(0.5 * a))}`;
+    },
+    ts: (v) => Math.round(v * k.typeScale * 100) / 100,
+    sp: (v) => Math.round(v * k.spacing * 10) / 10,
+    hair: Math.round(k.hairline * 10) / 10,
+    playerH: k.lock2U ? PLAYER_2U : k.playerH,
+    gutter: k.gutter,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+type Mode = "ready" | "listening" | "transcribing" | "submitting" | "speaking" | "paused";
+
+interface ModeMeta { key: Mode; word: string; detail: string; tint: string }
+
+function modesFor(p: Palette): ModeMeta[] {
+  return [
+    { key: "ready", word: "READY", detail: "LANE 02", tint: p.ink2 },
+    { key: "listening", word: "LISTENING", detail: "LANE 02", tint: p.accent },
+    { key: "transcribing", word: "TRANSCRIBING", detail: "ON DEVICE", tint: p.amber },
+    { key: "submitting", word: "SUBMITTING", detail: "MAC", tint: p.amber },
+    { key: "speaking", word: "SPEAKING", detail: "LANE 02", tint: p.accent },
+    { key: "paused", word: "PAUSED", detail: "LANE 02", tint: p.ink3 },
+  ];
+}
+
+const YOU = "Mock turn — walk the full lifecycle without Codex.";
+const AGENT =
+  "Lifecycle walkthrough complete. Listening, transcription, Mac work, and narration all lit in sequence. The radio never resized.";
+
+/** Speech-shaped envelope: phrase humps with breaths — not a sine toy. */
+function speechEnvelope(count: number, seed = 11) {
+  let s = seed;
+  const rand = () => {
+    s = (s * 1103515245 + 12345) % 2147483648;
+    return s / 2147483648;
+  };
+  return Array.from({ length: count }, (_, i) => {
+    const t = i / count;
+    const phrase = Math.sin(t * Math.PI * 3.2);
+    const formant = Math.abs(Math.sin(t * 47)) * 0.35 + Math.abs(Math.sin(t * 19)) * 0.25;
+    const breath = phrase > 0.12 ? 1 : 0.06;
+    const attack = t < 0.04 ? t / 0.04 : t > 0.94 ? (1 - t) / 0.06 : 1;
+    return Math.round(
+      Math.min(1, Math.max(0.04, (Math.abs(phrase) * 0.55 + formant) * breath * attack * (0.85 + rand() * 0.15))) * 100,
+    ) / 100;
+  });
+}
+
+function clock(frac: number, dur = 4.2) {
+  const s = Math.floor(frac * dur);
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+/** Wall-clock phase — see MicroThemesOpusStudy for why not rAF setState. */
+function useAnimationPhase(running: boolean, speed: number) {
+  const originRef = useRef<number | null>(null);
+  const [, setBeat] = useState(0);
+
+  useEffect(() => {
+    if (!running) {
+      originRef.current = null;
+      return;
+    }
+    originRef.current = performance.now();
+    const id = window.setInterval(() => setBeat((n) => (n + 1) % 1_000_000), 80);
+    return () => window.clearInterval(id);
+  }, [running, speed]);
+
+  if (!running || originRef.current == null) return 0;
+  const elapsed = (performance.now() - originRef.current) / 1000;
+  return (elapsed * 0.28 * speed) % 1;
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function MicroThemesKimiStudyPage({ page }: { page: StudioAppPage }) {
+  const [themeId, setThemeId] = useState<ThemeId>("flight");
+  const [presetIx, setPresetIx] = useState<Record<ThemeId, number>>({
+    flight: 0, obsidian: 0, ceramic: 0, porcelain: 0, amber: 0,
+  });
+  const [tokens, setTokens] = useState<Record<ThemeId, Palette>>(() =>
+    Object.fromEntries(THEMES.map((t) => [t.id, t.presets[0].tokens])) as Record<ThemeId, Palette>,
+  );
+  const [knobs, setKnobs] = useState<Knobs>(DEFAULT_KNOBS);
+
+  // Player state
+  const [mode, setMode] = useState<Mode>("speaking");
+  const [pos, setPos] = useState(0.38);
+  const [level, setLevel] = useState(0.62);
+  const [volume, setVolume] = useState(0.8);
+  const [speedIx, setSpeedIx] = useState(0);
+  const [autoplay, setAutoplay] = useState(true);
+  const [animate, setAnimate] = useState(true);
+
+  const theme = THEMES.find((t) => t.id === themeId) ?? THEMES[0];
+  const preset = theme.presets[presetIx[themeId]] ?? theme.presets[0];
+  const palette = tokens[themeId];
+  const modes = useMemo(() => modesFor(palette), [palette]);
+  const meta = modes.find((m) => m.key === mode) ?? modes[0];
+  const mat = useMemo(() => resolveMat(palette, preset.skin, theme.scheme, knobs), [palette, preset, theme, knobs]);
+
+  const phase = useAnimationPhase(animate, 1.65);
+  const env = useMemo(() => speechEnvelope(96), []);
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  const livePhase = hydrated ? phase : 0;
+
+  // Derive from phase — do not write pos/level back via useEffect (update-depth loop).
+  const livePos =
+    hydrated && animate && mode === "speaking" ? phase : pos;
+  const liveLevel =
+    hydrated && mode === "listening"
+      ? Math.round(
+          (0.18 +
+            Math.abs(Math.sin(phase * Math.PI * 2.4)) * 0.42 +
+            Math.abs(Math.sin(phase * Math.PI * 7.1)) * 0.22 +
+            Math.abs(Math.sin(phase * Math.PI * 13)) * 0.12) *
+            100,
+        ) / 100
+      : level;
+
+  const messages =
+    mode === "ready" || mode === "listening" || mode === "transcribing"
+      ? mode === "ready"
+        ? []
+        : [{ role: "you" as const, text: YOU }]
+      : [
+          { role: "you" as const, text: YOU },
+          { role: "agent" as const, text: AGENT },
+        ];
+
+  const pickPreset = (ix: number) => {
+    setPresetIx((prev) => ({ ...prev, [themeId]: ix }));
+    setTokens((prev) => ({ ...prev, [themeId]: theme.presets[ix].tokens }));
+  };
+  const setToken = (key: TokenKey, value: string) =>
+    setTokens((prev) => ({ ...prev, [themeId]: { ...prev[themeId], [key]: value } }));
+  const resetTheme = () => {
+    setPresetIx((prev) => ({ ...prev, [themeId]: 0 }));
+    setTokens((prev) => ({ ...prev, [themeId]: theme.presets[0].tokens }));
+  };
+  const setKnob = <K extends keyof Knobs>(key: K, value: Knobs[K]) =>
+    setKnobs((prev) => ({ ...prev, [key]: value }));
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+
+      <section className="max-w-[1100px] space-y-12 py-8">
+        {/* Thesis */}
+        <div>
+          <h2 className="mb-2 text-[15px] font-medium text-studio-ink-strong">
+            Five materials, one chassis
+          </h2>
+          <p className="max-w-[66ch] text-[13.5px] leading-relaxed text-studio-ink">
+            Full Micro Deck surface — lanes, pad, hold-to-speak, and the ledger
+            console. Geometry on the eye column stays fixed (50pt gutter, text rail
+            at 76). Themes change material: texture, lighting, chrome. Signal color
+            only where the circuit is live.
+          </p>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {THEMES.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setThemeId(t.id)}
+                className="rounded-lg p-3 text-left transition"
+                style={{
+                  border: `1px solid ${t.id === themeId ? tokens[t.id].accent : "var(--studio-rule, #333)"}`,
+                  background: tokens[t.id].page,
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="flex gap-1">
+                    {[tokens[t.id].panel, tokens[t.id].accent, tokens[t.id].amber].map((c, i) => (
+                      <span key={i} className="h-2.5 w-2.5 rounded-full" style={{ background: c, border: "1px solid rgba(127,127,127,0.35)" }} />
+                    ))}
+                  </span>
+                  <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]" style={{ color: tokens[t.id].ink }}>
+                    {t.name}
+                  </span>
+                </div>
+                <p className="mt-1.5 text-[11px] leading-snug" style={{ color: tokens[t.id].ink3 }}>
+                  {t.thesis}
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Playground */}
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">Playground</h2>
+          <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            Pick a theme, a material preset, and a lifecycle mode. Every knob below
+            re-renders the same Micro column live; token edits persist per theme.
+          </p>
+
+          {/* Material presets */}
+          <div className="mb-3 flex flex-wrap items-center gap-1.5">
+            <span className="mr-1 font-mono text-[9px] uppercase tracking-[0.16em] text-studio-ink-faint">Material</span>
+            {theme.presets.map((pr, ix) => (
+              <button
+                key={pr.id}
+                type="button"
+                onClick={() => pickPreset(ix)}
+                className="rounded px-2.5 py-1 text-[10px] font-medium tracking-wide transition"
+                style={{
+                  background: ix === presetIx[themeId] ? hexA(palette.accent, 0.14) : "transparent",
+                  color: ix === presetIx[themeId] ? palette.accent : "var(--studio-ink-faint, #888)",
+                  border: `1px solid ${ix === presetIx[themeId] ? hexA(palette.accent, 0.5) : "var(--studio-rule, #333)"}`,
+                }}
+              >
+                {pr.name}
+              </button>
+            ))}
+            <span className="ml-2 text-[11px] italic text-studio-ink-faint">{preset.skin.blurb}</span>
+          </div>
+
+          {/* Lifecycle */}
+          <div className="mb-4 flex flex-wrap items-center gap-1.5">
+            <span className="mr-1 font-mono text-[9px] uppercase tracking-[0.16em] text-studio-ink-faint">Lifecycle</span>
+            {modes.map((m) => (
+              <button
+                key={m.key}
+                type="button"
+                onClick={() => setMode(m.key)}
+                className="rounded px-2.5 py-1 text-[10px] font-medium tracking-wide transition"
+                style={{
+                  background: m.key === mode ? hexA(m.tint, 0.14) : "transparent",
+                  color: m.key === mode ? m.tint : "var(--studio-ink-faint, #888)",
+                  border: `1px solid ${m.key === mode ? hexA(m.tint, 0.5) : "var(--studio-rule, #333)"}`,
+                }}
+              >
+                {m.word}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => setAnimate((a) => !a)}
+              className="ml-2 rounded px-2.5 py-1 text-[10px] font-medium"
+              style={{
+                border: `1px solid ${animate ? "var(--studio-rule, #333)" : hexA(palette.accent, 0.6)}`,
+                color: animate ? "var(--studio-ink-faint, #888)" : palette.accent,
+                background: animate ? "transparent" : hexA(palette.accent, 0.1),
+              }}
+            >
+              {animate ? "❚❚ Freeze" : "▶ Animate"}
+            </button>
+          </div>
+
+          {/* Full Micro Deck on the theme's page backdrop */}
+          <div
+            className="overflow-x-auto rounded-xl p-4"
+            style={{
+              background: `radial-gradient(120% 90% at 50% 0%, ${mixHex(palette.page, "#FFFFFF", theme.scheme === "light" ? 0.25 : 0.04)}, ${palette.page})`,
+              border: `1px solid ${mat.lineSoft}`,
+            }}
+          >
+            <MicroDeckFullMock
+              tokens={palette}
+              mode={mode}
+              handWidth={300}
+              consoleWidth={400}
+              height={Math.max(520, mat.playerH + 320)}
+            >
+              <LaneColumn
+                m={mat}
+                mode={mode}
+                meta={meta}
+                messages={messages}
+                pos={livePos}
+                level={liveLevel}
+                volume={volume}
+                speedIx={speedIx}
+                autoplay={autoplay}
+                env={env}
+                phase={livePhase}
+                fillHeight
+                onSeek={(v) => { setAnimate(false); setPos(v); }}
+                onVolume={setVolume}
+                onCycleSpeed={() => setSpeedIx((i) => (i + 1) % 4)}
+                onToggleAuto={() => setAutoplay((a) => !a)}
+                onTogglePlay={() =>
+                  setMode((md) => (md === "speaking" ? "paused" : md === "paused" ? "speaking" : md))
+                }
+              />
+            </MicroDeckFullMock>
+          </div>
+
+          {/* Global knobs */}
+          <div className="mt-5">
+            <div className="mb-2 flex items-center gap-3">
+              <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-studio-ink-faint">Global knobs</span>
+              <button
+                type="button"
+                onClick={() => setKnobs(DEFAULT_KNOBS)}
+                className="rounded border border-studio-rule px-2 py-0.5 text-[10px] text-studio-ink-faint hover:text-studio-ink"
+              >
+                Reset knobs
+              </button>
+              <Toggle
+                label="Crisp only"
+                on={knobs.crisp}
+                onChange={(v) => setKnob("crisp", v)}
+                accent={palette.accent}
+              />
+              <Toggle
+                label="2U lock"
+                on={knobs.lock2U}
+                onChange={(v) => setKnob("lock2U", v)}
+                accent={palette.accent}
+              />
+            </div>
+            <div className="grid max-w-[860px] grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
+              <Knob label="Corner radius" min={0} max={20} step={1} value={knobs.radius} onChange={(v) => setKnob("radius", v)} fmt={(v) => `${v}px`} />
+              <Knob label="Border strength" min={0} max={1.5} step={0.05} value={knobs.border} onChange={(v) => setKnob("border", v)} fmt={(v) => v.toFixed(2)} />
+              <Knob label="Plate gradient" min={0} max={1} step={0.05} value={knobs.plateGrad} onChange={(v) => setKnob("plateGrad", v)} fmt={(v) => v.toFixed(2)} />
+              <Knob label="Hairline weight" min={0.5} max={2} step={0.1} value={knobs.hairline} onChange={(v) => setKnob("hairline", v)} fmt={(v) => `${v.toFixed(1)}px`} />
+              <Knob label="Type scale" min={0.85} max={1.25} step={0.01} value={knobs.typeScale} onChange={(v) => setKnob("typeScale", v)} fmt={(v) => `${Math.round(v * 100)}%`} />
+              <Knob label="Gutter width" min={30} max={70} step={1} value={knobs.gutter} onChange={(v) => setKnob("gutter", v)} fmt={(v) => `${v}px`} />
+              <Knob label="Player height" min={110} max={234} step={2} value={knobs.lock2U ? PLAYER_2U : knobs.playerH} onChange={(v) => { setKnob("lock2U", false); setKnob("playerH", v); }} fmt={(v) => knobs.lock2U ? `${v}px · 2U` : `${v}px`} />
+              <Knob label="Spacing scale" min={0.8} max={1.3} step={0.02} value={knobs.spacing} onChange={(v) => setKnob("spacing", v)} fmt={(v) => `${Math.round(v * 100)}%`} />
+              <Knob label="Live glow" min={0} max={1} step={0.05} value={knobs.glow} onChange={(v) => setKnob("glow", v)} fmt={(v) => v.toFixed(2)} />
+              <Knob label="Scrub position" min={0} max={1} step={0.01} value={pos} onChange={(v) => { setAnimate(false); setPos(v); }} fmt={(v) => v.toFixed(2)} />
+            </div>
+          </div>
+        </div>
+
+        {/* Token editor */}
+        <TokenEditor palette={palette} onChange={setToken} onReset={resetTheme} themeName={theme.name} />
+
+        {/* Theme strip — all five at designed defaults */}
+        <ThemeStrip active={themeId} onPick={setThemeId} />
+
+        {/* Export */}
+        <ExportPanel theme={theme} presetName={preset.name} palette={palette} />
+      </section>
+    </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Controls
+// ---------------------------------------------------------------------------
+
+function Knob({
+  label, min, max, step, value, onChange, fmt,
+}: {
+  label: string; min: number; max: number; step: number; value: number;
+  onChange: (v: number) => void; fmt: (v: number) => string;
+}) {
+  return (
+    <label className="flex items-center gap-3 text-[11px] text-studio-ink-faint">
+      <span className="w-24 shrink-0">{label}</span>
+      <input
+        type="range" min={min} max={max} step={step} value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="flex-1 accent-current"
+      />
+      <span className="w-16 shrink-0 tabular-nums text-right">{fmt(value)}</span>
+    </label>
+  );
+}
+
+function Toggle({ label, on, onChange, accent }: { label: string; on: boolean; onChange: (v: boolean) => void; accent: string }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!on)}
+      className="rounded px-2 py-0.5 text-[10px] font-medium"
+      style={{
+        border: `1px solid ${on ? hexA(accent, 0.6) : "var(--studio-rule, #333)"}`,
+        color: on ? accent : "var(--studio-ink-faint, #888)",
+        background: on ? hexA(accent, 0.1) : "transparent",
+      }}
+    >
+      {label} {on ? "ON" : "OFF"}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Token editor — every DeckThemePalette key, grouped
+// ---------------------------------------------------------------------------
+
+function TokenEditor({
+  palette, onChange, onReset, themeName,
+}: {
+  palette: Palette;
+  onChange: (key: TokenKey, value: string) => void;
+  onReset: () => void;
+  themeName: string;
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-3">
+        <h2 className="text-[15px] font-medium text-studio-ink-strong">Tokens — {themeName}</h2>
+        <button
+          type="button"
+          onClick={onReset}
+          className="rounded border border-studio-rule px-2 py-0.5 text-[10px] text-studio-ink-faint hover:text-studio-ink"
+        >
+          Reset theme defaults
+        </button>
+      </div>
+      <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+        Every <code>DeckThemePalette</code> key, grouped by role. Edits apply to the
+        live mock immediately and persist per theme while you explore.
+      </p>
+      <div className="grid gap-4 lg:grid-cols-2">
+        {TOKEN_GROUPS.map((g) => (
+          <div key={g.label} className="rounded-lg border border-studio-rule p-3">
+            <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.16em] text-studio-ink-faint">
+              {g.label}
+            </div>
+            <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
+              {g.keys.map((key) => (
+                <TokenRow key={key} name={key} value={palette[key]} onChange={(v) => onChange(key, v)} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TokenRow({ name, value, onChange }: { name: string; value: string; onChange: (v: string) => void }) {
+  const [text, setText] = useState(value);
+  useEffect(() => {
+    setText((prev) => (prev === value ? prev : value));
+  }, [value]);
+  const safe = /^#[0-9a-fA-F]{6}$/.test(value) ? value.toLowerCase() : "#000000";
+  const commit = (raw: string) => {
+    setText(raw);
+    const v = (raw.startsWith("#") ? raw : `#${raw}`).toLowerCase();
+    if (/^#[0-9a-fA-F]{6}$/.test(v) && v !== value.toLowerCase()) onChange(v);
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="color"
+        value={safe}
+        onChange={(e) => {
+          const next = e.target.value.toLowerCase();
+          if (next !== value.toLowerCase()) onChange(next);
+        }}
+        className="h-6 w-7 shrink-0 cursor-pointer rounded border border-studio-rule bg-transparent p-0.5"
+      />
+      <span className="w-[86px] shrink-0 font-mono text-[10px] text-studio-ink">{name}</span>
+      <input
+        type="text"
+        value={text}
+        onChange={(e) => commit(e.target.value)}
+        spellCheck={false}
+        className="w-full min-w-0 rounded border border-studio-rule bg-transparent px-1.5 py-0.5 font-mono text-[10px] text-studio-ink-faint"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Lane column — exact Micro ledger geometry, material-driven
+// ---------------------------------------------------------------------------
+
+function LaneColumn({
+  m, mode, meta, messages, pos, level, volume, speedIx, autoplay, env, phase,
+  fillHeight, onSeek, onVolume, onCycleSpeed, onToggleAuto, onTogglePlay,
+}: {
+  m: Mat;
+  mode: Mode;
+  meta: ModeMeta;
+  messages: { role: "you" | "agent"; text: string }[];
+  pos: number;
+  level: number;
+  volume: number;
+  speedIx: number;
+  autoplay: boolean;
+  env: number[];
+  phase: number;
+  /** Fill parent (full Micro shell) instead of fixed 560. */
+  fillHeight?: boolean;
+  onSeek?: (v: number) => void;
+  onVolume?: (v: number) => void;
+  onCycleSpeed?: () => void;
+  onToggleAuto?: () => void;
+  onTogglePlay?: () => void;
+}) {
+  const p = m.p;
+  const live = mode === "listening" || mode === "speaking";
+  const edge = m.sp(14);
+  const gap = m.sp(12);
+
+  return (
+    <div
+      className="flex flex-col overflow-hidden"
+      style={{
+        ...m.chassis,
+        borderRadius: m.knobs.radius,
+        border: `1px solid ${live ? hexA(meta.tint, 0.4) : m.line}`,
+        boxShadow: [m.rimShadow, live ? m.glow(meta.tint, 0.5) : undefined].filter(Boolean).join(", ") || undefined,
+        height: fillHeight ? "100%" : 560,
+      }}
+    >
+      {/* Identity — panel head of the same surface */}
+      <div
+        className="flex items-start"
+        style={{
+          ...m.head,
+          gap,
+          paddingLeft: edge,
+          paddingRight: edge,
+          paddingTop: m.sp(12),
+          paddingBottom: m.sp(10),
+          borderBottom: `${m.hair}px solid ${m.lineSoft}`,
+        }}
+      >
+        <div
+          className="font-mono font-semibold leading-none tabular-nums"
+          style={{
+            color: p.accent,
+            width: m.gutter,
+            fontSize: m.ts(28),
+            textShadow: live ? m.glow(p.accent, 0.6) : undefined,
+          }}
+        >
+          02
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span
+              className="truncate font-mono font-semibold tracking-wide"
+              style={{ color: p.ink, fontSize: m.ts(11) }}
+            >
+              USETALKIE.COM
+            </span>
+            <span className="ml-auto flex items-center gap-1.5">
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{
+                  background:
+                    mode === "listening"
+                      ? `linear-gradient(180deg, ${p.micTop}, ${p.micBottom})`
+                      : meta.tint,
+                  boxShadow: live ? m.glow(meta.tint) ?? `0 0 6px ${meta.tint}` : undefined,
+                }}
+              />
+              <span
+                className="font-mono font-bold"
+                style={{ color: meta.tint, fontSize: m.ts(7), letterSpacing: "0.14em" }}
+              >
+                {meta.word === "READY" ? "ACTIVE LANE" : meta.word}
+              </span>
+            </span>
+          </div>
+          <div
+            className="flex gap-2 font-mono"
+            style={{ color: p.ink3, fontSize: m.ts(7.5), marginTop: m.sp(4) }}
+          >
+            <span>main</span>
+            <span style={{ color: p.ink4 }}>5A83404D</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Ledger — role in numeral gutter, body on project-name / TURN rail */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div
+          className="min-h-0 flex-1 overflow-hidden"
+          style={{ paddingLeft: edge, paddingRight: edge, paddingTop: m.sp(10), paddingBottom: m.sp(10) }}
+        >
+          {messages.length === 0 ? (
+            <p
+              className="font-mono leading-relaxed"
+              style={{ color: p.ink3, paddingLeft: m.gutter + gap, fontSize: m.ts(9) }}
+            >
+              Check unmerged checkout changes
+            </p>
+          ) : (
+            <div style={{ display: "grid", gap: m.sp(8) }}>
+              {messages.map((msg, i) => (
+                <div key={i} className="flex items-start" style={{ gap }}>
+                  <div
+                    className="shrink-0 font-mono font-bold"
+                    style={{ width: m.gutter, color: p.ink4, fontSize: m.ts(6.5), letterSpacing: "0.09em" }}
+                  >
+                    {msg.role === "you" ? "YOU" : "AGENT"}
+                  </div>
+                  <p
+                    className="min-w-0 flex-1 font-mono leading-snug"
+                    style={{ color: msg.role === "agent" ? p.ink2 : p.ink3, fontSize: m.ts(9) }}
+                  >
+                    {msg.text}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* PLAYER — plate foot of the same surface (no gap, no second card) */}
+      <PlayerConsole
+        m={m}
+        mode={mode}
+        meta={meta}
+        pos={pos}
+        level={level}
+        volume={volume}
+        speedIx={speedIx}
+        autoplay={autoplay}
+        env={env}
+        phase={phase}
+        embedded
+        onSeek={onSeek}
+        onVolume={onVolume}
+        onCycleSpeed={onCycleSpeed}
+        onToggleAuto={onToggleAuto}
+        onTogglePlay={onTogglePlay}
+      />
+    </div>
+  );
+}
+
+function PlayerConsole({
+  m, mode, meta, pos, level, volume, speedIx, autoplay, env, phase = 0,
+  compact, embedded, onSeek, onVolume, onCycleSpeed, onToggleAuto, onTogglePlay,
+}: {
+  m: Mat;
+  mode: Mode;
+  meta: ModeMeta;
+  pos: number;
+  level: number;
+  volume: number;
+  speedIx: number;
+  autoplay: boolean;
+  env: number[];
+  phase?: number;
+  compact?: boolean;
+  embedded?: boolean;
+  onSeek?: (v: number) => void;
+  onVolume?: (v: number) => void;
+  onCycleSpeed?: () => void;
+  onToggleAuto?: () => void;
+  onTogglePlay?: () => void;
+}) {
+  const p = m.p;
+  const narrating = mode === "speaking" || mode === "paused";
+  const live = mode === "listening";
+  const working = mode === "transcribing" || mode === "submitting";
+  const tint = meta.tint;
+  // Shared rail with identity numeral / ledger roles / player ring
+  const gutter = m.gutter;
+  const ring = embedded ? 48 : 56;
+  const gap = m.sp(embedded ? 12 : 14);
+  const edge = m.sp(14);
+  const headInset = gutter + gap;
+  const restLabel = mode === "ready" ? "READY" : mode === "paused" ? "AT REST" : "NO AUDIO";
+  const lit = live || mode === "speaking";
+
+  // Face layout matches DeckPlayerConsole:
+  // head (status·caption) · transport band (ring + figure same H) · chips on floor
+  return (
+    <div
+      className="flex flex-col overflow-hidden"
+      style={{
+        height: m.playerH,
+        ...m.plate,
+        borderRadius: embedded ? 0 : Math.max(0, m.knobs.radius - 1),
+        border: embedded ? undefined : `1px solid ${lit ? hexA(tint, 0.3) : m.line}`,
+        borderTop: embedded ? `${m.hair}px solid ${lit ? hexA(tint, 0.4) : m.lineSoft}` : undefined,
+        boxShadow: embedded ? m.rimShadow : [m.rimShadow, lit ? m.glow(tint, 0.4) : undefined].filter(Boolean).join(", ") || undefined,
+        paddingTop: m.sp(embedded ? 10 : 12),
+        paddingBottom: m.sp(embedded ? 9 : 11),
+        paddingLeft: edge,
+        paddingRight: edge,
+        boxSizing: "border-box",
+      }}
+    >
+      {/* Head — indented to figure edge (text rail) */}
+      <div style={{ paddingLeft: headInset }}>
+        <div
+          className="flex items-center gap-1.5 font-mono"
+          style={{
+            height: 12,
+            fontSize: m.ts(9.5),
+            fontWeight: 600,
+            letterSpacing: "0.05em",
+            color: mode === "ready" ? p.ink2 : tint,
+          }}
+        >
+          <span>{mode === "ready" || narrating || working || live ? "TURN 14" : meta.detail}</span>
+          <span style={{ color: p.ink4, opacity: 0.65 }}>·</span>
+          <span style={{ color: mode === "ready" ? p.ink2 : tint }}>{meta.word}</span>
+          {mode === "speaking" && (
+            <span
+              className="inline-block h-1 w-1 shrink-0 rounded-full"
+              style={{ background: p.accent, boxShadow: m.glow(p.accent) }}
+            />
+          )}
+        </div>
+        <div
+          className="truncate"
+          style={{
+            marginTop: 2,
+            height: embedded ? 20 : 22,
+            fontSize: m.ts(12),
+            lineHeight: 1.35,
+            color: p.ink,
+          }}
+        >
+          {narrating || mode === "ready"
+            ? AGENT
+            : live
+              ? "Listening…"
+              : working
+                ? "Working…"
+                : ""}
+        </div>
+      </div>
+
+      {/* Free space mostly above transport — ring + bay a touch lower */}
+      <div style={{ flex: "1 1 8px", minHeight: 8 }} />
+
+      {/* Transport band — ring + figure same height; tape clock under bay only */}
+      <div>
+        <div className="flex items-center" style={{ gap }}>
+          <div
+            className="flex shrink-0 items-center justify-center"
+            style={{ width: gutter, height: ring }}
+          >
+            <button
+              type="button"
+              onClick={onTogglePlay}
+              className="relative flex items-center justify-center rounded-full"
+              style={{
+                width: ring,
+                height: ring,
+                ...m.bay,
+                border: `2px solid ${lit ? hexA(tint, 0.55) : m.line}`,
+                boxShadow: lit ? m.glow(tint, 0.7) : undefined,
+                color: narrating || mode === "ready" ? p.accent : p.ink3,
+              }}
+            >
+              {narrating && (
+                <span
+                  className="pointer-events-none absolute inset-0 rounded-full"
+                  style={{
+                    border: `2px solid ${tint}`,
+                    clipPath: `inset(0 ${100 - pos * 100}% 0 0)`,
+                    opacity: 0.9,
+                  }}
+                />
+              )}
+              <span style={{ fontSize: ring * 0.3, position: "relative" }}>
+                {mode === "speaking" ? "❚❚" : "▶"}
+              </span>
+            </button>
+          </div>
+
+          <div
+            className="relative min-w-0 flex-1"
+            style={{
+              height: ring,
+              borderRadius: Math.max(2, m.knobs.radius - 4),
+              ...m.bay,
+              border: `${m.hair}px solid ${m.line}`,
+              cursor: narrating || mode === "ready" ? "pointer" : "default",
+            }}
+            onClick={(e) => {
+              if (!onSeek || !(narrating || mode === "ready")) return;
+              const r = e.currentTarget.getBoundingClientRect();
+              onSeek(Math.min(1, Math.max(0, (e.clientX - r.left) / r.width)));
+            }}
+          >
+            <div className="absolute inset-0 px-2 py-1.5">
+              {mode === "ready" ? (
+                <RestField m={m} label="READY" silhouette />
+              ) : live || narrating || working ? (
+                <RadioFigure m={m} mode={mode} env={env} pos={pos} level={level} phase={phase} tint={tint} />
+              ) : (
+                <RestField m={m} label={restLabel} />
+              )}
+            </div>
+            {narrating && (
+              <span
+                className="pointer-events-none absolute top-1.5 bottom-1.5 w-[1.5px] rounded-full"
+                style={{
+                  left: `${pos * 100}%`,
+                  background: mode === "paused" ? p.ink2 : tint,
+                  boxShadow: mode === "paused" ? undefined : m.glow(tint),
+                  transform: "translateX(-50%)",
+                }}
+              />
+            )}
+          </div>
+        </div>
+        {/* Tape clock under the bay: 0:00 · current · total — not under the ring */}
+        {(mode === "ready" || narrating) && (
+          <div
+            className="relative font-mono tabular-nums"
+            style={{ marginTop: 4, marginLeft: gutter + gap, fontSize: m.ts(9), color: p.ink4 }}
+          >
+            <div className="flex justify-between">
+              <span>0:00</span>
+              <span>0:04</span>
+            </div>
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              style={{ color: narrating ? p.ink2 : p.ink3 }}
+            >
+              {narrating ? clock(pos) : "0:00"}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div style={{ flex: "0 0 8px", minHeight: 4, maxHeight: 10 }} />
+
+      {/* Chips on the floor of the plate */}
+      <div className="flex items-center gap-1.5" style={{ height: 22 }}>
+        <button type="button" onClick={onCycleSpeed} className="appearance-none">
+          <Chip m={m}>
+            <span className="font-mono" style={{ color: p.ink3, fontSize: m.ts(10) }}>
+              {["1.00×", "1.25×", "1.50×", "0.75×"][speedIx]}
+            </span>
+          </Chip>
+        </button>
+        <Chip m={m}>
+          <span className="font-mono" style={{ color: p.ink4, opacity: 0.55, fontSize: m.ts(10) }}>
+            VOL
+          </span>
+          <span
+            className="ml-1.5 inline-block h-[2.5px] w-[26px] rounded-full"
+            style={{ background: m.line }}
+            onPointerDown={(e) => {
+              if (!onVolume) return;
+              const el = e.currentTarget;
+              const move = (ev: PointerEvent) => {
+                const r = el.getBoundingClientRect();
+                onVolume(Math.min(1, Math.max(0, (ev.clientX - r.left) / r.width)));
+              };
+              move(e.nativeEvent);
+              const up = () => {
+                window.removeEventListener("pointermove", move);
+                window.removeEventListener("pointerup", up);
+              };
+              window.addEventListener("pointermove", move);
+              window.addEventListener("pointerup", up);
+            }}
+          >
+            <span className="block h-full rounded-full" style={{ width: `${volume * 100}%`, background: p.ink3 }} />
+          </span>
+        </Chip>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={onToggleAuto}
+          className="rounded px-2 py-0.5 font-mono font-semibold tracking-wide"
+          style={{
+            fontSize: m.ts(9.5),
+            background: autoplay ? hexA(p.amber, 0.12) : m.chipBg,
+            border: `1px solid ${autoplay ? hexA(p.amber, 0.4) : m.line}`,
+            color: autoplay ? p.amber : p.ink4,
+            boxShadow: autoplay ? m.glow(p.amber, 0.5) : undefined,
+          }}
+        >
+          {autoplay ? "AUTOPLAY ON" : "AUTOPLAY OFF"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Chip({ m, children }: { m: Mat; children: React.ReactNode }) {
+  return (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5"
+      style={{
+        borderRadius: Math.max(2, m.knobs.radius - 6),
+        background: m.chipBg,
+        border: `${m.hair}px solid ${m.line}`,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Figures — bar genres parameterized by material
+// ---------------------------------------------------------------------------
+
+const BAR_RADIUS = 1;
+
+function RadioFigure({
+  m, mode, env, pos, level, phase, tint,
+}: {
+  m: Mat; mode: Mode; env: number[]; pos: number; level: number; phase: number; tint: string;
+}) {
+  switch (mode) {
+    case "speaking":
+    case "paused":
+      return <PlaybackWave m={m} env={env} pos={pos} tint={mode === "paused" ? m.p.ink3 : m.p.accent} />;
+    case "listening":
+      return <CaptureWave m={m} level={level} phase={phase} />;
+    case "transcribing":
+    case "submitting":
+      return <ActivityField m={m} tint={tint} phase={phase} kind={mode === "transcribing" ? "sweep" : "pulse"} />;
+    default:
+      return <RestField m={m} />;
+  }
+}
+
+/** One vertical meter stroke — thin tall rectangle, not a capsule. */
+function Bar({ height, color, opacity }: { height: number; color: string; opacity: number }) {
+  return (
+    <div className="flex flex-1 items-center justify-center" style={{ height: "100%", minWidth: 0 }}>
+      <div
+        style={{
+          width: "85%",
+          maxWidth: 2,
+          height,
+          borderRadius: BAR_RADIUS,
+          background: color,
+          opacity: op(opacity),
+        }}
+      />
+    </div>
+  );
+}
+
+/** Playback: full silhouette of the file + played span lit + playhead. */
+function PlaybackWave({ m, env, pos, tint }: { m: Mat; env: number[]; pos: number; tint: string }) {
+  const n = env.length;
+  const head = Math.min(n - 1, Math.floor(pos * n));
+  const left = `${(Math.round(pos * 1000) / 10).toFixed(1)}%`;
+  return (
+    <div className="relative flex h-full w-full items-center">
+      <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+        {env.map((v, i) => {
+          const played = i <= head;
+          return (
+            <Bar key={i} height={px(v * 28)} color={played ? tint : m.line} opacity={played ? 0.95 : 0.3} />
+          );
+        })}
+      </div>
+      <div
+        className="pointer-events-none absolute top-0 bottom-0"
+        style={{
+          left,
+          width: 1,
+          background: tint,
+          boxShadow: m.glow(tint) ?? `0 0 5px ${tint}`,
+          opacity: 0.95,
+        }}
+      />
+    </div>
+  );
+}
+
+/** Capture: dense rectangular strokes across the full width; silence still scrolls. */
+function CaptureWave({ m, level, phase }: { m: Mat; level: number; phase: number }) {
+  const bars = 88;
+  const drift = (Math.round(phase * 100) / 100) * Math.PI * 2;
+  const heights = Array.from({ length: bars }, (_, i) => {
+    const t = i / bars;
+    const speech =
+      Math.abs(Math.sin(t * 14 + drift * 1.7)) * 0.45 +
+      Math.abs(Math.sin(t * 31 + drift * 2.3)) * 0.3 +
+      Math.abs(Math.sin(t * 53 - drift)) * 0.2;
+    const win = Math.sin(t * Math.PI);
+    const v = level * speech * (0.55 + win * 0.45);
+    return { h: px(Math.max(2, v * 28)), hot: v > 0.06 };
+  });
+  return (
+    <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+      {heights.map((bar, i) => (
+        <Bar key={i} height={bar.h} color={m.p.accent} opacity={bar.hot ? 0.92 : 0.14} />
+      ))}
+    </div>
+  );
+}
+
+/** Working activity — sweep: sheen travels edge to edge; pulse: amplitude breathes. */
+function ActivityField({
+  m, tint, phase, kind,
+}: {
+  m: Mat; tint: string; phase: number; kind: "sweep" | "pulse";
+}) {
+  const bars = 80;
+  const ph = Math.round(phase * 100) / 100;
+
+  if (kind === "pulse") {
+    const amp = 0.35 + Math.abs(Math.sin(ph * Math.PI * 2)) * 0.55;
+    return (
+      <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+        {Array.from({ length: bars }, (_, i) => {
+          const t = i / bars;
+          const hump = Math.sin(t * Math.PI);
+          return <Bar key={i} height={px(2 + hump * amp * 26)} color={tint} opacity={op(0.25 + hump * 0.55)} />;
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+      {Array.from({ length: bars }, (_, i) => {
+        const t = i / (bars - 1);
+        const d = Math.min(Math.abs(t - ph), 1 - Math.abs(t - ph));
+        const lobe = Math.max(0, 1 - d * 2.4);
+        return <Bar key={i} height={px(3 + lobe * 24)} color={tint} opacity={op(0.18 + lobe * 0.78)} />;
+      })}
+    </div>
+  );
+}
+
+/** Zero-state bay — same height as the transport ring. */
+function RestField({ m, label = "AT REST", silhouette = false }: { m: Mat; label?: string; silhouette?: boolean }) {
+  const n = 64;
+  return (
+    <div className="relative flex h-full w-full items-center justify-center">
+      {silhouette ? (
+        <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+          {Array.from({ length: n }, (_, i) => {
+            const t = i / (n - 1);
+            const phrase = Math.abs(Math.sin(t * Math.PI * 3.2));
+            const formant = Math.abs(Math.sin(t * 47)) * 0.35 + Math.abs(Math.sin(t * 19)) * 0.25;
+            const breath = phrase > 0.12 ? 1 : 0.08;
+            const v = Math.min(1, Math.max(0.06, (phrase * 0.55 + formant) * breath));
+            return <Bar key={i} height={px(2 + v * 22)} color={m.line} opacity={op(0.28 + v * 0.22)} />;
+          })}
+        </div>
+      ) : (
+        <div className="mx-1 h-px w-full" style={{ background: m.lineSoft }} />
+      )}
+      <span
+        className="pointer-events-none absolute font-mono font-semibold"
+        style={{
+          fontSize: 8,
+          letterSpacing: "0.14em",
+          color: m.p.ink4,
+          background: m.p.trace,
+          padding: "2px 8px",
+          borderRadius: 999,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Theme strip — all five at designed defaults, frozen in speaking mode
+// ---------------------------------------------------------------------------
+
+function ThemeStrip({ active, onPick }: { active: ThemeId; onPick: (id: ThemeId) => void }) {
+  const env = useMemo(() => speechEnvelope(72, 7), []);
+  return (
+    <div>
+      <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">The five materials</h2>
+      <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+        Same mock, same state (speaking), designed defaults. Click a card to load
+        the theme into the playground.
+      </p>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {THEMES.map((t) => {
+          const p = t.presets[0].tokens;
+          const mat = resolveMat(p, t.presets[0].skin, t.scheme, DEFAULT_KNOBS);
+          const meta = modesFor(p)[4]; // speaking
+          return (
+            <div
+              key={t.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => onPick(t.id)}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onPick(t.id); }}
+              className="cursor-pointer rounded-xl p-4 text-left transition"
+              style={{
+                background: p.page,
+                border: `1px solid ${t.id === active ? p.accent : mat.lineSoft}`,
+                boxShadow: t.id === active ? `0 0 0 1px ${hexA(p.accent, 0.5)}` : undefined,
+              }}
+            >
+              <div className="mb-2 flex items-baseline justify-between">
+                <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]" style={{ color: p.ink }}>
+                  {t.name}
+                </span>
+                <span className="font-mono text-[8.5px] uppercase tracking-[0.12em]" style={{ color: p.ink4 }}>
+                  {t.presets[0].skin.name}
+                </span>
+              </div>
+              <div className="pointer-events-none">
+                <LaneColumn
+                  m={mat}
+                  mode="speaking"
+                  meta={meta}
+                  messages={[{ role: "you", text: YOU }, { role: "agent", text: AGENT }]}
+                  pos={0.42}
+                  level={0.6}
+                  volume={0.8}
+                  speedIx={0}
+                  autoplay
+                  env={env}
+                  phase={0.35}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Export — DeckThemePalette JSON + Swift-ready hex literals
+// ---------------------------------------------------------------------------
+
+function exportJSON(p: Palette): string {
+  const out: Record<string, string> = {};
+  for (const k of TOKEN_KEYS) out[k] = p[k].toUpperCase();
+  return JSON.stringify(out, null, 2);
+}
+
+function swiftHex(hex: string): string {
+  return `0x${hex.replace("#", "").toUpperCase()}`;
+}
+
+function exportSwift(p: Palette): string {
+  const g = (keys: TokenKey[]) => keys.map((k) => `${k}: ${swiftHex(p[k])}`).join(", ");
+  return [
+    "DeckThemePalette(",
+    `    ${g(["page", "panel", "panelHead", "cell"])},`,
+    `    ${g(["trace", "line", "lineSoft"])},`,
+    `    ${g(["ink", "ink2", "ink3", "ink4"])},`,
+    `    ${g(["accent", "accentDim", "accentDark", "accentEdge"])},`,
+    `    ${g(["amber", "plate", "plateTop", "plateBottom"])},`,
+    `    ${g(["pad", "padBottom", "empty"])},`,
+    `    ${g(["micTop", "micBottom"])}`,
+    ")",
+  ].join("\n");
+}
+
+function ExportPanel({ theme, presetName, palette }: { theme: ThemeDef; presetName: string; palette: Palette }) {
+  const json = exportJSON(palette);
+  const swift = exportSwift(palette);
+  return (
+    <div>
+      <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">Export</h2>
+      <p className="mb-4 max-w-[70ch] text-[13px] leading-relaxed text-studio-ink-faint">
+        {theme.name} · {presetName} — current tokens as{" "}
+        <code>DeckThemePalette</code>-keyed JSON, or drop-in Swift hex literals for{" "}
+        <code>DeckTheme.swift</code>.
+      </p>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ExportBlock title="tokens.json" body={json} />
+        <ExportBlock title="DeckTheme.swift palette" body={swift} />
+      </div>
+    </div>
+  );
+}
+
+function ExportBlock({ title, body }: { title: string; body: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(body);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  };
+  return (
+    <div className="overflow-hidden rounded-lg border border-studio-rule">
+      <div className="flex items-center justify-between border-b border-studio-rule px-3 py-1.5">
+        <span className="font-mono text-[10px] text-studio-ink-faint">{title}</span>
+        <button
+          type="button"
+          onClick={copy}
+          className="rounded border border-studio-rule px-2 py-0.5 text-[10px] text-studio-ink-faint hover:text-studio-ink"
+        >
+          {copied ? "Copied ✓" : "Copy"}
+        </button>
+      </div>
+      <pre className="max-h-[320px] overflow-auto p-3 font-mono text-[10.5px] leading-relaxed text-studio-ink">
+        {body}
+      </pre>
+    </div>
+  );
+}

--- a/design/studio/src/studio/MicroThemesMatureStudy.tsx
+++ b/design/studio/src/studio/MicroThemesMatureStudy.tsx
@@ -1,0 +1,639 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { PageHeader } from "@/studio/PageHeader";
+import { MicroDeckFullMock, type FullMockTokens } from "@/studio/MicroDeckFullMock";
+import type { StudioAppPage } from "@/studio/studioRegistry";
+
+/**
+ * Premium theme targets for the real Micro Deck product language.
+ *
+ * Structure matches shipping iPad (pad faces, hold key, lane chips, ledger rail).
+ * Color is where class lives — each theme is a considered material + signal pair.
+ */
+
+type ThemeId = "flight" | "obsidian" | "ceramic" | "porcelain" | "amber";
+type Mode = "ready" | "listening" | "speaking" | "paused";
+
+const MONO =
+  'ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace';
+
+const GUTTER = 46;
+const GAP = 12;
+
+/**
+ * Hand-tuned. Not Tailwind defaults.
+ * Flight specifically avoids “black + neon mint.”
+ */
+const THEMES: {
+  id: ThemeId;
+  name: string;
+  scheme: "dark" | "light";
+  thesis: string;
+  kinship: string;
+  tokens: FullMockTokens;
+}[] = [
+  {
+    id: "flight",
+    name: "Flight",
+    scheme: "dark",
+    thesis:
+      "Blue-graphite instrument case. Signal is sea-glass — cool, soft, jewelry-store green, not esports mint.",
+    kinship: "Bang & Olufsen night · aviation glass",
+    tokens: {
+      page: "#080b0f",
+      panel: "#0e1319",
+      panelHead: "#131920",
+      cell: "#171e27",
+      line: "#2a333f",
+      lineSoft: "#1c242e",
+      ink: "#eef2f5",
+      ink2: "#9aa7b4",
+      ink3: "#6a7786",
+      ink4: "#4b5664",
+      accent: "#6eb8a4",
+      accentDim: "#3d8a78",
+      amber: "#c4a05a",
+      pad: "#171e27",
+      padBottom: "#11171f",
+      plate: "#0b0f14",
+      plateTop: "#151c24",
+      plateBottom: "#090c10",
+      micTop: "#4a9a86",
+      micBottom: "#2a6456",
+      empty: "#080b0f",
+    },
+  },
+  {
+    id: "obsidian",
+    name: "Obsidian",
+    scheme: "dark",
+    thesis:
+      "Ink black with cold depth. Signal is pewter-blue — mission steel, not SaaS hyperlink blue.",
+    kinship: "Hasselblad UI · ops theater",
+    tokens: {
+      page: "#050506",
+      panel: "#0b0b0d",
+      panelHead: "#111114",
+      cell: "#16161a",
+      line: "#2a2a30",
+      lineSoft: "#1a1a1f",
+      ink: "#f3f3f4",
+      ink2: "#a3a3ab",
+      ink3: "#70707a",
+      ink4: "#505058",
+      accent: "#7f96b5",
+      accentDim: "#536a8a",
+      amber: "#b89650",
+      pad: "#16161a",
+      padBottom: "#101014",
+      plate: "#08080a",
+      plateTop: "#131316",
+      plateBottom: "#060607",
+      micTop: "#5a7190",
+      micBottom: "#354a66",
+      empty: "#050506",
+    },
+  },
+  {
+    id: "ceramic",
+    name: "Ceramic",
+    scheme: "light",
+    thesis:
+      "Warm bone field (not kraft paper). Accent is oxblood — print shop, not marketing orange.",
+    kinship: "Hermès packaging · Apple light",
+    tokens: {
+      page: "#efe9e0",
+      panel: "#f7f3ec",
+      panelHead: "#fcf9f4",
+      cell: "#fffcf7",
+      line: "#ddd4c6",
+      lineSoft: "#e8e1d5",
+      ink: "#1c1612",
+      ink2: "#5a4f46",
+      ink3: "#7d7166",
+      ink4: "#a39689",
+      accent: "#7a3428",
+      accentDim: "#9a4a3a",
+      amber: "#8f6528",
+      pad: "#fffcf7",
+      padBottom: "#f0ebe2",
+      plate: "#e8e1d5",
+      plateTop: "#fcf9f4",
+      plateBottom: "#e0d8cb",
+      micTop: "#9a4a3a",
+      micBottom: "#7a3428",
+      empty: "#efe9e0",
+    },
+  },
+  {
+    id: "porcelain",
+    name: "Porcelain",
+    scheme: "light",
+    thesis:
+      "Cool gallery white. Signal is deep navy-ink — almost typographic, never sky-blue chrome.",
+    kinship: "Braun white · Swiss product",
+    tokens: {
+      page: "#ececee",
+      panel: "#f5f5f6",
+      panelHead: "#fbfbfc",
+      cell: "#ffffff",
+      line: "#dcdce0",
+      lineSoft: "#e8e8ec",
+      ink: "#121214",
+      ink2: "#484850",
+      ink3: "#6c6c76",
+      ink4: "#9898a2",
+      accent: "#1e2d48",
+      accentDim: "#3a4d6e",
+      amber: "#7a5c24",
+      pad: "#ffffff",
+      padBottom: "#f0f0f2",
+      plate: "#e6e6ea",
+      plateTop: "#ffffff",
+      plateBottom: "#dcdee2",
+      micTop: "#3a4d6e",
+      micBottom: "#1e2d48",
+      empty: "#ececee",
+    },
+  },
+  {
+    id: "amber",
+    name: "Amber",
+    scheme: "dark",
+    thesis:
+      "Espresso chassis. Copper signal kept matte and expensive — never neon, never pumpkin.",
+    kinship: "Aged brass · late studio",
+    tokens: {
+      page: "#0e0c0a",
+      panel: "#161310",
+      panelHead: "#1c1914",
+      cell: "#221e18",
+      line: "#383028",
+      lineSoft: "#28241e",
+      ink: "#f6f0e6",
+      ink2: "#c0b2a0",
+      ink3: "#8a7c6c",
+      ink4: "#685c50",
+      accent: "#b88458",
+      accentDim: "#8f6240",
+      amber: "#a88838",
+      pad: "#221e18",
+      padBottom: "#18140f",
+      plate: "#12100d",
+      plateTop: "#1e1a15",
+      plateBottom: "#0e0c0a",
+      micTop: "#a07048",
+      micBottom: "#6f4a2c",
+      empty: "#0e0c0a",
+    },
+  },
+];
+
+const LEDGER = [
+  { role: "you" as const, text: "Walk the full lifecycle without Codex." },
+  {
+    role: "agent" as const,
+    text: "Lifecycle complete. Listening, transcription, and narration held geometry.",
+  },
+  { role: "you" as const, text: "Tighten the player foot and ledger rail." },
+  {
+    role: "agent" as const,
+    text: "Ring in the gutter, caption on the text rail, tape clock under the bay only.",
+  },
+];
+
+export function MicroThemesMatureStudyPage({ page }: { page: StudioAppPage }) {
+  const [themeId, setThemeId] = useState<ThemeId>("flight");
+  const [mode, setMode] = useState<Mode>("speaking");
+  const [pos] = useState(0.34);
+
+  const theme = THEMES.find((x) => x.id === themeId) ?? THEMES[0];
+  const t = theme.tokens;
+  const live = mode === "listening" || mode === "speaking";
+
+  const messages = useMemo(
+    () =>
+      mode === "ready" ? [] : mode === "listening" ? LEDGER.slice(0, 1) : LEDGER,
+    [mode],
+  );
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+
+      <section className="mx-auto max-w-[1220px] space-y-10 py-8">
+        <div className="max-w-[54ch]">
+          <h2 className="mb-2 text-[15px] font-semibold tracking-[-0.02em] text-studio-ink-strong">
+            Premium targets
+          </h2>
+          <p className="text-[13px] leading-[1.65] text-studio-ink">
+            Structure matches the shipping Micro Deck (pad faces, hold key, lane
+            chips, ledger rail). Class is in the palette and type weight — sea-glass
+            on graphite, oxblood on bone, pewter on black. Not Tailwind emerald. Not
+            workshop grain.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {THEMES.map((th) => {
+            const on = th.id === themeId;
+            return (
+              <button
+                key={th.id}
+                type="button"
+                onClick={() => setThemeId(th.id)}
+                className="rounded-lg px-3 py-2 text-left"
+                style={{
+                  border: `1px solid ${on ? th.tokens.accent : "var(--studio-rule, #333)"}`,
+                  background: on ? th.tokens.panel : "transparent",
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="h-2 w-2 rounded-full"
+                    style={{ background: th.tokens.accent }}
+                  />
+                  <span className="text-[12px] font-semibold tracking-[-0.02em] text-studio-ink-strong">
+                    {th.name}
+                  </span>
+                </div>
+                <div className="mt-0.5 text-[10px] text-studio-ink-faint">{th.kinship}</div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {(
+            [
+              ["ready", "Ready"],
+              ["listening", "Listening"],
+              ["speaking", "Speaking"],
+              ["paused", "Paused"],
+            ] as const
+          ).map(([key, word]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setMode(key)}
+              className="rounded-md px-2.5 py-1 text-[11px] font-medium"
+              style={{
+                border: `1px solid ${mode === key ? t.accent : "var(--studio-rule, #333)"}`,
+                color: mode === key ? t.accent : "var(--studio-ink-faint, #888)",
+                background: mode === key ? rgba(t.accent, 0.08) : "transparent",
+              }}
+            >
+              {word}
+            </button>
+          ))}
+        </div>
+
+        <div
+          className="overflow-x-auto rounded-2xl p-4"
+          style={{ background: t.page, border: `1px solid ${t.lineSoft}` }}
+        >
+          <MicroDeckFullMock
+            tokens={t}
+            mode={mode}
+            handWidth={318}
+            consoleWidth={400}
+            height={600}
+          >
+            <ShipConsole
+              t={t}
+              mode={mode}
+              messages={messages}
+              pos={mode === "speaking" || mode === "paused" ? pos : 0}
+              live={live}
+            />
+          </MicroDeckFullMock>
+        </div>
+
+        <div className="grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+          {THEMES.map((th) => (
+            <button
+              key={th.id}
+              type="button"
+              onClick={() => setThemeId(th.id)}
+              className="rounded-xl p-3 text-left"
+              style={{
+                background: th.tokens.page,
+                border: `1px solid ${th.id === themeId ? th.tokens.accent : th.tokens.line}`,
+              }}
+            >
+              <div
+                className="text-[12px] font-semibold tracking-[-0.02em]"
+                style={{ color: th.tokens.ink }}
+              >
+                {th.name}
+              </div>
+              <div className="mt-0.5 text-[10px]" style={{ color: th.tokens.ink4 }}>
+                {th.kinship}
+              </div>
+              <p className="mt-2 text-[11px] leading-snug" style={{ color: th.tokens.ink3 }}>
+                {th.thesis}
+              </p>
+              <div className="mt-3 flex gap-1">
+                {[th.tokens.panel, th.tokens.accent, th.tokens.ink2, th.tokens.micTop].map(
+                  (c) => (
+                    <span
+                      key={c + th.id}
+                      className="h-5 flex-1 rounded"
+                      style={{
+                        background: c,
+                        border: `1px solid ${th.tokens.lineSoft}`,
+                      }}
+                    />
+                  ),
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+/** Console matches shipping language: mono instrument, ledger rail. */
+function ShipConsole({
+  t,
+  mode,
+  messages,
+  pos,
+  live,
+}: {
+  t: FullMockTokens;
+  mode: Mode;
+  messages: { role: "you" | "agent"; text: string }[];
+  pos: number;
+  live: boolean;
+}) {
+  const status =
+    mode === "listening"
+      ? "LISTENING"
+      : mode === "speaking"
+        ? "SPEAKING"
+        : mode === "paused"
+          ? "PAUSED"
+          : "ACTIVE LANE";
+
+  return (
+    <div
+      className="flex h-full flex-col overflow-hidden"
+      style={{
+        fontFamily: MONO,
+        background: t.panel,
+        border: `1px solid ${live ? rgba(t.accent, 0.4) : t.line}`,
+        borderRadius: 10,
+      }}
+    >
+      <div
+        className="flex items-start gap-3 px-3.5 pb-2.5 pt-3"
+        style={{ borderBottom: `1px solid ${t.lineSoft}` }}
+      >
+        <span
+          style={{
+            width: GUTTER,
+            fontSize: 26,
+            fontWeight: 600,
+            letterSpacing: "-0.03em",
+            lineHeight: 1,
+            color: t.accent,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          01
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span
+              className="truncate"
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: "0.06em",
+                color: t.ink,
+              }}
+            >
+              LINEA
+            </span>
+            <span className="ml-auto flex items-center gap-1.5">
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{
+                  background: live ? t.accent : t.ink4,
+                  boxShadow: live ? `0 0 6px ${t.accent}` : undefined,
+                }}
+              />
+              <span
+                style={{
+                  fontSize: 8,
+                  fontWeight: 700,
+                  letterSpacing: "0.12em",
+                  color: live ? t.accent : t.ink3,
+                }}
+              >
+                {status}
+              </span>
+            </span>
+          </div>
+          <div className="mt-1 flex gap-2" style={{ fontSize: 8, color: t.ink4 }}>
+            <span>main</span>
+            <span
+              className="rounded px-1"
+              style={{
+                border: `1px solid ${t.lineSoft}`,
+                color: t.ink3,
+              }}
+            >
+              6B306A13
+            </span>
+            <span
+              className="rounded px-1"
+              style={{
+                border: `1px solid ${rgba(t.accent, 0.35)}`,
+                color: t.accent,
+                fontSize: 7,
+                fontWeight: 700,
+                letterSpacing: "0.08em",
+              }}
+            >
+              DECK
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto px-3.5 py-2.5">
+        {messages.length === 0 ? (
+          <p style={{ paddingLeft: GUTTER + GAP, fontSize: 10, color: t.ink4 }}>
+            No exchange yet on this lane.
+          </p>
+        ) : (
+          <div className="space-y-2.5">
+            {messages.map((m, i) => (
+              <div key={i} className="flex items-start gap-3">
+                <span
+                  style={{
+                    width: GUTTER,
+                    fontSize: 7.5,
+                    fontWeight: 700,
+                    letterSpacing: "0.08em",
+                    color: t.ink4,
+                    paddingTop: 2,
+                  }}
+                >
+                  {m.role === "you" ? "YOU" : "AGENT"}
+                </span>
+                <p
+                  className="min-w-0 flex-1"
+                  style={{
+                    fontSize: 10,
+                    lineHeight: 1.45,
+                    color: m.role === "agent" ? t.ink2 : t.ink3,
+                  }}
+                >
+                  {m.text}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          borderTop: `1px solid ${t.lineSoft}`,
+          background: `linear-gradient(180deg, ${t.plateTop}, ${t.plateBottom})`,
+          padding: "10px 14px 11px",
+        }}
+      >
+        <div style={{ paddingLeft: GUTTER + GAP }} className="mb-2">
+          <div className="flex items-center gap-1.5" style={{ fontSize: 8, fontWeight: 700, letterSpacing: "0.1em" }}>
+            <span style={{ color: live ? t.accent : t.ink3 }}>TURN 1</span>
+            <span style={{ color: t.ink4 }}>·</span>
+            <span style={{ color: live ? t.accent : t.ink3 }}>
+              {mode === "speaking" ? "SPEAKING" : mode === "paused" ? "PAUSED" : "SUMMARY"}
+            </span>
+          </div>
+          <div
+            className="mt-1 truncate"
+            style={{ fontSize: 10, color: t.ink, lineHeight: 1.35 }}
+          >
+            {messages.find((m) => m.role === "agent")?.text ?? "Nothing to play"}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="flex justify-center" style={{ width: GUTTER }}>
+            <div
+              className="flex h-[44px] w-[44px] items-center justify-center rounded-full"
+              style={{
+                background: t.empty,
+                border: `2px solid ${live || mode === "ready" || mode === "paused" ? t.accent : t.line}`,
+                color: live || mode === "ready" || mode === "paused" ? t.accent : t.ink4,
+              }}
+            >
+              <span style={{ fontSize: 12 }}>{mode === "speaking" ? "❚❚" : "▶"}</span>
+            </div>
+          </div>
+          <div
+            className="relative h-[44px] min-w-0 flex-1 overflow-hidden"
+            style={{
+              borderRadius: 6,
+              background: t.empty,
+              border: `1px solid ${t.line}`,
+            }}
+          >
+            <div className="absolute inset-0 flex items-center px-2">
+              <Wave
+                pos={mode === "speaking" || mode === "paused" ? pos : 0}
+                accent={t.accent}
+                line={t.line}
+              />
+            </div>
+          </div>
+        </div>
+
+        {(mode === "speaking" || mode === "paused" || mode === "ready") && (
+          <div
+            className="relative mt-1.5 tabular-nums"
+            style={{
+              marginLeft: GUTTER + GAP,
+              fontSize: 9,
+              color: t.ink4,
+            }}
+          >
+            <div className="flex justify-between">
+              <span>0:00</span>
+              <span>0:04</span>
+            </div>
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              style={{ color: t.ink3 }}
+            >
+              {mode === "ready" ? "0:00" : "0:01"}
+            </div>
+          </div>
+        )}
+
+        <div className="mt-2 flex gap-1.5">
+          {[
+            { a: "1.00×", b: "" },
+            { a: "VOL", b: "——" },
+            { a: "AUTOPLAY", b: "ON" },
+          ].map((chip) => (
+            <span
+              key={chip.a}
+              className="rounded px-1.5 py-1"
+              style={{
+                border: `1px solid ${chip.a === "AUTOPLAY" ? rgba(t.amber, 0.45) : t.lineSoft}`,
+                background: chip.a === "AUTOPLAY" ? rgba(t.amber, 0.1) : t.cell,
+                fontSize: 8,
+                fontWeight: 600,
+                letterSpacing: "0.04em",
+                color: chip.a === "AUTOPLAY" ? t.amber : t.ink3,
+              }}
+            >
+              {chip.a}
+              {chip.b ? ` ${chip.b}` : ""}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Wave({ pos, accent, line }: { pos: number; accent: string; line: string }) {
+  const n = 56;
+  return (
+    <div className="flex h-7 w-full items-center gap-px">
+      {Array.from({ length: n }, (_, i) => {
+        const x = i / (n - 1);
+        const h = 0.12 + Math.abs(Math.sin(x * Math.PI * 3.1)) * 0.8;
+        const played = x <= pos;
+        return (
+          <div
+            key={i}
+            className="flex-1"
+            style={{
+              height: `${h * 100}%`,
+              borderRadius: 1,
+              background: played ? accent : line,
+              opacity: played ? 0.92 : 0.3,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function rgba(hex: string, a: number) {
+  const h = hex.replace("#", "");
+  const n = parseInt(h, 16);
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+}

--- a/design/studio/src/studio/MicroThemesOpusStudy.tsx
+++ b/design/studio/src/studio/MicroThemesOpusStudy.tsx
@@ -1,0 +1,2934 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { PageHeader } from "@/studio/PageHeader";
+import { MicroDeckFullMock } from "@/studio/MicroDeckFullMock";
+import type { StudioAppPage } from "@/studio/studioRegistry";
+
+/**
+ * Micro Deck — theme material study (Opus).
+ *
+ * The layout is fixed: it is the shipped Micro ledger column from
+ * `NativeDeckView.ActiveLaneInstrument` + `DeckPlayerConsole` (see
+ * `LaneConsoleStudy` for the same geometry in the studio). One outer surface,
+ * 50pt gutter, text rail at 76, fused player foot at 2U, tape clock under the
+ * bay only, chips on the plate floor.
+ *
+ * What changes here is the *material*: every theme is redesigned as a distinct
+ * physical object — anodized graphite, obsidian glass, phosphor CRT, fired
+ * glaze, kraft press, bisque, frosted glass, Swiss plate, vacuum tube, ferric
+ * tape, brass and walnut. Colour is only one axis; texture, lighting, corner
+ * language, hairline weight and type do the rest.
+ *
+ * Everything is live: theme, material preset, every palette token, and a rack
+ * of global knobs. Export emits `DeckThemePalette` field names so a direction
+ * can be pasted straight back into `deck/ipad/Sources/DeckTheme.swift`.
+ */
+
+/* ------------------------------------------------------------------ tokens */
+
+/** Field names mirror `DeckThemePalette` exactly — export must round-trip. */
+const TOKEN_KEYS = [
+  "page",
+  "panel",
+  "panelHead",
+  "cell",
+  "trace",
+  "line",
+  "lineSoft",
+  "ink",
+  "ink2",
+  "ink3",
+  "ink4",
+  "accent",
+  "accentDim",
+  "accentDark",
+  "accentEdge",
+  "amber",
+  "plate",
+  "plateTop",
+  "plateBottom",
+  "pad",
+  "padBottom",
+  "empty",
+  "micTop",
+  "micBottom",
+] as const;
+
+type TokenKey = (typeof TOKEN_KEYS)[number];
+type Tokens = Record<TokenKey, string>;
+
+const TOKEN_GROUPS: { title: string; keys: TokenKey[] }[] = [
+  { title: "Chassis", keys: ["page", "panel", "panelHead", "cell", "trace", "empty"] },
+  { title: "Rules", keys: ["line", "lineSoft"] },
+  { title: "Ink ladder", keys: ["ink", "ink2", "ink3", "ink4"] },
+  { title: "Signal", keys: ["accent", "accentDim", "accentDark", "accentEdge", "amber"] },
+  { title: "Plate", keys: ["plate", "plateTop", "plateBottom"] },
+  { title: "Pad", keys: ["pad", "padBottom"] },
+  { title: "Mic", keys: ["micTop", "micBottom"] },
+];
+
+/* ---------------------------------------------------------------- material */
+
+const FONTS = {
+  mono: `ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace`,
+  typewriter: `"Courier New", Courier, ui-monospace, monospace`,
+  grotesk: `"Helvetica Neue", Helvetica, Inter, system-ui, sans-serif`,
+  serif: `Georgia, "Iowan Old Style", "Times New Roman", serif`,
+} as const;
+
+type FontKey = keyof typeof FONTS;
+type Texture = "matte" | "glass" | "scanline" | "brushed" | "paper" | "grain";
+
+/**
+ * The non-colour half of a material. Everything here is a live knob; presets
+ * only seed it. `playerH` is ignored while `lockU` holds (2U contract).
+ */
+interface Material {
+  texture: Texture;
+  grain: number;
+  sheen: number;
+  bevel: number;
+  plateGrad: number;
+  radius: number;
+  bayRadius: number;
+  chipRadius: number;
+  hairline: number;
+  borderAlpha: number;
+  glow: number;
+  typeScale: number;
+  identTrack: number;
+  gutter: number;
+  lockU: boolean;
+  playerH: number;
+  spacing: number;
+  fontMono: FontKey;
+  fontCaption: FontKey;
+  numeralWeight: number;
+}
+
+interface Preset {
+  id: string;
+  label: string;
+  blurb: string;
+  tokens: Tokens;
+  material: Material;
+}
+
+interface ThemeDef {
+  id: string;
+  name: string;
+  scheme: "dark" | "light";
+  thesis: string;
+  presets: Preset[];
+}
+
+/** One key-bank row — the Micro pad grid unit. Player is exactly 2U. */
+const U = 78;
+const PLAYER_2U = U * 2;
+
+/** Quieter defaults — product maturity over workshop texture. */
+const BASE_MATERIAL: Material = {
+  texture: "matte",
+  grain: 0.08,
+  sheen: 0.12,
+  bevel: 0.15,
+  plateGrad: 0.55,
+  radius: 10,
+  bayRadius: 6,
+  chipRadius: 6,
+  hairline: 1,
+  borderAlpha: 0.75,
+  glow: 0.12,
+  typeScale: 1,
+  identTrack: 0.01,
+  gutter: 50,
+  lockU: true,
+  playerH: PLAYER_2U,
+  spacing: 1,
+  fontMono: "mono",
+  fontCaption: "grotesk",
+  numeralWeight: 600,
+};
+
+function mat(patch: Partial<Material>): Material {
+  return { ...BASE_MATERIAL, ...patch };
+}
+
+/* ------------------------------------------------------------------ themes */
+
+const THEMES: ThemeDef[] = [
+  {
+    id: "flight",
+    name: "Flight",
+    scheme: "dark",
+    thesis:
+      "Anodised graphite — a brushed instrument case lit from the top edge, mint kept as a lamp, never a wash.",
+    presets: [
+      {
+        id: "void-graphite",
+        label: "Void graphite",
+        blurb:
+          "Brushed anodised aluminium over void. Top-lit plate, recessed bay, mint only where the signal is live.",
+        tokens: {
+          page: "#06080a",
+          panel: "#0e141a",
+          panelHead: "#131a21",
+          cell: "#19212a",
+          trace: "#05070a",
+          line: "#2a333c",
+          lineSoft: "#19212a",
+          ink: "#f1f5f7",
+          ink2: "#a6b1bb",
+          ink3: "#6a7681",
+          ink4: "#47525c",
+          accent: "#5ee9c2",
+          accentDim: "#35b394",
+          accentDark: "#08201b",
+          accentEdge: "#1c4f42",
+          amber: "#e0a83f",
+          plate: "#0a0e12",
+          plateTop: "#151c22",
+          plateBottom: "#080b0e",
+          pad: "#19212a",
+          padBottom: "#0e1318",
+          empty: "#05070a",
+          micTop: "#14a07a",
+          micBottom: "#0a6b50",
+        },
+        material: mat({
+          texture: "brushed",
+          grain: 0.45,
+          sheen: 0.35,
+          bevel: 0.5,
+          plateGrad: 0.95,
+          radius: 10,
+          bayRadius: 6,
+          chipRadius: 4,
+          glow: 0.35,
+        }),
+      },
+      {
+        id: "liquid-glass-mint",
+        label: "Liquid glass mint",
+        blurb:
+          "Refractive slab. Specular sweep off the top-left corner, generous radii, hairlines dissolved to rim light.",
+        tokens: {
+          page: "#04070b",
+          panel: "#0f1821",
+          panelHead: "#16222c",
+          cell: "#1b2833",
+          trace: "#081119",
+          line: "#3a5563",
+          lineSoft: "#1e2e3a",
+          ink: "#effbf7",
+          ink2: "#a9c6c6",
+          ink3: "#6e8c92",
+          ink4: "#4a6670",
+          accent: "#7cffda",
+          accentDim: "#46c7ac",
+          accentDark: "#062822",
+          accentEdge: "#2a6f60",
+          amber: "#f2c46a",
+          plate: "#0b141c",
+          plateTop: "#1b2b36",
+          plateBottom: "#080f16",
+          pad: "#1a2932",
+          padBottom: "#101b23",
+          empty: "#071018",
+          micTop: "#22c79c",
+          micBottom: "#0e7c63",
+        },
+        material: mat({
+          texture: "glass",
+          grain: 0.12,
+          sheen: 1,
+          bevel: 0.85,
+          plateGrad: 1.25,
+          radius: 18,
+          bayRadius: 12,
+          chipRadius: 9,
+          borderAlpha: 0.55,
+          glow: 0.85,
+          typeScale: 1.02,
+          fontCaption: "grotesk",
+        }),
+      },
+      {
+        id: "brutal-plate",
+        label: "Brutal plate",
+        blurb:
+          "Cast, not milled. Square corners, 1.5px rules, zero gloss — mint demoted to a hard chip of pigment.",
+        tokens: {
+          page: "#0b0b0b",
+          panel: "#151515",
+          panelHead: "#191919",
+          cell: "#1e1e1e",
+          trace: "#0e0e0e",
+          line: "#3a3a3a",
+          lineSoft: "#262626",
+          ink: "#ffffff",
+          ink2: "#b8b8b8",
+          ink3: "#7c7c7c",
+          ink4: "#565656",
+          accent: "#3ce0a8",
+          accentDim: "#2a9e77",
+          accentDark: "#0c1a15",
+          accentEdge: "#1f4535",
+          amber: "#d99a2b",
+          plate: "#131313",
+          plateTop: "#1a1a1a",
+          plateBottom: "#101010",
+          pad: "#1c1c1c",
+          padBottom: "#141414",
+          empty: "#0e0e0e",
+          micTop: "#199e77",
+          micBottom: "#0c6349",
+        },
+        material: mat({
+          texture: "matte",
+          grain: 0.2,
+          sheen: 0,
+          bevel: 0.08,
+          plateGrad: 0.25,
+          radius: 2,
+          bayRadius: 2,
+          chipRadius: 0,
+          hairline: 1.5,
+          borderAlpha: 1,
+          glow: 0,
+          typeScale: 0.97,
+          identTrack: 0.08,
+        }),
+      },
+    ],
+  },
+  {
+    id: "obsidian",
+    name: "Obsidian",
+    scheme: "dark",
+    thesis:
+      "Volcanic glass — near-black with a cool blue sub-surface; the plate reads as depth, not as paint.",
+    presets: [
+      {
+        id: "obsidian-glass",
+        label: "Obsidian glass",
+        blurb:
+          "Black glass with blue scatter under the surface. Deep recessed wells, soft corner light, cold ink.",
+        tokens: {
+          page: "#020304",
+          panel: "#080b0e",
+          panelHead: "#0c1116",
+          cell: "#101720",
+          trace: "#06090c",
+          line: "#26303a",
+          lineSoft: "#161d25",
+          ink: "#f0f5fa",
+          ink2: "#b3c1ce",
+          ink3: "#74838f",
+          ink4: "#4a5661",
+          accent: "#79b8ff",
+          accentDim: "#4b82b8",
+          accentDark: "#071827",
+          accentEdge: "#244968",
+          amber: "#e8b85d",
+          plate: "#06090c",
+          plateTop: "#121a23",
+          plateBottom: "#05080a",
+          pad: "#131a22",
+          padBottom: "#0b1015",
+          empty: "#070a0d",
+          micTop: "#256fa8",
+          micBottom: "#184a72",
+        },
+        material: mat({
+          texture: "glass",
+          grain: 0.1,
+          sheen: 0.75,
+          bevel: 0.7,
+          plateGrad: 1.1,
+          radius: 12,
+          bayRadius: 8,
+          chipRadius: 5,
+          borderAlpha: 0.7,
+          glow: 0.5,
+        }),
+      },
+      {
+        id: "machined-black",
+        label: "Machined black",
+        blurb:
+          "Brutalist instrument plate: bead-blasted black, engraved steel-blue legends, hard 1.25px rules.",
+        tokens: {
+          page: "#060606",
+          panel: "#0d0f10",
+          panelHead: "#111415",
+          cell: "#171b1d",
+          trace: "#0a0c0d",
+          line: "#313a40",
+          lineSoft: "#1c2226",
+          ink: "#edf2f5",
+          ink2: "#a9b4bb",
+          ink3: "#6e7981",
+          ink4: "#4b555c",
+          accent: "#6fa8d0",
+          accentDim: "#47708c",
+          accentDark: "#0b1720",
+          accentEdge: "#23485e",
+          amber: "#c9932f",
+          plate: "#0b0d0e",
+          plateTop: "#14181a",
+          plateBottom: "#090b0c",
+          pad: "#171b1e",
+          padBottom: "#0f1214",
+          empty: "#0a0c0d",
+          micTop: "#2b6f96",
+          micBottom: "#1a4a64",
+        },
+        material: mat({
+          texture: "brushed",
+          grain: 0.85,
+          sheen: 0.22,
+          bevel: 0.3,
+          plateGrad: 0.5,
+          radius: 3,
+          bayRadius: 3,
+          chipRadius: 2,
+          hairline: 1.25,
+          borderAlpha: 1,
+          glow: 0.05,
+          identTrack: 0.06,
+        }),
+      },
+      {
+        id: "phosphor-crt",
+        label: "Phosphor CRT",
+        blurb:
+          "Retro-future: scanlined tube face, cyan phosphor bloom, typewriter legends burnt into the glass.",
+        tokens: {
+          page: "#01060a",
+          panel: "#04121a",
+          panelHead: "#061821",
+          cell: "#08202b",
+          trace: "#020d13",
+          line: "#12485c",
+          lineSoft: "#0a2833",
+          ink: "#d6fbff",
+          ink2: "#8fd6e4",
+          ink3: "#4e93a4",
+          ink4: "#2e5f6e",
+          accent: "#4fd7ff",
+          accentDim: "#2b94b8",
+          accentDark: "#032430",
+          accentEdge: "#0f5670",
+          amber: "#ffc46b",
+          plate: "#031017",
+          plateTop: "#072029",
+          plateBottom: "#020b10",
+          pad: "#08202b",
+          padBottom: "#041219",
+          empty: "#020d13",
+          micTop: "#2199c4",
+          micBottom: "#0e5f7e",
+        },
+        material: mat({
+          texture: "scanline",
+          grain: 0.9,
+          sheen: 0.3,
+          bevel: 0.2,
+          plateGrad: 0.8,
+          radius: 6,
+          bayRadius: 4,
+          chipRadius: 3,
+          borderAlpha: 0.85,
+          glow: 1.15,
+          fontMono: "typewriter",
+          fontCaption: "typewriter",
+          identTrack: 0.05,
+        }),
+      },
+    ],
+  },
+  {
+    id: "ceramic",
+    name: "Ceramic",
+    scheme: "light",
+    thesis:
+      "Fired clay — a warm glazed body with a terracotta signal; daylight console, gloss only on the plate.",
+    presets: [
+      {
+        id: "fired-glaze",
+        label: "Fired glaze",
+        blurb:
+          "Cream glaze over warm bisque. Soft top gloss, terracotta lamp, hairlines the colour of unfired edge.",
+        tokens: {
+          page: "#e3dacc",
+          panel: "#f7f3eb",
+          panelHead: "#fcf8f1",
+          cell: "#fffdf8",
+          trace: "#f0e9dc",
+          line: "#d3c6ae",
+          lineSoft: "#e6ddcb",
+          ink: "#191410",
+          ink2: "#3d352a",
+          ink3: "#6e6455",
+          ink4: "#9a8e7a",
+          accent: "#b5421c",
+          accentDim: "#c9764f",
+          accentDark: "#f8e9da",
+          accentEdge: "#e7cfae",
+          amber: "#b57b1b",
+          plate: "#f2ede3",
+          plateTop: "#fdfbf6",
+          plateBottom: "#e9e2d5",
+          pad: "#fffdf8",
+          padBottom: "#efe9dd",
+          empty: "#ede6d8",
+          micTop: "#b5421c",
+          micBottom: "#8f3a1c",
+        },
+        material: mat({
+          texture: "glass",
+          grain: 0.14,
+          sheen: 0.8,
+          bevel: 0.5,
+          plateGrad: 1,
+          radius: 12,
+          bayRadius: 8,
+          chipRadius: 6,
+          borderAlpha: 0.9,
+          glow: 0.28,
+        }),
+      },
+      {
+        id: "kraft-press",
+        label: "Kraft press",
+        blurb:
+          "Industrial paper stock. Ink-stamped legends, fibre tooth, no gloss anywhere — a press proof, not a screen.",
+        tokens: {
+          page: "#dcd3c2",
+          panel: "#f2ecdf",
+          panelHead: "#f6f1e5",
+          cell: "#faf6ec",
+          trace: "#eae2d1",
+          line: "#c6b99f",
+          lineSoft: "#ded4c0",
+          ink: "#221d16",
+          ink2: "#453c2e",
+          ink3: "#6e6250",
+          ink4: "#9c8f79",
+          accent: "#a8341b",
+          accentDim: "#c06a4e",
+          accentDark: "#f4e4d6",
+          accentEdge: "#dcc3a3",
+          amber: "#8c6516",
+          plate: "#ede6d6",
+          plateTop: "#f4eee1",
+          plateBottom: "#e4dbc8",
+          pad: "#f7f2e6",
+          padBottom: "#e9e1cf",
+          empty: "#e6ddca",
+          micTop: "#a8341b",
+          micBottom: "#7d2814",
+        },
+        material: mat({
+          texture: "paper",
+          grain: 1,
+          sheen: 0,
+          bevel: 0,
+          plateGrad: 0.3,
+          radius: 3,
+          bayRadius: 2,
+          chipRadius: 2,
+          borderAlpha: 1,
+          glow: 0,
+          fontMono: "typewriter",
+          fontCaption: "typewriter",
+          identTrack: 0.05,
+        }),
+      },
+      {
+        id: "enamel-steel",
+        label: "Enamel steel",
+        blurb:
+          "Vitreous enamel on pressed steel. Hard specular, saturated orange-red, cool white body — a kitchen instrument.",
+        tokens: {
+          page: "#dde0dc",
+          panel: "#fafbf9",
+          panelHead: "#fffffe",
+          cell: "#ffffff",
+          trace: "#f0f2ee",
+          line: "#c8cec6",
+          lineSoft: "#e2e6e0",
+          ink: "#131711",
+          ink2: "#3a4136",
+          ink3: "#6b7266",
+          ink4: "#9aa096",
+          accent: "#d6431a",
+          accentDim: "#e4784f",
+          accentDark: "#fde7dc",
+          accentEdge: "#f3bfa6",
+          amber: "#c58a12",
+          plate: "#f4f6f2",
+          plateTop: "#ffffff",
+          plateBottom: "#e8ece5",
+          pad: "#ffffff",
+          padBottom: "#eff2ec",
+          empty: "#e9ece7",
+          micTop: "#d6431a",
+          micBottom: "#a33212",
+        },
+        material: mat({
+          texture: "glass",
+          grain: 0.05,
+          sheen: 1,
+          bevel: 0.6,
+          plateGrad: 1.15,
+          radius: 14,
+          bayRadius: 10,
+          chipRadius: 7,
+          borderAlpha: 0.7,
+          glow: 0.3,
+          fontCaption: "grotesk",
+        }),
+      },
+    ],
+  },
+  {
+    id: "porcelain",
+    name: "Porcelain",
+    scheme: "light",
+    thesis:
+      "Unglazed bisque as the default skin — tailored graphite type, slate-teal signal, no warmth borrowed from Ceramic.",
+    presets: [
+      {
+        id: "bisque",
+        label: "Bisque",
+        blurb:
+          "Matte unglazed porcelain. Almost no specular; the object is read through edge and shadow, not shine.",
+        tokens: {
+          page: "#eceae5",
+          panel: "#fcfbf9",
+          panelHead: "#f7f5f1",
+          cell: "#ffffff",
+          trace: "#f2f0eb",
+          line: "#d3cfc7",
+          lineSoft: "#e5e1d9",
+          ink: "#1e2328",
+          ink2: "#4c545c",
+          ink3: "#757c83",
+          ink4: "#a3a8ac",
+          accent: "#245a74",
+          accentDim: "#5a8396",
+          accentDark: "#e6f0f4",
+          accentEdge: "#b9d0d9",
+          amber: "#9b6b22",
+          plate: "#f4f4f2",
+          plateTop: "#fdfdfc",
+          plateBottom: "#eaeae7",
+          pad: "#fcfcfb",
+          padBottom: "#efefec",
+          empty: "#ebebe8",
+          micTop: "#2f6d85",
+          micBottom: "#204d60",
+        },
+        material: mat({
+          texture: "matte",
+          grain: 0.25,
+          sheen: 0.18,
+          bevel: 0.25,
+          plateGrad: 0.5,
+          radius: 10,
+          bayRadius: 6,
+          chipRadius: 4,
+          borderAlpha: 0.85,
+          glow: 0.12,
+        }),
+      },
+      {
+        id: "frosted-glass",
+        label: "Frosted glass",
+        blurb:
+          "Liquid glass in the light: milk-white refraction, big radii, borders half-dissolved, blue depth under the bay.",
+        tokens: {
+          page: "#e7ebee",
+          panel: "#fafcfd",
+          panelHead: "#f3f7fa",
+          cell: "#ffffff",
+          trace: "#eef3f6",
+          line: "#cbd6dd",
+          lineSoft: "#e1e9ee",
+          ink: "#14202a",
+          ink2: "#45545f",
+          ink3: "#71818c",
+          ink4: "#9fadb6",
+          accent: "#1d7fa8",
+          accentDim: "#5ca6c4",
+          accentDark: "#e2f2f8",
+          accentEdge: "#add6e6",
+          amber: "#a0761f",
+          plate: "#f2f7fa",
+          plateTop: "#ffffff",
+          plateBottom: "#e7eef3",
+          pad: "#fbfdfe",
+          padBottom: "#edf3f7",
+          empty: "#e9eff3",
+          micTop: "#1d7fa8",
+          micBottom: "#145a78",
+        },
+        material: mat({
+          texture: "glass",
+          grain: 0.05,
+          sheen: 1,
+          bevel: 0.7,
+          plateGrad: 1.2,
+          radius: 20,
+          bayRadius: 14,
+          chipRadius: 10,
+          borderAlpha: 0.5,
+          glow: 0.45,
+          fontCaption: "grotesk",
+          typeScale: 1.02,
+        }),
+      },
+      {
+        id: "swiss-plate",
+        label: "Swiss plate",
+        blurb:
+          "Brutalist white: square, black hairline rules, zero light modelling. The grid is the only ornament.",
+        tokens: {
+          page: "#e8e8e6",
+          panel: "#ffffff",
+          panelHead: "#ffffff",
+          cell: "#ffffff",
+          trace: "#f4f4f2",
+          line: "#111111",
+          lineSoft: "#c9c9c6",
+          ink: "#000000",
+          ink2: "#333333",
+          ink3: "#6b6b6b",
+          ink4: "#9a9a9a",
+          accent: "#14486b",
+          accentDim: "#4e7b96",
+          accentDark: "#e7eff4",
+          accentEdge: "#a9c4d2",
+          amber: "#8a6410",
+          plate: "#ffffff",
+          plateTop: "#ffffff",
+          plateBottom: "#f3f3f1",
+          pad: "#ffffff",
+          padBottom: "#f0f0ee",
+          empty: "#f0f0ee",
+          micTop: "#14486b",
+          micBottom: "#0d3149",
+        },
+        material: mat({
+          texture: "matte",
+          grain: 0,
+          sheen: 0,
+          bevel: 0,
+          plateGrad: 0.15,
+          radius: 0,
+          bayRadius: 0,
+          chipRadius: 0,
+          hairline: 1.5,
+          borderAlpha: 1,
+          glow: 0,
+          typeScale: 0.96,
+          identTrack: 0,
+          fontMono: "grotesk",
+          fontCaption: "grotesk",
+          numeralWeight: 700,
+        }),
+      },
+    ],
+  },
+  {
+    id: "amber",
+    name: "Amber",
+    scheme: "dark",
+    thesis:
+      "Low-light studio — warm bakelite and oxide brown carrying a tube filament; the only theme where glow is structural.",
+    presets: [
+      {
+        id: "vacuum-tube",
+        label: "Vacuum tube",
+        blurb:
+          "Bakelite chassis with a filament behind the bay. Heat bloom on the ring; ink warmed like old paper labels.",
+        tokens: {
+          page: "#140f08",
+          panel: "#1f1810",
+          panelHead: "#262016",
+          cell: "#2b2318",
+          trace: "#1a140c",
+          line: "#3f3223",
+          lineSoft: "#2e2519",
+          ink: "#f5ecda",
+          ink2: "#dac9af",
+          ink3: "#a19278",
+          ink4: "#766b59",
+          accent: "#e0673a",
+          accentDim: "#b25a3a",
+          accentDark: "#33200e",
+          accentEdge: "#55341f",
+          amber: "#e8ae44",
+          plate: "#1c1509",
+          plateTop: "#2e2416",
+          plateBottom: "#191207",
+          pad: "#2b2318",
+          padBottom: "#1f1710",
+          empty: "#1a140c",
+          micTop: "#c2521f",
+          micBottom: "#93391a",
+        },
+        material: mat({
+          texture: "grain",
+          grain: 0.35,
+          sheen: 0.45,
+          bevel: 0.6,
+          plateGrad: 1,
+          radius: 9,
+          bayRadius: 6,
+          chipRadius: 5,
+          borderAlpha: 0.85,
+          glow: 0.95,
+        }),
+      },
+      {
+        id: "ferric-tape",
+        label: "Ferric tape",
+        blurb:
+          "Oxide-coated: matte ferric brown, visible particle tooth, transport chips stamped like a tape deck.",
+        tokens: {
+          page: "#17110a",
+          panel: "#241a11",
+          panelHead: "#2a2015",
+          cell: "#302417",
+          trace: "#1c150d",
+          line: "#4a3823",
+          lineSoft: "#34281a",
+          ink: "#f2e6d2",
+          ink2: "#d2be9f",
+          ink3: "#99866a",
+          ink4: "#6e6049",
+          accent: "#d9822f",
+          accentDim: "#a9662c",
+          accentDark: "#33210e",
+          accentEdge: "#5c3a1c",
+          amber: "#e5b04c",
+          plate: "#1f170e",
+          plateTop: "#302518",
+          plateBottom: "#1a130b",
+          pad: "#2e2317",
+          padBottom: "#221a10",
+          empty: "#1c150d",
+          micTop: "#b96b21",
+          micBottom: "#8a4a15",
+        },
+        material: mat({
+          texture: "grain",
+          grain: 1,
+          sheen: 0.1,
+          bevel: 0.25,
+          plateGrad: 0.55,
+          radius: 4,
+          bayRadius: 3,
+          chipRadius: 2,
+          hairline: 1.25,
+          borderAlpha: 1,
+          glow: 0.2,
+          fontMono: "typewriter",
+          fontCaption: "typewriter",
+        }),
+      },
+      {
+        id: "brass-walnut",
+        label: "Brass & walnut",
+        blurb:
+          "Dark walnut body, brushed brass foot. The plate is metal and says so; the ledger stays timber-quiet.",
+        tokens: {
+          page: "#120c07",
+          panel: "#23170e",
+          panelHead: "#2c1e12",
+          cell: "#2f2115",
+          trace: "#180f08",
+          line: "#6b4d28",
+          lineSoft: "#3a2716",
+          ink: "#f7eedc",
+          ink2: "#dcc59d",
+          ink3: "#a98f63",
+          ink4: "#7a6444",
+          accent: "#e9a93f",
+          accentDim: "#b98429",
+          accentDark: "#35240d",
+          accentEdge: "#6b4d1c",
+          amber: "#f0c463",
+          plate: "#1c120a",
+          plateTop: "#3a2a14",
+          plateBottom: "#180f07",
+          pad: "#2e2013",
+          padBottom: "#1e140b",
+          empty: "#180f08",
+          micTop: "#c08428",
+          micBottom: "#8a5c18",
+        },
+        material: mat({
+          texture: "brushed",
+          grain: 0.6,
+          sheen: 0.7,
+          bevel: 0.55,
+          plateGrad: 1.35,
+          radius: 8,
+          bayRadius: 5,
+          chipRadius: 4,
+          borderAlpha: 0.9,
+          glow: 0.5,
+          fontCaption: "serif",
+        }),
+      },
+    ],
+  },
+];
+
+const THEME_BY_ID = new Map(THEMES.map((t) => [t.id, t]));
+
+/* ------------------------------------------------------------- colour util */
+
+function clamp01(n: number) {
+  return Math.min(1, Math.max(0, n));
+}
+
+/** #rrggbb → rgba(). Tolerates #rgb; anything else falls back to the input. */
+function rgba(hex: string, alpha: number): string {
+  let h = hex.trim().replace("#", "");
+  if (h.length === 3) h = h.split("").map((c) => c + c).join("");
+  if (h.length !== 6 || /[^0-9a-f]/i.test(h)) return hex;
+  const n = parseInt(h, 16);
+  const a = Math.round(clamp01(alpha) * 1000) / 1000;
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${a})`;
+}
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/* --------------------------------------------------------------- lifecycle */
+
+type Mode =
+  | "ready"
+  | "listening"
+  | "transcribing"
+  | "submitting"
+  | "speaking"
+  | "paused";
+
+const MODES: { key: Mode; word: string; detail: string; tint: TokenKey }[] = [
+  { key: "ready", word: "READY", detail: "LANE 01", tint: "ink2" },
+  { key: "listening", word: "LISTENING", detail: "LANE 01", tint: "accent" },
+  { key: "transcribing", word: "TRANSCRIBING", detail: "ON DEVICE", tint: "amber" },
+  { key: "submitting", word: "SUBMITTING", detail: "MAC", tint: "amber" },
+  { key: "speaking", word: "SPEAKING", detail: "LANE 01", tint: "accent" },
+  { key: "paused", word: "PAUSED", detail: "LANE 01", tint: "ink3" },
+];
+
+const LEDGER: { role: "you" | "agent"; text: string }[] = [
+  { role: "agent", text: "Loud and clear. One, two, one, two." },
+  { role: "you", text: "Okay." },
+  { role: "agent", text: "All good." },
+  { role: "you", text: "I'm still testing to see the difference." },
+  { role: "agent", text: "I hear you, and I'll wait until you've finished speaking before responding." },
+  { role: "you", text: "Thank you." },
+  { role: "agent", text: "You're welcome." },
+  {
+    role: "you",
+    text: "You're even able to hear me before how come you're able to hear me before I'm done.",
+  },
+];
+
+const CAPTION =
+  "Loud and clear. The full message arrived without interruption.";
+
+/* ------------------------------------------------------------------ figure */
+
+/** Speech-shaped envelope: phrase humps with breaths, quantised for SSR. */
+function speechEnvelope(count: number, seed = 11) {
+  let s = seed;
+  const rand = () => {
+    s = (s * 1103515245 + 12345) % 2147483648;
+    return s / 2147483648;
+  };
+  return Array.from({ length: count }, (_, i) => {
+    const t = i / count;
+    const phrase = Math.sin(t * Math.PI * 3.2);
+    const formant =
+      Math.abs(Math.sin(t * 47)) * 0.35 + Math.abs(Math.sin(t * 19)) * 0.25;
+    const breath = phrase > 0.12 ? 1 : 0.06;
+    const attack = t < 0.04 ? t / 0.04 : t > 0.94 ? (1 - t) / 0.06 : 1;
+    return (
+      Math.round(
+        Math.min(
+          1,
+          Math.max(
+            0.04,
+            (Math.abs(phrase) * 0.55 + formant) * breath * attack * (0.85 + rand() * 0.15),
+          ),
+        ) * 100,
+      ) / 100
+    );
+  });
+}
+
+function clock(frac: number, dur = 4.2) {
+  const s = Math.floor(frac * dur);
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function px(n: number) {
+  return Math.max(2, Math.round(n));
+}
+
+function op(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+/* --------------------------------------------------------- material → CSS */
+
+interface Skin {
+  t: Tokens;
+  m: Material;
+  scheme: "dark" | "light";
+}
+
+/** White gloss on light bodies, ink gloss on dark ones. */
+function sheenInk(skin: Skin) {
+  return skin.scheme === "light" ? "#ffffff" : skin.t.ink;
+}
+
+/**
+ * Texture is the whole point of this study — each material paints its own
+ * overlay stack above the flat fill. Kept as pure CSS so it maps to a Swift
+ * overlay later (or gets dropped for the flat token on device).
+ */
+function textureLayers(skin: Skin, scale = 1): string[] {
+  const { m } = skin;
+  const g = m.grain * scale;
+  const s = m.sheen * scale;
+  const gloss = sheenInk(skin);
+  switch (m.texture) {
+    case "glass":
+      return [
+        `radial-gradient(140% 100% at 8% -18%, ${rgba(gloss, 0.13 * s)}, transparent 58%)`,
+        `linear-gradient(158deg, ${rgba(gloss, 0.07 * s)} 0%, transparent 34%)`,
+        `radial-gradient(90% 70% at 92% 108%, ${rgba(skin.t.accent, 0.05 * s)}, transparent 60%)`,
+      ];
+    case "scanline":
+      return [
+        `repeating-linear-gradient(0deg, ${rgba(gloss, 0.05 * g)} 0 1px, transparent 1px 3px)`,
+        `radial-gradient(120% 90% at 50% -10%, ${rgba(skin.t.accent, 0.06 * s)}, transparent 62%)`,
+      ];
+    case "brushed":
+      return [
+        `repeating-linear-gradient(90deg, ${rgba(gloss, 0.028 * g)} 0 1px, ${rgba("#000000", 0.02 * g)} 1px 2px)`,
+        `linear-gradient(180deg, ${rgba(gloss, 0.06 * s)}, transparent 38%)`,
+      ];
+    case "paper":
+      return [
+        `repeating-linear-gradient(45deg, ${rgba("#000000", 0.016 * g)} 0 2px, transparent 2px 4px)`,
+        `repeating-linear-gradient(-45deg, ${rgba("#000000", 0.012 * g)} 0 3px, transparent 3px 6px)`,
+      ];
+    case "grain":
+      return [
+        `repeating-radial-gradient(circle at 0 0, ${rgba("#000000", 0.035 * g)} 0 1px, transparent 1px 3px)`,
+        `repeating-radial-gradient(circle at 7px 5px, ${rgba(gloss, 0.02 * g)} 0 1px, transparent 1px 4px)`,
+        `linear-gradient(180deg, ${rgba(gloss, 0.04 * s)}, transparent 45%)`,
+      ];
+    case "matte":
+    default:
+      return s > 0
+        ? [`linear-gradient(180deg, ${rgba(gloss, 0.035 * s)}, transparent 30%)`]
+        : [];
+  }
+}
+
+/** Panel body: identity + ledger share one fill; no recessed card. */
+function panelBackground(skin: Skin): string {
+  return [...textureLayers(skin), `linear-gradient(${skin.t.panelHead}, ${skin.t.panel})`].join(
+    ", ",
+  );
+}
+
+/** Plate foot: different texture from the panel, gradient strength is a knob. */
+function plateBackground(skin: Skin): string {
+  const { t, m } = skin;
+  const k = clamp01(m.plateGrad / 1.8);
+  const top = rgba(t.plateTop, 1);
+  const bottom = rgba(t.plateBottom, 1);
+  const stop = 100 - Math.round(k * 55);
+  return [
+    ...textureLayers(skin, 1.15),
+    `linear-gradient(180deg, ${top} 0%, ${bottom} ${stop}%)`,
+  ].join(", ");
+}
+
+/** Inner bevel — top light, bottom shade. Reads as a machined edge. */
+function bevelShadow(skin: Skin): string | undefined {
+  const b = skin.m.bevel;
+  if (b <= 0.01) return undefined;
+  const gloss = sheenInk(skin);
+  return [
+    `inset 0 1px 0 ${rgba(gloss, 0.1 * b)}`,
+    `inset 0 -1px 0 ${rgba("#000000", 0.28 * b)}`,
+  ].join(", ");
+}
+
+/* ------------------------------------------------------------------- page */
+
+const STORE_KEY = "se.micro.themes.opus.v2";
+
+interface Draft {
+  presetId: string;
+  tokens: Tokens;
+  material: Material;
+}
+
+type Drafts = Record<string, Draft>;
+
+function defaultDraft(theme: ThemeDef): Draft {
+  const p = theme.presets[0];
+  return { presetId: p.id, tokens: { ...p.tokens }, material: { ...p.material } };
+}
+
+function defaultDrafts(): Drafts {
+  return Object.fromEntries(THEMES.map((t) => [t.id, defaultDraft(t)]));
+}
+
+export function MicroThemesOpusStudyPage({ page }: { page: StudioAppPage }) {
+  const [themeId, setThemeId] = useState("flight");
+  const [drafts, setDrafts] = useState<Drafts>(() => defaultDrafts());
+  const [mode, setMode] = useState<Mode>("speaking");
+  const [pos, setPos] = useState(0.38);
+  const [level, setLevel] = useState(0.62);
+  const [volume, setVolume] = useState(0.8);
+  const [speedIx, setSpeedIx] = useState(0);
+  const [autoplay, setAutoplay] = useState(true);
+  const [animate, setAnimate] = useState(true);
+  const [crisp, setCrisp] = useState(false);
+  const [width, setWidth] = useState(430);
+  const [compareId, setCompareId] = useState<string | null>(null);
+  const [openTokens, setOpenTokens] = useState(false);
+  const [exported, setExported] = useState<"json" | "swift" | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [slots, setSlots] = useState<Record<"A" | "B", Drafts | null>>({
+    A: null,
+    B: null,
+  });
+
+  const theme = THEME_BY_ID.get(themeId) ?? THEMES[0];
+  const draft = drafts[themeId] ?? defaultDraft(theme);
+
+  /* Restore after mount — never during render, or SSR and client disagree. */
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+    try {
+      const raw = window.localStorage.getItem(STORE_KEY);
+      if (!raw) return;
+      const saved = JSON.parse(raw) as { drafts?: Drafts; slots?: typeof slots };
+      if (saved.drafts) {
+        setDrafts((cur) => {
+          const next = { ...cur };
+          for (const t of THEMES) {
+            const d = saved.drafts?.[t.id];
+            if (!d?.tokens || !d?.material) continue;
+            next[t.id] = {
+              presetId: d.presetId ?? t.presets[0].id,
+              tokens: { ...next[t.id].tokens, ...d.tokens },
+              material: { ...next[t.id].material, ...d.material },
+            };
+          }
+          return next;
+        });
+      }
+      if (saved.slots) setSlots({ A: saved.slots.A ?? null, B: saved.slots.B ?? null });
+    } catch {
+      /* corrupt store — fall back to designed defaults */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(STORE_KEY, JSON.stringify({ drafts, slots }));
+    } catch {
+      /* quota / private mode — the page still works, just not sticky */
+    }
+  }, [drafts, slots, hydrated]);
+
+  const phase = useAnimationPhase(animate, 1.65);
+  const livePhase = hydrated ? phase : 0;
+  const env = useMemo(() => speechEnvelope(96), []);
+  const meta = MODES.find((m) => m.key === mode) ?? MODES[0];
+
+  // Derive live pos/level from phase — never write them back via useEffect
+  // (that + RAF setPhase was causing "Maximum update depth exceeded").
+  const livePos =
+    hydrated && animate && mode === "speaking" ? phase : pos;
+  const liveLevel =
+    hydrated && mode === "listening"
+      ? Math.round(
+          (0.18 +
+            Math.abs(Math.sin(phase * Math.PI * 2.4)) * 0.42 +
+            Math.abs(Math.sin(phase * Math.PI * 7.1)) * 0.22 +
+            Math.abs(Math.sin(phase * Math.PI * 13)) * 0.12) *
+            100,
+        ) / 100
+      : level;
+
+  const setToken = useCallback(
+    (key: TokenKey, value: string) => {
+      setDrafts((cur) => ({
+        ...cur,
+        [themeId]: { ...cur[themeId], tokens: { ...cur[themeId].tokens, [key]: value } },
+      }));
+    },
+    [themeId],
+  );
+
+  const setMat = useCallback(
+    <K extends keyof Material>(key: K, value: Material[K]) => {
+      setDrafts((cur) => ({
+        ...cur,
+        [themeId]: { ...cur[themeId], material: { ...cur[themeId].material, [key]: value } },
+      }));
+    },
+    [themeId],
+  );
+
+  const applyPreset = useCallback(
+    (presetId: string) => {
+      const p = theme.presets.find((x) => x.id === presetId) ?? theme.presets[0];
+      setDrafts((cur) => ({
+        ...cur,
+        [themeId]: { presetId: p.id, tokens: { ...p.tokens }, material: { ...p.material } },
+      }));
+    },
+    [theme, themeId],
+  );
+
+  const reset = useCallback(() => applyPreset(draft.presetId), [applyPreset, draft.presetId]);
+
+  /* "Crisp only" is a render-time override — it never eats the saved values. */
+  const skin: Skin = useMemo(() => {
+    const m = crisp
+      ? { ...draft.material, sheen: 0, bevel: 0, glow: 0, grain: 0, plateGrad: Math.min(draft.material.plateGrad, 0.2) }
+      : draft.material;
+    return { t: draft.tokens, m, scheme: theme.scheme };
+  }, [draft, crisp, theme.scheme]);
+
+  const compareTheme = compareId ? THEME_BY_ID.get(compareId) : null;
+  const compareSkin: Skin | null = useMemo(() => {
+    if (!compareTheme) return null;
+    const d = drafts[compareTheme.id];
+    const m = crisp
+      ? { ...d.material, sheen: 0, bevel: 0, glow: 0, grain: 0, plateGrad: Math.min(d.material.plateGrad, 0.2) }
+      : d.material;
+    return { t: d.tokens, m, scheme: compareTheme.scheme };
+  }, [compareTheme, drafts, crisp]);
+
+  const jsonOut = useMemo(() => exportJSON(theme, draft), [theme, draft]);
+  const swiftOut = useMemo(() => exportSwift(theme, draft), [theme, draft]);
+
+  const copy = useCallback((label: string, text: string) => {
+    void navigator.clipboard?.writeText(text);
+    setCopied(label);
+    window.setTimeout(() => setCopied(null), 1400);
+  }, []);
+
+  const messages =
+    mode === "ready"
+      ? []
+      : mode === "listening" || mode === "transcribing"
+        ? LEDGER.slice(0, 5)
+        : LEDGER;
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+
+      <section className="max-w-[1240px] space-y-12 py-8">
+        {/* Thesis */}
+        <div>
+          <h2 className="mb-2 text-[15px] font-medium text-studio-ink-strong">
+            Five materials, one chassis
+          </h2>
+          <p className="mb-5 max-w-[72ch] text-[13.5px] leading-relaxed text-studio-ink">
+            Full Micro Deck — hand column (lanes + pad + hold-to-speak) and eye
+            column (ledger + player foot). Geometry is frozen on the ledger rail
+            (50pt gutter, text at 76). Themes move material: color, texture,
+            lighting, chrome. If two read as the same object with a different hue,
+            the study failed.
+          </p>
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {THEMES.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setThemeId(t.id)}
+                className="rounded-lg border border-studio-rule p-3 text-left transition hover:border-studio-ink-faint"
+                style={{
+                  borderColor: t.id === themeId ? t.presets[0].tokens.accent : undefined,
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="h-2.5 w-2.5 rounded-full"
+                    style={{ background: t.presets[0].tokens.accent }}
+                  />
+                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-studio-ink-strong">
+                    {t.name}
+                  </span>
+                  <span className="ml-auto font-mono text-[9px] uppercase tracking-[0.14em] text-studio-ink-faint">
+                    {t.scheme}
+                  </span>
+                </div>
+                <p className="mt-1.5 text-[12px] leading-snug text-studio-ink-faint">
+                  {t.thesis}
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Playground */}
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">
+            Playground
+          </h2>
+          <p className="mb-4 max-w-[72ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            Pick a theme, pick a material direction, then take it apart. Every knob
+            is live and sticky per theme; <em>Reset</em> restores the designed
+            defaults for the active preset.
+          </p>
+
+          <div className="grid gap-6 xl:grid-cols-[auto_1fr]">
+            {/* Mock */}
+            <div className="space-y-3">
+              <div className="flex flex-wrap gap-1.5">
+                {MODES.map((m) => (
+                  <button
+                    key={m.key}
+                    type="button"
+                    onClick={() => setMode(m.key)}
+                    className="rounded px-2.5 py-1 font-mono text-[9.5px] font-medium tracking-wide transition"
+                    style={{
+                      background: m.key === mode ? skin.t.pad : "transparent",
+                      color: m.key === mode ? skin.t[m.tint] : undefined,
+                      borderWidth: 1,
+                      borderStyle: "solid",
+                      borderColor:
+                        m.key === mode ? rgba(skin.t[m.tint], 0.5) : "var(--studio-rule, #333)",
+                    }}
+                  >
+                    <span className={m.key === mode ? "" : "text-studio-ink-faint"}>
+                      {m.word}
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="overflow-x-auto">
+                <div className="flex flex-wrap items-start gap-6">
+                  <MicroDeckFullMock
+                    tokens={skin.t}
+                    mode={mode}
+                    handWidth={Math.round(width * 0.82)}
+                    consoleWidth={width}
+                    height={Math.max(520, Math.round(560 * (draft.material.spacing || 1)))}
+                  >
+                    <MicroColumn
+                      skin={skin}
+                      mode={mode}
+                      meta={meta}
+                      messages={messages}
+                      pos={livePos}
+                      level={liveLevel}
+                      volume={volume}
+                      speedIx={speedIx}
+                      autoplay={autoplay}
+                      env={env}
+                      phase={livePhase}
+                      height="100%"
+                      onSeek={(v) => {
+                        setAnimate(false);
+                        setPos(v);
+                      }}
+                      onVolume={setVolume}
+                      onCycleSpeed={() => setSpeedIx((i) => (i + 1) % 4)}
+                      onToggleAuto={() => setAutoplay((a) => !a)}
+                      onTogglePlay={() =>
+                        setMode((m) =>
+                          m === "speaking" ? "paused" : m === "paused" ? "speaking" : m,
+                        )
+                      }
+                    />
+                  </MicroDeckFullMock>
+                  {compareSkin && compareTheme ? (
+                    <div>
+                      <MicroDeckFullMock
+                        tokens={compareSkin.t}
+                        mode={mode}
+                        handWidth={Math.round(width * 0.82)}
+                        consoleWidth={width}
+                        height={Math.max(520, Math.round(560 * (drafts[compareTheme.id]?.material.spacing || 1)))}
+                      >
+                        <MicroColumn
+                          skin={compareSkin}
+                          mode={mode}
+                          meta={meta}
+                          messages={messages}
+                          pos={livePos}
+                          level={liveLevel}
+                          volume={volume}
+                          speedIx={speedIx}
+                          autoplay={autoplay}
+                          env={env}
+                          phase={livePhase}
+                          height="100%"
+                        />
+                      </MicroDeckFullMock>
+                      <div
+                        className="mt-2 text-center font-mono text-[9px] uppercase tracking-[0.16em]"
+                        style={{ color: compareSkin.t.ink4 }}
+                      >
+                        {compareTheme.name} · {drafts[compareTheme.id].presetId}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+
+            {/* Knob rack — sliders pick up the active accent so the rack reads
+                as part of the object being tuned */}
+            <div
+              className="min-w-0 space-y-4"
+              style={{ accentColor: draft.tokens.accent }}
+            >
+              <Rack title="Theme">
+                <div className="flex flex-wrap gap-1.5">
+                  {THEMES.map((t) => (
+                    <Pill
+                      key={t.id}
+                      active={t.id === themeId}
+                      tint={t.presets[0].tokens.accent}
+                      onClick={() => setThemeId(t.id)}
+                    >
+                      {t.name}
+                    </Pill>
+                  ))}
+                </div>
+              </Rack>
+
+              <Rack title={`Material · ${theme.name}`}>
+                <div className="flex flex-wrap gap-1.5">
+                  {theme.presets.map((p) => (
+                    <Pill
+                      key={p.id}
+                      active={p.id === draft.presetId}
+                      tint={p.tokens.accent}
+                      onClick={() => applyPreset(p.id)}
+                    >
+                      {p.label}
+                    </Pill>
+                  ))}
+                </div>
+                <p className="mt-2 max-w-[70ch] text-[12px] leading-snug text-studio-ink-faint">
+                  {theme.presets.find((p) => p.id === draft.presetId)?.blurb}
+                </p>
+              </Rack>
+
+              <Rack title="Surface">
+                <div className="grid gap-x-6 gap-y-1 md:grid-cols-2">
+                  <Select
+                    label="Texture"
+                    value={draft.material.texture}
+                    options={["matte", "glass", "brushed", "scanline", "paper", "grain"]}
+                    onChange={(v) => setMat("texture", v as Texture)}
+                  />
+                  <Knob
+                    label="Grain"
+                    value={draft.material.grain}
+                    min={0}
+                    max={1.2}
+                    step={0.02}
+                    onChange={(v) => setMat("grain", v)}
+                  />
+                  <Knob
+                    label="Sheen"
+                    value={draft.material.sheen}
+                    min={0}
+                    max={1.2}
+                    step={0.02}
+                    onChange={(v) => setMat("sheen", v)}
+                  />
+                  <Knob
+                    label="Bevel"
+                    value={draft.material.bevel}
+                    min={0}
+                    max={1}
+                    step={0.02}
+                    onChange={(v) => setMat("bevel", v)}
+                  />
+                  <Knob
+                    label="Plate gradient"
+                    value={draft.material.plateGrad}
+                    min={0}
+                    max={1.8}
+                    step={0.05}
+                    onChange={(v) => setMat("plateGrad", v)}
+                  />
+                  <Knob
+                    label="Live glow"
+                    value={draft.material.glow}
+                    min={0}
+                    max={1.5}
+                    step={0.05}
+                    onChange={(v) => setMat("glow", v)}
+                  />
+                </div>
+              </Rack>
+
+              <Rack title="Chrome">
+                <div className="grid gap-x-6 gap-y-1 md:grid-cols-2">
+                  <Knob
+                    label="Corner radius"
+                    value={draft.material.radius}
+                    min={0}
+                    max={26}
+                    step={1}
+                    onChange={(v) => setMat("radius", v)}
+                    unit="pt"
+                  />
+                  <Knob
+                    label="Bay radius"
+                    value={draft.material.bayRadius}
+                    min={0}
+                    max={18}
+                    step={1}
+                    onChange={(v) => setMat("bayRadius", v)}
+                    unit="pt"
+                  />
+                  <Knob
+                    label="Chip radius"
+                    value={draft.material.chipRadius}
+                    min={0}
+                    max={14}
+                    step={1}
+                    onChange={(v) => setMat("chipRadius", v)}
+                    unit="pt"
+                  />
+                  <Knob
+                    label="Border strength"
+                    value={draft.material.borderAlpha}
+                    min={0.15}
+                    max={1.4}
+                    step={0.05}
+                    onChange={(v) => setMat("borderAlpha", v)}
+                  />
+                  <Knob
+                    label="Hairline weight"
+                    value={draft.material.hairline}
+                    min={0.5}
+                    max={2.5}
+                    step={0.25}
+                    onChange={(v) => setMat("hairline", v)}
+                    unit="px"
+                  />
+                </div>
+              </Rack>
+
+              <Rack title="Type & rail">
+                <div className="grid gap-x-6 gap-y-1 md:grid-cols-2">
+                  <Select
+                    label="Mono face"
+                    value={draft.material.fontMono}
+                    options={["mono", "typewriter", "grotesk", "serif"]}
+                    onChange={(v) => setMat("fontMono", v as FontKey)}
+                  />
+                  <Select
+                    label="Caption face"
+                    value={draft.material.fontCaption}
+                    options={["mono", "typewriter", "grotesk", "serif"]}
+                    onChange={(v) => setMat("fontCaption", v as FontKey)}
+                  />
+                  <Knob
+                    label="Type scale"
+                    value={draft.material.typeScale}
+                    min={0.85}
+                    max={1.3}
+                    step={0.01}
+                    onChange={(v) => setMat("typeScale", v)}
+                    unit="×"
+                  />
+                  <Knob
+                    label="Ident tracking"
+                    value={draft.material.identTrack}
+                    min={0}
+                    max={0.2}
+                    step={0.01}
+                    onChange={(v) => setMat("identTrack", v)}
+                    unit="em"
+                  />
+                  <Knob
+                    label="Gutter"
+                    value={draft.material.gutter}
+                    min={34}
+                    max={74}
+                    step={1}
+                    onChange={(v) => setMat("gutter", v)}
+                    unit="pt"
+                  />
+                  <Knob
+                    label="Spacing scale"
+                    value={draft.material.spacing}
+                    min={0.75}
+                    max={1.5}
+                    step={0.05}
+                    onChange={(v) => setMat("spacing", v)}
+                    unit="×"
+                  />
+                  <Knob
+                    label="Player height"
+                    value={draft.material.lockU ? PLAYER_2U : draft.material.playerH}
+                    min={120}
+                    max={230}
+                    step={2}
+                    disabled={draft.material.lockU}
+                    onChange={(v) => setMat("playerH", v)}
+                    unit="pt"
+                  />
+                  <div className="flex items-center gap-2 py-1.5">
+                    <Toggle
+                      on={draft.material.lockU}
+                      onClick={() => setMat("lockU", !draft.material.lockU)}
+                    >
+                      2U lock ({PLAYER_2U}pt)
+                    </Toggle>
+                  </div>
+                </div>
+                <div className="mt-2 font-mono text-[10px] text-studio-ink-faint">
+                  text rail = 14 + {Math.round(draft.material.gutter)} + 12 ={" "}
+                  <span className="text-studio-ink">
+                    {Math.round(draft.material.gutter) + 26}
+                  </span>
+                </div>
+              </Rack>
+
+              <Rack title="Stage">
+                <div className="grid gap-x-6 gap-y-1 md:grid-cols-2">
+                  <Knob
+                    label="Column width"
+                    value={width}
+                    min={340}
+                    max={560}
+                    step={2}
+                    onChange={setWidth}
+                    unit="pt"
+                  />
+                  <Knob
+                    label="Scrub position"
+                    value={pos}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    onChange={(v) => {
+                      setAnimate(false);
+                      setPos(v);
+                    }}
+                  />
+                  <Knob
+                    label="Volume"
+                    value={volume}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    onChange={setVolume}
+                  />
+                  <Knob
+                    label="Input level"
+                    value={level}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    onChange={setLevel}
+                  />
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  <Toggle on={animate} onClick={() => setAnimate((a) => !a)}>
+                    {animate ? "Animating" : "Frozen"}
+                  </Toggle>
+                  <Toggle on={crisp} onClick={() => setCrisp((c) => !c)}>
+                    Crisp only
+                  </Toggle>
+                  <Toggle on={autoplay} onClick={() => setAutoplay((a) => !a)}>
+                    Autoplay
+                  </Toggle>
+                  <Toggle on={compareId !== null} onClick={() => setCompareId(null)}>
+                    Compare off
+                  </Toggle>
+                  {THEMES.filter((t) => t.id !== themeId).map((t) => (
+                    <Toggle
+                      key={t.id}
+                      on={compareId === t.id}
+                      onClick={() => setCompareId(compareId === t.id ? null : t.id)}
+                    >
+                      vs {t.name}
+                    </Toggle>
+                  ))}
+                </div>
+              </Rack>
+
+              <Rack
+                title="Tokens"
+                aside={
+                  <button
+                    type="button"
+                    onClick={() => setOpenTokens((o) => !o)}
+                    className="font-mono text-[10px] uppercase tracking-[0.14em] text-studio-ink-faint hover:text-studio-ink"
+                  >
+                    {openTokens ? "Collapse" : "Expand"}
+                  </button>
+                }
+              >
+                {openTokens ? (
+                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    {TOKEN_GROUPS.map((g) => (
+                      <div key={g.title}>
+                        <div className="mb-1.5 font-mono text-[9px] uppercase tracking-[0.16em] text-studio-ink-faint">
+                          {g.title}
+                        </div>
+                        {g.keys.map((k) => (
+                          <ColorRow
+                            key={k}
+                            name={k}
+                            value={draft.tokens[k]}
+                            onChange={(v) => setToken(k, v)}
+                          />
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap gap-1">
+                    {TOKEN_KEYS.map((k) => (
+                      <span
+                        key={k}
+                        title={`${k} ${draft.tokens[k]}`}
+                        className="h-5 w-5 rounded-[3px]"
+                        style={{
+                          background: draft.tokens[k],
+                          border: "1px solid rgba(128,128,128,0.35)",
+                        }}
+                      />
+                    ))}
+                  </div>
+                )}
+              </Rack>
+
+              <Rack title="Snapshots & reset">
+                <div className="flex flex-wrap gap-1.5">
+                  {(["A", "B"] as const).map((slot) => (
+                    <span key={slot} className="flex gap-1.5">
+                      <Toggle on={false} onClick={() => setSlots((s) => ({ ...s, [slot]: drafts }))}>
+                        Save {slot}
+                      </Toggle>
+                      <Toggle
+                        on={false}
+                        disabled={!slots[slot]}
+                        onClick={() => {
+                          const snap = slots[slot];
+                          if (snap) setDrafts(snap);
+                        }}
+                      >
+                        Load {slot}
+                      </Toggle>
+                    </span>
+                  ))}
+                  <Toggle on={false} onClick={reset}>
+                    Reset {theme.name}
+                  </Toggle>
+                  <Toggle on={false} onClick={() => setDrafts(defaultDrafts())}>
+                    Reset all
+                  </Toggle>
+                </div>
+              </Rack>
+            </div>
+          </div>
+        </div>
+
+        {/* Strip */}
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">
+            Five objects, same column
+          </h2>
+          <p className="mb-4 max-w-[72ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            Each at its current preset, same lifecycle state. The rail, the 2U foot
+            and the tape clock line up across all five — only the material moves.
+          </p>
+          <div className="flex flex-wrap gap-4">
+            {THEMES.map((t) => {
+              const d = drafts[t.id];
+              const s: Skin = {
+                t: d.tokens,
+                m: crisp
+                  ? { ...d.material, sheen: 0, bevel: 0, glow: 0, grain: 0, plateGrad: 0.2 }
+                  : d.material,
+                scheme: t.scheme,
+              };
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setThemeId(t.id)}
+                  className="rounded-lg p-3 text-left"
+                  style={{
+                    background: d.tokens.page,
+                    border: `1px solid ${t.id === themeId ? d.tokens.accent : rgba(d.tokens.line, 0.6)}`,
+                  }}
+                >
+                  <div style={{ width: 320 }}>
+                    <MicroColumn
+                      skin={s}
+                      mode={mode === "listening" ? "ready" : mode}
+                      meta={meta}
+                      messages={messages.slice(0, 4)}
+                      pos={0.38}
+                      level={0.55}
+                      volume={volume}
+                      speedIx={speedIx}
+                      autoplay={autoplay}
+                      env={env}
+                      phase={0.35}
+                      height={430}
+                    />
+                  </div>
+                  <div
+                    className="mt-2 flex items-baseline gap-2 font-mono text-[9px] uppercase tracking-[0.16em]"
+                    style={{ color: d.tokens.ink3 }}
+                  >
+                    <span style={{ color: d.tokens.ink2 }}>{t.name}</span>
+                    <span style={{ color: d.tokens.ink4 }}>{d.presetId}</span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Export */}
+        <div>
+          <h2 className="mb-1 text-[15px] font-medium text-studio-ink-strong">Export</h2>
+          <p className="mb-4 max-w-[72ch] text-[13px] leading-relaxed text-studio-ink-faint">
+            JSON uses the <code>DeckThemePalette</code> field names verbatim, plus a{" "}
+            <code>material</code> block for the parts Swift does not model yet.
+            Swift emits the exact initialiser argument order from{" "}
+            <code>DeckTheme.swift</code> — paste it over the matching case.
+          </p>
+          <div className="mb-3 flex flex-wrap gap-1.5">
+            <Toggle on={exported === "json"} onClick={() => setExported(exported === "json" ? null : "json")}>
+              JSON
+            </Toggle>
+            <Toggle on={exported === "swift"} onClick={() => setExported(exported === "swift" ? null : "swift")}>
+              Swift
+            </Toggle>
+            <Toggle on={false} onClick={() => copy("json", jsonOut)}>
+              Copy JSON
+            </Toggle>
+            <Toggle on={false} onClick={() => copy("swift", swiftOut)}>
+              Copy Swift
+            </Toggle>
+            {copied ? (
+              <span className="self-center font-mono text-[10px] uppercase tracking-[0.16em] text-studio-ink-faint">
+                copied {copied}
+              </span>
+            ) : null}
+          </div>
+          {exported ? (
+            <pre
+              className="max-h-[460px] overflow-auto rounded-lg p-4 font-mono text-[11px] leading-relaxed"
+              style={{
+                background: skin.t.page,
+                border: `1px solid ${rgba(skin.t.line, 0.6)}`,
+                color: skin.t.ink2,
+              }}
+            >
+              {exported === "json" ? jsonOut : swiftOut}
+            </pre>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+/* ------------------------------------------------------------- micro column */
+
+function MicroColumn({
+  skin,
+  mode,
+  meta,
+  messages,
+  pos,
+  level,
+  volume,
+  speedIx,
+  autoplay,
+  env,
+  phase,
+  height,
+  onSeek,
+  onVolume,
+  onCycleSpeed,
+  onToggleAuto,
+  onTogglePlay,
+}: {
+  skin: Skin;
+  mode: Mode;
+  meta: (typeof MODES)[number];
+  messages: { role: "you" | "agent"; text: string }[];
+  pos: number;
+  level: number;
+  volume: number;
+  speedIx: number;
+  autoplay: boolean;
+  env: number[];
+  phase: number;
+  height: number | string;
+  onSeek?: (v: number) => void;
+  onVolume?: (v: number) => void;
+  onCycleSpeed?: () => void;
+  onToggleAuto?: () => void;
+  onTogglePlay?: () => void;
+}) {
+  const { t, m } = skin;
+  const live = mode === "listening" || mode === "speaking";
+  const tint = t[meta.tint];
+  const gutter = Math.round(m.gutter);
+  const gap = 12;
+  const edge = 14;
+  const rail = gutter + gap;
+  const pad = (n: number) => Math.round(n * m.spacing);
+  const fs = (n: number) => Math.round(n * m.typeScale * 100) / 100;
+  const mono = FONTS[m.fontMono];
+
+  return (
+    <div
+      className="flex flex-col overflow-hidden"
+      style={{
+        borderRadius: m.radius,
+        background: panelBackground(skin),
+        border: `1px solid ${live ? rgba(tint, 0.35 + m.glow * 0.3) : rgba(t.line, m.borderAlpha)}`,
+        boxShadow: live && m.glow > 0.02
+          ? `0 0 ${Math.round(m.glow * 26)}px ${rgba(tint, m.glow * 0.16)}`
+          : bevelShadow(skin),
+        height,
+        fontFamily: mono,
+      }}
+    >
+      {/* IDENTITY — panel head of the same surface */}
+      <div
+        className="flex items-start"
+        style={{
+          gap,
+          paddingLeft: edge,
+          paddingRight: edge,
+          paddingTop: pad(12),
+          paddingBottom: pad(10),
+          borderBottom: `${m.hairline}px solid ${rgba(t.lineSoft, m.borderAlpha)}`,
+        }}
+      >
+        <div
+          className="tabular-nums leading-none"
+          style={{
+            width: gutter,
+            fontSize: fs(28),
+            fontWeight: m.numeralWeight,
+            color: t.accent,
+            letterSpacing: `${m.identTrack}em`,
+            textShadow:
+              m.glow > 0.4 ? `0 0 ${Math.round(m.glow * 10)}px ${rgba(t.accent, 0.4)}` : undefined,
+          }}
+        >
+          01
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span
+              className="truncate font-semibold"
+              style={{
+                fontSize: fs(11),
+                color: t.ink,
+                letterSpacing: `${m.identTrack + 0.02}em`,
+              }}
+            >
+              USETALKIE.COM
+            </span>
+            <span className="ml-auto flex items-center gap-1.5">
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{
+                  background: tint,
+                  boxShadow: live && m.glow > 0.02 ? `0 0 ${4 + m.glow * 6}px ${tint}` : undefined,
+                }}
+              />
+              <span
+                className="font-bold"
+                style={{ fontSize: fs(7), letterSpacing: "0.14em", color: tint }}
+              >
+                {meta.word === "READY" ? "ACTIVE LANE" : meta.word}
+              </span>
+            </span>
+          </div>
+          <div
+            className="mt-1 flex gap-2"
+            style={{ fontSize: fs(7.5), color: t.ink3 }}
+          >
+            <span>main</span>
+            <span style={{ color: t.ink4 }}>6B306A13</span>
+          </div>
+        </div>
+      </div>
+
+      {/* LEDGER — same fill as identity; role in gutter, body on the text rail */}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <div
+          className="h-full overflow-hidden"
+          style={{
+            paddingLeft: edge,
+            paddingRight: edge,
+            paddingTop: pad(10),
+            paddingBottom: pad(10),
+          }}
+        >
+          {messages.length === 0 ? (
+            <p
+              style={{
+                paddingLeft: rail,
+                fontSize: fs(9),
+                lineHeight: 1.65,
+                color: t.ink3,
+              }}
+            >
+              Check unmerged checkout changes
+            </p>
+          ) : (
+            <div style={{ display: "grid", rowGap: pad(8) }}>
+              {messages.map((msg, i) => (
+                <div key={i} className="flex items-start" style={{ gap }}>
+                  <div
+                    className="shrink-0 font-bold"
+                    style={{
+                      width: gutter,
+                      fontSize: fs(6.5),
+                      letterSpacing: "0.09em",
+                      color: t.ink4,
+                      paddingTop: 2,
+                    }}
+                  >
+                    {msg.role === "you" ? "YOU" : "AGENT"}
+                  </div>
+                  <p
+                    className="min-w-0 flex-1"
+                    style={{
+                      fontSize: fs(9),
+                      lineHeight: 1.45,
+                      color: msg.role === "agent" ? t.ink2 : t.ink3,
+                    }}
+                  >
+                    {msg.text}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* PLAYER FOOT — plate texture, hairline seam, no second card */}
+      <PlayerFoot
+        skin={skin}
+        // Strip / compare mocks are display-only: render the transport as plain
+        // elements so a card can wrap them without nesting interactive nodes.
+        frozen={!onTogglePlay}
+        mode={mode}
+        meta={meta}
+        pos={pos}
+        level={level}
+        volume={volume}
+        speedIx={speedIx}
+        autoplay={autoplay}
+        env={env}
+        phase={phase}
+        onSeek={onSeek}
+        onVolume={onVolume}
+        onCycleSpeed={onCycleSpeed}
+        onToggleAuto={onToggleAuto}
+        onTogglePlay={onTogglePlay}
+      />
+    </div>
+  );
+}
+
+function PlayerFoot({
+  skin,
+  mode,
+  meta,
+  pos,
+  level,
+  volume,
+  speedIx,
+  autoplay,
+  env,
+  phase,
+  frozen,
+  onSeek,
+  onVolume,
+  onCycleSpeed,
+  onToggleAuto,
+  onTogglePlay,
+}: {
+  skin: Skin;
+  mode: Mode;
+  meta: (typeof MODES)[number];
+  pos: number;
+  level: number;
+  volume: number;
+  speedIx: number;
+  autoplay: boolean;
+  env: number[];
+  phase: number;
+  frozen?: boolean;
+  onSeek?: (v: number) => void;
+  onVolume?: (v: number) => void;
+  onCycleSpeed?: () => void;
+  onToggleAuto?: () => void;
+  onTogglePlay?: () => void;
+}) {
+  const { t, m } = skin;
+  const narrating = mode === "speaking" || mode === "paused";
+  const live = mode === "listening";
+  const working = mode === "transcribing" || mode === "submitting";
+  const tint = t[meta.tint];
+  const gutter = Math.round(m.gutter);
+  const gap = 12;
+  const edge = 14;
+  const ring = Math.min(gutter, 48);
+  const bandH = 48;
+  const headInset = gutter + gap;
+  const height = m.lockU ? PLAYER_2U : Math.round(m.playerH);
+  const fs = (n: number) => Math.round(n * m.typeScale * 100) / 100;
+  const restLabel = mode === "ready" ? "READY" : mode === "paused" ? "AT REST" : "NO AUDIO";
+  const seekable = narrating || mode === "ready";
+
+  return (
+    <div
+      className="flex flex-col overflow-hidden"
+      style={{
+        height,
+        background: plateBackground(skin),
+        borderTop: `${m.hairline}px solid ${
+          live || mode === "speaking" ? rgba(tint, 0.5) : rgba(t.lineSoft, m.borderAlpha)
+        }`,
+        boxShadow: bevelShadow(skin),
+        paddingTop: 10,
+        paddingBottom: 9,
+        paddingLeft: edge,
+        paddingRight: edge,
+        boxSizing: "border-box",
+      }}
+    >
+      {/* Head — TURN · status + caption, indented to the text rail */}
+      <div style={{ paddingLeft: headInset }}>
+        <div
+          className="flex items-center gap-1.5"
+          style={{
+            height: 12,
+            fontSize: fs(9.5),
+            fontWeight: 600,
+            letterSpacing: "0.05em",
+            color: mode === "ready" ? t.ink2 : tint,
+          }}
+        >
+          <span>TURN 14</span>
+          <span style={{ color: t.ink4, opacity: 0.65 }}>·</span>
+          <span>{meta.word}</span>
+          {mode === "speaking" ? (
+            <span
+              className="inline-block h-1 w-1 shrink-0 rounded-full"
+              style={{
+                background: t.accent,
+                boxShadow: m.glow > 0.02 ? `0 0 ${3 + m.glow * 5}px ${t.accent}` : undefined,
+              }}
+            />
+          ) : null}
+        </div>
+        <div
+          className="truncate"
+          style={{
+            marginTop: 2,
+            height: 20,
+            fontSize: fs(12),
+            lineHeight: 1.35,
+            color: t.ink,
+            fontFamily: FONTS[m.fontCaption],
+          }}
+        >
+          {narrating || mode === "ready"
+            ? CAPTION
+            : live
+              ? "Listening…"
+              : working
+                ? "Working…"
+                : ""}
+        </div>
+      </div>
+
+      <div style={{ flex: "1 1 8px", minHeight: 6 }} />
+
+      {/* Transport band — ring in the gutter, bay same height */}
+      <div>
+        <div className="flex items-center" style={{ gap }}>
+          <div
+            className="flex shrink-0 items-center justify-center"
+            style={{ width: gutter, height: bandH }}
+          >
+            <Press
+              frozen={frozen}
+              onClick={onTogglePlay}
+              className="relative flex items-center justify-center rounded-full"
+              style={{
+                width: ring,
+                height: ring,
+                background: `linear-gradient(180deg, ${t.pad}, ${t.padBottom})`,
+                border: `2px solid ${rgba(t.line, m.borderAlpha)}`,
+                color: narrating || mode === "ready" ? t.accent : t.ink3,
+                boxShadow:
+                  narrating && m.glow > 0.02
+                    ? `0 0 ${Math.round(m.glow * 16)}px ${rgba(t.accent, m.glow * 0.3)}, ${bevelShadow(skin) ?? "none"}`
+                    : bevelShadow(skin),
+              }}
+            >
+              {narrating ? (
+                <span
+                  className="pointer-events-none absolute inset-0 rounded-full"
+                  style={{
+                    border: `2px solid ${tint}`,
+                    clipPath: `inset(0 ${100 - pos * 100}% 0 0)`,
+                    opacity: 0.9,
+                  }}
+                />
+              ) : null}
+              <span style={{ fontSize: ring * 0.3, position: "relative" }}>
+                {mode === "speaking" ? "❚❚" : "▶"}
+              </span>
+            </Press>
+          </div>
+
+          <div
+            className="relative min-w-0 flex-1"
+            style={{
+              height: bandH,
+              borderRadius: m.bayRadius,
+              background: t.trace,
+              border: `1px solid ${rgba(t.line, m.borderAlpha)}`,
+              boxShadow: `inset 0 1px 3px ${rgba("#000000", 0.25 + m.bevel * 0.25)}`,
+              cursor: seekable && onSeek ? "pointer" : "default",
+              overflow: "hidden",
+            }}
+            onClick={(e) => {
+              if (!onSeek || !seekable) return;
+              const r = e.currentTarget.getBoundingClientRect();
+              onSeek(Math.min(1, Math.max(0, (e.clientX - r.left) / r.width)));
+            }}
+          >
+            <div className="absolute inset-0 px-2 py-1.5">
+              {mode === "ready" ? (
+                <RestField skin={skin} label="READY" silhouette />
+              ) : (
+                <RadioFigure
+                  skin={skin}
+                  mode={mode}
+                  env={env}
+                  pos={pos}
+                  level={level}
+                  phase={phase}
+                  tint={tint}
+                  restLabel={restLabel}
+                />
+              )}
+            </div>
+            {narrating ? (
+              <span
+                className="pointer-events-none absolute top-1.5 bottom-1.5"
+                style={{
+                  left: `${Math.round(pos * 1000) / 10}%`,
+                  width: 1.5,
+                  borderRadius: 999,
+                  background: mode === "paused" ? t.ink2 : tint,
+                  boxShadow: m.glow > 0.02 ? `0 0 ${Math.round(m.glow * 8)}px ${tint}` : undefined,
+                  transform: "translateX(-50%)",
+                }}
+              />
+            ) : null}
+          </div>
+        </div>
+
+        {/* Tape clock under the bay only */}
+        {mode === "ready" || narrating ? (
+          <div
+            className="relative tabular-nums"
+            style={{
+              marginTop: 4,
+              marginLeft: gutter + gap,
+              fontSize: fs(9),
+              color: t.ink4,
+            }}
+          >
+            <div className="flex justify-between">
+              <span>0:00</span>
+              <span>0:04</span>
+            </div>
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              style={{ color: narrating ? t.ink2 : t.ink3 }}
+            >
+              {narrating ? clock(pos) : "0:00"}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <div style={{ flex: "0 0 8px", minHeight: 4, maxHeight: 10 }} />
+
+      {/* Chips on the floor of the plate */}
+      <div className="flex items-center gap-1.5" style={{ height: 22 }}>
+        <Press frozen={frozen} onClick={onCycleSpeed} className="appearance-none">
+          <Chip skin={skin}>
+            <span style={{ fontSize: fs(10), color: t.ink3 }}>
+              {["1.00×", "1.25×", "1.50×", "0.75×"][speedIx]}
+            </span>
+          </Chip>
+        </Press>
+        <Chip skin={skin}>
+          <span style={{ fontSize: fs(10), color: t.ink4, opacity: 0.6 }}>VOL</span>
+          <span
+            className="ml-1.5 inline-block h-[3px] w-[26px] rounded-full"
+            style={{ background: rgba(t.line, m.borderAlpha) }}
+            onPointerDown={(e) => {
+              if (!onVolume) return;
+              const el = e.currentTarget;
+              const move = (ev: PointerEvent) => {
+                const r = el.getBoundingClientRect();
+                onVolume(Math.min(1, Math.max(0, (ev.clientX - r.left) / r.width)));
+              };
+              move(e.nativeEvent);
+              const up = () => {
+                window.removeEventListener("pointermove", move);
+                window.removeEventListener("pointerup", up);
+              };
+              window.addEventListener("pointermove", move);
+              window.addEventListener("pointerup", up);
+            }}
+          >
+            <span
+              className="block h-full rounded-full"
+              style={{ width: `${Math.round(volume * 100)}%`, background: t.ink3 }}
+            />
+          </span>
+        </Chip>
+        <div className="flex-1" />
+        <Press
+          frozen={frozen}
+          onClick={onToggleAuto}
+          style={{
+            borderRadius: m.chipRadius,
+            padding: "1px 8px",
+            fontSize: fs(9.5),
+            fontWeight: 600,
+            letterSpacing: "0.04em",
+            background: autoplay ? rgba(t.amber, 0.12) : `linear-gradient(180deg, ${t.pad}, ${t.padBottom})`,
+            border: `1px solid ${autoplay ? rgba(t.amber, 0.5) : rgba(t.line, m.borderAlpha)}`,
+            color: autoplay ? t.amber : t.ink4,
+          }}
+        >
+          {autoplay ? "AUTOPLAY ON" : "AUTOPLAY OFF"}
+        </Press>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Transport affordance. Renders as a plain box when the mock is display-only —
+ * the strip wraps whole columns in a card button, and nested interactive nodes
+ * are invalid HTML.
+ */
+function Press({
+  frozen,
+  onClick,
+  className,
+  style,
+  children,
+}: {
+  frozen?: boolean;
+  onClick?: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}) {
+  if (frozen) {
+    return (
+      <div className={className} style={style}>
+        {children}
+      </div>
+    );
+  }
+  return (
+    <button type="button" onClick={onClick} className={className} style={style}>
+      {children}
+    </button>
+  );
+}
+
+function Chip({ skin, children }: { skin: Skin; children: React.ReactNode }) {
+  const { t, m } = skin;
+  return (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5"
+      style={{
+        borderRadius: m.chipRadius,
+        background: `linear-gradient(180deg, ${t.pad}, ${t.padBottom})`,
+        border: `1px solid ${rgba(t.line, m.borderAlpha)}`,
+        boxShadow: bevelShadow(skin),
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------------ figures */
+
+function RadioFigure({
+  skin,
+  mode,
+  env,
+  pos,
+  level,
+  phase,
+  tint,
+  restLabel,
+}: {
+  skin: Skin;
+  mode: Mode;
+  env: number[];
+  pos: number;
+  level: number;
+  phase: number;
+  tint: string;
+  restLabel: string;
+}) {
+  switch (mode) {
+    case "speaking":
+    case "paused":
+      return (
+        <PlaybackWave
+          skin={skin}
+          env={env}
+          pos={pos}
+          tint={mode === "paused" ? skin.t.ink3 : skin.t.accent}
+        />
+      );
+    case "listening":
+      return <CaptureWave skin={skin} level={level} phase={phase} />;
+    case "transcribing":
+    case "submitting":
+      return (
+        <ActivityField
+          skin={skin}
+          tint={tint}
+          phase={phase}
+          kind={mode === "transcribing" ? "sweep" : "pulse"}
+        />
+      );
+    default:
+      return <RestField skin={skin} label={restLabel} />;
+  }
+}
+
+/**
+ * One meter stroke. Radius follows the material so a brutalist plate gets
+ * square posts and a glass slab gets rounded strokes.
+ */
+function Bar({
+  skin,
+  height,
+  color,
+  opacity,
+}: {
+  skin: Skin;
+  height: number;
+  color: string;
+  opacity: number;
+}) {
+  const r = skin.m.radius > 12 ? 2 : skin.m.radius < 3 ? 0 : 1;
+  return (
+    <div className="flex flex-1 items-center justify-center" style={{ height: "100%", minWidth: 0 }}>
+      <div
+        style={{
+          width: "85%",
+          maxWidth: 2,
+          height,
+          borderRadius: r,
+          background: color,
+          opacity: op(opacity),
+        }}
+      />
+    </div>
+  );
+}
+
+function PlaybackWave({
+  skin,
+  env,
+  pos,
+  tint,
+}: {
+  skin: Skin;
+  env: number[];
+  pos: number;
+  tint: string;
+}) {
+  const n = env.length;
+  const head = Math.min(n - 1, Math.floor(pos * n));
+  return (
+    <div className="relative flex h-full w-full items-center">
+      <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+        {env.map((v, i) => {
+          const played = i <= head;
+          return (
+            <Bar
+              key={i}
+              skin={skin}
+              height={px(v * 28)}
+              color={played ? tint : skin.t.line}
+              opacity={played ? 0.95 : 0.3}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function CaptureWave({ skin, level, phase }: { skin: Skin; level: number; phase: number }) {
+  const bars = 88;
+  const drift = (Math.round(phase * 100) / 100) * Math.PI * 2;
+  const heights = Array.from({ length: bars }, (_, i) => {
+    const t = i / bars;
+    const speech =
+      Math.abs(Math.sin(t * 14 + drift * 1.7)) * 0.45 +
+      Math.abs(Math.sin(t * 31 + drift * 2.3)) * 0.3 +
+      Math.abs(Math.sin(t * 53 - drift)) * 0.2;
+    const window = Math.sin(t * Math.PI);
+    const v = level * speech * (0.55 + window * 0.45);
+    return { h: px(Math.max(2, v * 28)), hot: v > 0.06 };
+  });
+  return (
+    <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+      {heights.map((bar, i) => (
+        <Bar
+          key={i}
+          skin={skin}
+          height={bar.h}
+          color={skin.t.accent}
+          opacity={bar.hot ? 0.92 : 0.14}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ActivityField({
+  skin,
+  tint,
+  phase,
+  kind,
+}: {
+  skin: Skin;
+  tint: string;
+  phase: number;
+  kind: "sweep" | "pulse";
+}) {
+  const bars = 80;
+  const p = Math.round(phase * 100) / 100;
+
+  if (kind === "pulse") {
+    const amp = 0.35 + Math.abs(Math.sin(p * Math.PI * 2)) * 0.55;
+    return (
+      <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+        {Array.from({ length: bars }, (_, i) => {
+          const t = i / bars;
+          const hump = Math.sin(t * Math.PI);
+          return (
+            <Bar
+              key={i}
+              skin={skin}
+              height={px(2 + hump * amp * 26)}
+              color={tint}
+              opacity={op(0.25 + hump * 0.55)}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+      {Array.from({ length: bars }, (_, i) => {
+        const t = i / (bars - 1);
+        const d = Math.min(Math.abs(t - p), 1 - Math.abs(t - p));
+        const lobe = Math.max(0, 1 - d * 2.4);
+        return (
+          <Bar
+            key={i}
+            skin={skin}
+            height={px(3 + lobe * 24)}
+            color={tint}
+            opacity={op(0.18 + lobe * 0.78)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function RestField({
+  skin,
+  label = "AT REST",
+  silhouette = false,
+}: {
+  skin: Skin;
+  label?: string;
+  silhouette?: boolean;
+}) {
+  const n = 64;
+  return (
+    <div className="relative flex h-full w-full items-center justify-center">
+      {silhouette ? (
+        <div className="flex h-full w-full items-stretch" style={{ gap: 1 }}>
+          {Array.from({ length: n }, (_, i) => {
+            const t = i / (n - 1);
+            const phrase = Math.abs(Math.sin(t * Math.PI * 3.2));
+            const formant =
+              Math.abs(Math.sin(t * 47)) * 0.35 + Math.abs(Math.sin(t * 19)) * 0.25;
+            const breath = phrase > 0.12 ? 1 : 0.08;
+            const v = Math.min(1, Math.max(0.06, (phrase * 0.55 + formant) * breath));
+            return (
+              <Bar
+                key={i}
+                skin={skin}
+                height={px(2 + v * 22)}
+                color={skin.t.line}
+                opacity={op(0.28 + v * 0.22)}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mx-1 h-px w-full" style={{ background: skin.t.lineSoft }} />
+      )}
+      <span
+        className="pointer-events-none absolute font-semibold"
+        style={{
+          fontSize: 8,
+          letterSpacing: "0.14em",
+          color: skin.t.ink4,
+          background: skin.t.empty,
+          padding: "2px 8px",
+          borderRadius: Math.max(2, skin.m.chipRadius),
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------- knob chrome */
+
+function Rack({
+  title,
+  aside,
+  children,
+}: {
+  title: string;
+  aside?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-studio-rule p-3.5">
+      <div className="mb-2.5 flex items-center justify-between">
+        <div className="font-mono text-[9.5px] uppercase tracking-[0.18em] text-studio-ink-faint">
+          {title}
+        </div>
+        {aside}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Pill({
+  active,
+  tint,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  tint: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded px-2.5 py-1 text-[11px] font-medium transition"
+      style={{
+        border: `1px solid ${active ? tint : "var(--studio-rule, #3a3a3a)"}`,
+        background: active ? rgba(tint, 0.14) : "transparent",
+        color: active ? tint : undefined,
+      }}
+    >
+      <span className={active ? "" : "text-studio-ink-faint"}>{children}</span>
+    </button>
+  );
+}
+
+function Toggle({
+  on,
+  disabled,
+  onClick,
+  children,
+}: {
+  on: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="rounded px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] transition disabled:opacity-40"
+      style={{
+        border: "1px solid var(--studio-rule, #3a3a3a)",
+        background: on ? "rgba(120,180,160,0.16)" : "transparent",
+      }}
+    >
+      <span className={on ? "text-studio-ink-strong" : "text-studio-ink-faint"}>
+        {children}
+      </span>
+    </button>
+  );
+}
+
+function Knob({
+  label,
+  value,
+  min,
+  max,
+  step,
+  unit,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  unit?: string;
+  disabled?: boolean;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2.5 py-1 text-[11px] text-studio-ink-faint">
+      <span className="w-[104px] shrink-0">{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="min-w-0 flex-1 disabled:opacity-40"
+      />
+      <span className="w-[54px] shrink-0 text-right font-mono tabular-nums">
+        {step < 1 ? value.toFixed(2) : Math.round(value)}
+        {unit ?? ""}
+      </span>
+    </label>
+  );
+}
+
+function Select({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2.5 py-1 text-[11px] text-studio-ink-faint">
+      <span className="w-[104px] shrink-0">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="min-w-0 flex-1 rounded border border-studio-rule bg-transparent px-1.5 py-1 font-mono text-[10px] text-studio-ink"
+      >
+        {options.map((o) => (
+          <option key={o} value={o} style={{ color: "#111" }}>
+            {o}
+          </option>
+        ))}
+      </select>
+      <span className="w-[54px] shrink-0" />
+    </label>
+  );
+}
+
+function ColorRow({
+  name,
+  value,
+  onChange,
+}: {
+  name: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [text, setText] = useState(value);
+  // Sync only when the prop actually changes — never echo the same string
+  // (avoids update loops when parent re-renders for unrelated reasons).
+  useEffect(() => {
+    setText((prev) => (prev === value ? prev : value));
+  }, [value]);
+  const safeColor = HEX_RE.test(value) ? value.toLowerCase() : "#000000";
+  return (
+    <div className="flex items-center gap-2 py-[3px]">
+      <input
+        type="color"
+        value={safeColor}
+        onChange={(e) => {
+          const next = e.target.value.toLowerCase();
+          if (next !== value.toLowerCase()) onChange(next);
+        }}
+        className="h-5 w-5 shrink-0 cursor-pointer rounded border border-studio-rule bg-transparent p-0"
+        aria-label={name}
+      />
+      <span className="w-[76px] shrink-0 font-mono text-[10px] text-studio-ink-faint">
+        {name}
+      </span>
+      <input
+        value={text}
+        onChange={(e) => {
+          const raw = e.target.value;
+          setText(raw);
+          if (HEX_RE.test(raw)) {
+            const next = raw.toLowerCase();
+            if (next !== value.toLowerCase()) onChange(next);
+          }
+        }}
+        spellCheck={false}
+        className="min-w-0 flex-1 rounded border border-studio-rule bg-transparent px-1.5 py-0.5 font-mono text-[10px] text-studio-ink"
+      />
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ export */
+
+function exportJSON(theme: ThemeDef, draft: Draft): string {
+  const palette: Record<string, string> = {};
+  for (const k of TOKEN_KEYS) palette[k] = draft.tokens[k];
+  return JSON.stringify(
+    {
+      id: theme.id,
+      name: theme.name,
+      scheme: theme.scheme,
+      preset: draft.presetId,
+      palette,
+      material: draft.material,
+    },
+    null,
+    2,
+  );
+}
+
+function exportSwift(theme: ThemeDef, draft: Draft): string {
+  const hex = (k: TokenKey) =>
+    `0x${(draft.tokens[k] ?? "#000000").replace("#", "").toUpperCase()}`;
+  const rows = [
+    ["page", "panel", "panelHead", "cell"],
+    ["trace", "line", "lineSoft"],
+    ["ink", "ink2", "ink3", "ink4"],
+    ["accent", "accentDim", "accentDark", "accentEdge"],
+    ["amber", "plate", "plateTop", "plateBottom"],
+    ["pad", "padBottom", "empty"],
+    ["micTop", "micBottom"],
+  ] as TokenKey[][];
+  const body = rows
+    .map((row) => `    ${row.map((k) => `${k}: ${hex(k)}`).join(", ")}`)
+    .join(",\n");
+  return [
+    `// ${theme.name} — ${draft.presetId}`,
+    `case .${theme.id}:`,
+    `    DeckThemePalette(`,
+    body.replace(/^ {4}/gm, "        "),
+    `    )`,
+  ].join("\n");
+}
+
+/* --------------------------------------------------------------- animation */
+
+/**
+ * Wall-clock phase. We never call setState every rAF with a new phase value —
+ * that re-rendered the whole study tree and, under React 19 + Turbopack,
+ * surfaced as "Maximum update depth exceeded". Instead we tick a cheap counter
+ * on an interval and derive phase from performance.now() during render.
+ */
+function useAnimationPhase(running: boolean, speed: number) {
+  const originRef = useRef<number | null>(null);
+  const [, setBeat] = useState(0);
+
+  useEffect(() => {
+    if (!running) {
+      originRef.current = null;
+      return;
+    }
+    originRef.current = performance.now();
+    // ~12 fps is enough for the mock figures; keeps the tree calm.
+    const id = window.setInterval(() => setBeat((n) => (n + 1) % 1_000_000), 80);
+    return () => window.clearInterval(id);
+  }, [running, speed]);
+
+  if (!running || originRef.current == null) return 0;
+  const elapsed = (performance.now() - originRef.current) / 1000;
+  return (elapsed * 0.28 * speed) % 1;
+}

--- a/design/studio/src/studio/PlayerFaceStudy.tsx
+++ b/design/studio/src/studio/PlayerFaceStudy.tsx
@@ -1,0 +1,845 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import { PageHeader } from "@/studio/PageHeader";
+import type { StudioAppPage } from "@/studio/studioRegistry";
+
+/**
+ * Player face — turn player cutout (studio only).
+ *
+ * Design language from the state-range board:
+ *   circular play ring · caption-first · one scrub · chip controls
+ * Same geometry empty → finished. No iPad deploys from this file.
+ */
+
+// ── Palette (dark instrument) ────────────────────────────────
+
+const C = {
+  page: "#0a0b0e",
+  plate: "#14161b",
+  plateEdge: "#22262f",
+  well: "#0e1014",
+  ink: "#e6e8ee",
+  ink2: "#9aa3b2",
+  ink3: "#6a7280",
+  ink4: "#454b58",
+  ink5: "#333842",
+  line: "#2a2f3a",
+  lineSoft: "#1a1e26",
+  mint: "#5ee9c2",
+  mintDim: "#3ab894",
+  mintSoft: "rgba(94, 233, 194, 0.12)",
+  amber: "#d4a04a",
+  amberSoft: "rgba(212, 160, 74, 0.12)",
+  coral: "#e07a5f",
+  chip: "#1a1d25",
+  chipEdge: "#2c313c",
+} as const;
+
+/** Fixed face height — 3-line caption + status + scrub + chips. */
+const CARD_H = 134;
+/** Caption measure so copy wraps to 2–3 even lines (matches board). */
+const CAPTION_MAX = 430;
+/** Default hero face width — instrument, not stretched bar. */
+const HERO_DEFAULT_W = 500;
+
+// ── States ───────────────────────────────────────────────────
+
+type PlayerState =
+  | "empty"
+  | "working"
+  | "ready"
+  | "playing"
+  | "paused"
+  | "finished"
+  | "failed";
+
+type StateSpec = {
+  id: PlayerState;
+  code: string;
+  title: string;
+  head: string;
+  headTone: "muted" | "mint" | "amber" | "coral";
+  live?: boolean;
+  status: string;
+  statusTone: "muted" | "mint" | "amber" | "coral";
+  meta?: string;
+  caption: string;
+  captionLive?: boolean;
+  progress: number;
+  showKnob: boolean;
+  duration: string;
+  ring: "idle" | "working" | "ready" | "playing" | "paused" | "finished" | "failed";
+  ringProgress?: number;
+  primary: "play" | "pause" | "replay" | "retry" | "idle";
+  speed: string;
+  vol: number;
+  autoplay: "on" | "off" | "next";
+  autoLabel?: string;
+};
+
+const CAPTION_READY =
+  "Refactored the auth middleware into a single guard and moved token refresh off the request path.";
+
+const STATES: StateSpec[] = [
+  {
+    id: "empty",
+    code: "2a",
+    title: "Empty — no turn has returned yet",
+    head: "LANE 02",
+    headTone: "muted",
+    status: "NO AUDIO",
+    statusTone: "muted",
+    caption: "",
+    progress: 0,
+    showKnob: false,
+    duration: "—:——",
+    ring: "idle",
+    primary: "idle",
+    speed: "1.00×",
+    vol: 0.35,
+    autoplay: "on",
+  },
+  {
+    id: "working",
+    code: "2b",
+    title: "Working — turn running, voice not synthesised yet",
+    head: "TURN 15",
+    headTone: "amber",
+    status: "WORKING",
+    statusTone: "amber",
+    meta: "00:41",
+    caption: "Reading src/auth/middleware.ts and the four call sites that touch it",
+    captionLive: true,
+    progress: 0.1,
+    showKnob: false,
+    duration: "0:00",
+    ring: "working",
+    ringProgress: 0.3,
+    primary: "idle",
+    speed: "1.00×",
+    vol: 0.45,
+    autoplay: "on",
+  },
+  {
+    id: "ready",
+    code: "2c",
+    title: "Ready — arrived, untouched (the at-rest face)",
+    head: "TURN 14",
+    headTone: "mint",
+    status: "SUMMARY",
+    statusTone: "mint",
+    meta: "1:14",
+    caption: CAPTION_READY,
+    progress: 0,
+    showKnob: true,
+    duration: "0:00",
+    ring: "ready",
+    primary: "play",
+    speed: "1.00×",
+    vol: 0.4,
+    autoplay: "on",
+  },
+  {
+    id: "playing",
+    code: "2d",
+    title: "Playing — caption fills as it speaks",
+    head: "TURN 14",
+    headTone: "mint",
+    live: true,
+    status: "SPEAKING",
+    statusTone: "mint",
+    caption: CAPTION_READY,
+    progress: 0.34,
+    showKnob: true,
+    duration: "0:25",
+    ring: "playing",
+    ringProgress: 0.34,
+    primary: "pause",
+    speed: "1.25×",
+    vol: 0.55,
+    autoplay: "on",
+  },
+  {
+    id: "paused",
+    code: "2e",
+    title: "Paused — held mid-clip, scrub knob live",
+    head: "TURN 14",
+    headTone: "muted",
+    status: "PAUSED",
+    statusTone: "muted",
+    meta: "0:28 LEFT",
+    caption: CAPTION_READY,
+    progress: 0.62,
+    showKnob: true,
+    duration: "0:46",
+    ring: "paused",
+    ringProgress: 0.62,
+    primary: "play",
+    speed: "1.25×",
+    vol: 0.35,
+    autoplay: "off",
+  },
+  {
+    id: "finished",
+    code: "2f",
+    title: "Finished — played out, replay offered, next turn armed",
+    head: "TURN 14",
+    headTone: "muted",
+    status: "PLAYED",
+    statusTone: "muted",
+    meta: "1:14",
+    caption: CAPTION_READY,
+    progress: 1,
+    showKnob: false,
+    duration: "REPLAY",
+    ring: "finished",
+    ringProgress: 1,
+    primary: "replay",
+    speed: "1.25×",
+    vol: 0.35,
+    autoplay: "next",
+    autoLabel: "NEXT TURN AUTOPLAYS",
+  },
+  {
+    id: "failed",
+    code: "2g",
+    title: "Voice unavailable — text landed, audio did not",
+    head: "TURN 13",
+    headTone: "coral",
+    status: "SYNTHESIS FAILED",
+    statusTone: "coral",
+    meta: "READ ABOVE",
+    caption: "Migrated the session store to Redis and pinned the client version.",
+    progress: 0,
+    showKnob: false,
+    duration: "RETRY",
+    ring: "failed",
+    primary: "retry",
+    speed: "1.25×",
+    vol: 0.3,
+    autoplay: "on",
+  },
+];
+
+function tone(t: StateSpec["headTone"]): string {
+  if (t === "mint") return C.mint;
+  if (t === "amber") return C.amber;
+  if (t === "coral") return C.coral;
+  return C.ink4;
+}
+
+// ─────────────────────────────────────────────────────────────
+
+export function PlayerFaceStudyPage({ page }: { page: StudioAppPage }) {
+  const [focus, setFocus] = useState<PlayerState>("ready");
+  const [width, setWidth] = useState(HERO_DEFAULT_W);
+  const focused = useMemo(() => STATES.find((s) => s.id === focus) ?? STATES[2], [focus]);
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+
+      <section className="max-w-[720px] space-y-14 py-8">
+        <p className="max-w-[58ch] text-[14px] leading-[1.7] text-studio-ink">
+          Turn player — same geometry empty through finished. Circular play ring,
+          caption-first, one scrub, chip controls. Caption measure locked so copy
+          wraps to two–three even lines.
+        </p>
+
+        {/* Hero */}
+        <section>
+          <Eyebrow>
+            Hero · {focused.code} · {focused.id}
+          </Eyebrow>
+          <p className="mb-4 text-[13px] text-studio-ink-faint">{focused.title}</p>
+          <div
+            className="flex justify-center rounded-2xl px-8 py-14"
+            style={{ background: C.page, border: `1px solid ${C.lineSoft}` }}
+          >
+            <div style={{ width, maxWidth: "100%" }}>
+              <TurnPlayer spec={focused} />
+            </div>
+          </div>
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <label className="flex items-center gap-2 font-mono text-[11px] text-studio-ink-faint">
+              Width
+              <input
+                type="range"
+                min={420}
+                max={560}
+                step={4}
+                value={width}
+                onChange={(e) => setWidth(Number(e.target.value))}
+                style={{ accentColor: C.mint }}
+              />
+              <span className="w-12 tabular-nums">{width}pt</span>
+            </label>
+            <div className="flex flex-wrap gap-1.5">
+              {STATES.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => setFocus(s.id)}
+                  className="rounded-md px-2 py-1 font-mono text-[10px] transition"
+                  style={{
+                    background: focus === s.id ? C.mintSoft : C.chip,
+                    border: `1px solid ${focus === s.id ? C.mint + "55" : C.chipEdge}`,
+                    color: focus === s.id ? C.mint : C.ink3,
+                  }}
+                >
+                  {s.code}
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* State range — single column, full measure (board fidelity) */}
+        <section>
+          <Eyebrow>2 · State range for 1b — same geometry, empty through finished</Eyebrow>
+          <div className="mt-5 flex flex-col gap-4">
+            {STATES.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => setFocus(s.id)}
+                className="rounded-xl p-4 text-left transition"
+                style={{
+                  background: C.page,
+                  border: `1px solid ${focus === s.id ? C.mint + "44" : C.lineSoft}`,
+                }}
+              >
+                <div className="mb-3 flex items-baseline gap-2">
+                  <span
+                    className="rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                    style={{
+                      background: C.chip,
+                      color: C.ink3,
+                      border: `1px solid ${C.chipEdge}`,
+                    }}
+                  >
+                    {s.code}
+                  </span>
+                  <span className="font-mono text-[11px] text-studio-ink-faint">{s.title}</span>
+                </div>
+                <TurnPlayer spec={s} />
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-3 md:grid-cols-3">
+          <Note title="One geometry">
+            Every state is the same card height and structure. Emptiness is quiet
+            chrome, not a different layout.
+          </Note>
+          <Note title="Ring = transport">
+            The circle is play, pause, progress, and error. No second playhead in
+            a waveform bay.
+          </Note>
+          <Note title="Caption first">
+            The turn summary is the content. Scrub is one line under it. Chips
+            handle speed, volume, autoplay.
+          </Note>
+        </section>
+      </section>
+    </main>
+  );
+}
+
+// ── Component ────────────────────────────────────────────────
+
+function TurnPlayer({ spec }: { spec: StateSpec }) {
+  const empty = spec.id === "empty";
+  const failed = spec.id === "failed";
+  const working = spec.id === "working";
+  /** Whole-module dim for empty — keeps geometry, quiets presence. */
+  const moduleDim = empty ? 0.42 : 1;
+
+  return (
+    <div
+      style={{
+        height: CARD_H,
+        borderRadius: 16,
+        background: C.plate,
+        border: `1px solid ${C.plateEdge}`,
+        display: "flex",
+        alignItems: "stretch",
+        gap: 14,
+        padding: "13px 16px 12px 14px",
+        isolation: "isolate",
+        overflow: "hidden",
+        boxSizing: "border-box",
+        opacity: moduleDim,
+      }}
+    >
+      {/* Ring column — fixed */}
+      <div
+        className="flex shrink-0 flex-col items-center"
+        style={{ width: 56, paddingTop: 2, gap: 7 }}
+      >
+        <PlayRing kind={spec.ring} progress={spec.ringProgress ?? 0} />
+        <div
+          className="font-mono tabular-nums"
+          style={{
+            color: failed ? C.coral : empty ? C.ink5 : C.ink3,
+            fontSize: spec.duration === "REPLAY" || spec.duration === "RETRY" ? 9 : 10,
+            fontWeight: 500,
+            letterSpacing:
+              spec.duration === "REPLAY" || spec.duration === "RETRY" ? "0.1em" : "0.02em",
+            lineHeight: 1,
+          }}
+        >
+          {spec.duration}
+        </div>
+      </div>
+
+      {/* Body — pinned rows */}
+      <div
+        className="flex min-w-0 flex-1 flex-col"
+        style={{
+          paddingTop: 1,
+          // status · caption · scrub · chips — fixed slots
+          display: "grid",
+          gridTemplateRows: "14px 1fr 14px 22px",
+          gap: 0,
+          minHeight: 0,
+        }}
+      >
+        {/* Status */}
+        <div
+          className="flex items-center gap-1.5 font-mono"
+          style={{
+            fontSize: 10,
+            lineHeight: 1,
+            letterSpacing: "0.05em",
+            minWidth: 0,
+          }}
+        >
+          {spec.live && (
+            <span
+              className="inline-block shrink-0 rounded-full"
+              style={{ width: 4, height: 4, background: C.mint }}
+            />
+          )}
+          <span
+            style={{
+              color: empty ? C.ink5 : tone(spec.headTone),
+              fontWeight: 600,
+            }}
+          >
+            {spec.head}
+          </span>
+          <span style={{ color: C.ink5 }}>·</span>
+          <span
+            style={{
+              color: empty ? C.ink5 : tone(spec.statusTone),
+              fontWeight: 600,
+            }}
+          >
+            {spec.status}
+          </span>
+          {spec.meta != null && (
+            <>
+              <span style={{ color: C.ink5 }}>·</span>
+              <span style={{ color: C.ink4 }}>{spec.meta}</span>
+            </>
+          )}
+        </div>
+
+        {/* Caption — measure capped */}
+        <div
+          className="min-h-0 overflow-hidden font-sans"
+          style={{
+            maxWidth: CAPTION_MAX,
+            fontSize: 13,
+            lineHeight: 1.4,
+            color: empty ? C.ink5 : C.ink,
+            letterSpacing: "-0.01em",
+            paddingTop: 6,
+            paddingBottom: 6,
+          }}
+        >
+          {empty ? (
+            <EmptyGhostLines />
+          ) : (
+            <>
+              {spec.caption}
+              {spec.captionLive && (
+                <span
+                  className="ml-0.5 inline-block"
+                  style={{
+                    width: 1.5,
+                    height: 12,
+                    background: C.amber,
+                    verticalAlign: "text-bottom",
+                    marginBottom: 1,
+                  }}
+                />
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Scrub */}
+        <div className="flex items-center">
+          <ScrubLine
+            progress={spec.progress}
+            showKnob={spec.showKnob}
+            tone={
+              spec.id === "playing" || spec.id === "paused" || spec.id === "finished"
+                ? "mint"
+                : working
+                  ? "amber"
+                  : "muted"
+            }
+            empty={empty || failed}
+          />
+        </div>
+
+        {/* Chips */}
+        <div className="flex items-center gap-1.5" style={{ paddingTop: 4 }}>
+          <Chip quiet={empty}>{spec.speed}</Chip>
+          <Chip quiet={empty}>
+            <span style={{ opacity: 0.5, marginRight: 6 }}>VOL</span>
+            <VolBar value={spec.vol} quiet={empty} />
+          </Chip>
+          <div className="flex-1" />
+          <AutoChip kind={spec.autoplay} label={spec.autoLabel} quiet={empty} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyGhostLines() {
+  return (
+    <div className="flex flex-col justify-center gap-[8px] pt-1">
+      <div style={{ height: 1, width: "88%", background: C.line }} />
+      <div style={{ height: 1, width: "64%", background: C.line }} />
+      <div style={{ height: 1, width: "42%", background: C.line }} />
+    </div>
+  );
+}
+
+function PlayRing({
+  kind,
+  progress,
+}: {
+  kind: StateSpec["ring"];
+  progress: number;
+}) {
+  const size = 52;
+  const stroke = 2;
+  const r = (size - stroke) / 2 - 1;
+  const circ = 2 * Math.PI * r;
+  const p = Math.max(0, Math.min(1, progress));
+
+  let trackColor: string = C.line;
+  let progressColor: string = C.line;
+  let glyphColor: string = C.ink3;
+  let showArc = false;
+  let arcFull = false;
+
+  switch (kind) {
+    case "idle":
+      trackColor = C.line;
+      glyphColor = C.ink5;
+      break;
+    case "working":
+      trackColor = C.line;
+      progressColor = C.amber;
+      glyphColor = C.ink3;
+      showArc = true;
+      break;
+    case "ready":
+      trackColor = C.line;
+      glyphColor = C.mint;
+      break;
+    case "playing":
+      trackColor = C.line;
+      progressColor = C.mint;
+      glyphColor = C.mint;
+      showArc = true;
+      break;
+    case "paused":
+      trackColor = C.line;
+      progressColor = C.mint;
+      glyphColor = C.mint;
+      showArc = true;
+      break;
+    case "finished":
+      trackColor = C.line;
+      progressColor = C.mintDim;
+      glyphColor = C.ink2;
+      showArc = true;
+      arcFull = true;
+      break;
+    case "failed":
+      trackColor = C.coral;
+      glyphColor = C.coral;
+      break;
+  }
+
+  const dashLen = showArc ? circ * (arcFull ? 0.999 : Math.max(0.08, p)) : 0;
+
+  return (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      <svg width={size} height={size} className="absolute inset-0">
+        <circle cx={size / 2} cy={size / 2} r={r} fill={C.well} stroke="none" />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke={trackColor}
+          strokeWidth={stroke}
+          opacity={kind === "failed" ? 0.9 : 0.95}
+        />
+        {showArc && (
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            fill="none"
+            stroke={progressColor}
+            strokeWidth={stroke}
+            strokeLinecap="round"
+            strokeDasharray={`${dashLen.toFixed(2)} ${(circ - dashLen).toFixed(2)}`}
+            transform={`rotate(-90 ${size / 2} ${size / 2})`}
+            opacity={kind === "finished" ? 0.65 : 1}
+          />
+        )}
+      </svg>
+
+      <div className="absolute inset-0 flex items-center justify-center">
+        {kind === "working" ? (
+          <span className="flex items-center gap-[3px]">
+            {[0, 1, 2].map((i) => (
+              <span
+                key={i}
+                className="rounded-full"
+                style={{
+                  width: 3,
+                  height: 3,
+                  background: C.ink3,
+                  opacity: 0.4 + i * 0.22,
+                }}
+              />
+            ))}
+          </span>
+        ) : kind === "failed" ? (
+          <svg width="16" height="16" viewBox="0 0 16 16">
+            <line
+              x1="4.5"
+              y1="11.5"
+              x2="11.5"
+              y2="4.5"
+              stroke={C.coral}
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </svg>
+        ) : kind === "playing" ? (
+          <PauseGlyph color={glyphColor} />
+        ) : (
+          <PlayGlyph color={glyphColor} dim={kind === "idle"} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PlayGlyph({ color, dim }: { color: string; dim?: boolean }) {
+  // Optical center: triangle sits slightly right of geometric center
+  return (
+    <svg
+      width="12"
+      height="14"
+      viewBox="0 0 12 14"
+      style={{ marginLeft: 1.5, opacity: dim ? 0.5 : 1 }}
+    >
+      <path d="M1.5 1.2 L11 7 L1.5 12.8 Z" fill={color} />
+    </svg>
+  );
+}
+
+function PauseGlyph({ color }: { color: string }) {
+  return (
+    <svg width="11" height="12" viewBox="0 0 11 12">
+      <rect x="1" y="1" width="3" height="10" rx="0.6" fill={color} />
+      <rect x="7" y="1" width="3" height="10" rx="0.6" fill={color} />
+    </svg>
+  );
+}
+
+function ScrubLine({
+  progress,
+  showKnob,
+  tone: t,
+  empty,
+}: {
+  progress: number;
+  showKnob: boolean;
+  tone: "mint" | "amber" | "muted";
+  empty: boolean;
+}) {
+  const fill = t === "mint" ? C.mint : t === "amber" ? C.amber : C.line;
+  const pct = Math.round(progress * 1000) / 10;
+  const atStart = showKnob && !empty && progress === 0;
+
+  return (
+    <div
+      className="relative w-full"
+      style={{ height: 12, opacity: empty ? 0.5 : 1, maxWidth: CAPTION_MAX + 40 }}
+    >
+      {/* track hairline */}
+      <div
+        className="absolute left-0 right-0 top-1/2 -translate-y-1/2"
+        style={{ height: 1, background: C.line }}
+      />
+      {/* fill hairline */}
+      {!empty && progress > 0 && (
+        <div
+          className="absolute left-0 top-1/2 -translate-y-1/2"
+          style={{
+            width: `${pct}%`,
+            height: 1,
+            background: fill,
+            opacity: t === "amber" ? 0.7 : 1,
+          }}
+        />
+      )}
+      {/* knob — crisp, no soft blob */}
+      {showKnob && !empty && (
+        <div
+          className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full"
+          style={{
+            left: atStart ? 0 : `${pct}%`,
+            width: 8,
+            height: 8,
+            background: "#eef0f4",
+            boxShadow: `0 0 0 1.5px ${C.plate}${
+              t === "mint" || atStart ? `, 0 0 0 2.5px ${C.mint}40` : ""
+            }`,
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function Chip({ children, quiet }: { children: ReactNode; quiet?: boolean }) {
+  return (
+    <span
+      className="inline-flex items-center font-mono tabular-nums"
+      style={{
+        background: C.chip,
+        border: `1px solid ${C.chipEdge}`,
+        color: quiet ? C.ink5 : C.ink3,
+        fontSize: 10,
+        fontWeight: 500,
+        padding: "3px 7px",
+        borderRadius: 6,
+        lineHeight: 1,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function VolBar({ value, quiet }: { value: number; quiet?: boolean }) {
+  const pct = Math.round(value * 100);
+  const on = quiet ? C.ink5 : C.ink3;
+  return (
+    <span
+      className="inline-block rounded-sm"
+      style={{
+        width: 26,
+        height: 2.5,
+        background: `linear-gradient(90deg, ${on} ${pct}%, ${C.line} ${pct}%)`,
+      }}
+    />
+  );
+}
+
+function AutoChip({
+  kind,
+  label,
+  quiet,
+}: {
+  kind: "on" | "off" | "next";
+  label?: string;
+  quiet?: boolean;
+}) {
+  if (kind === "off") {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 font-mono"
+        style={{
+          background: C.chip,
+          border: `1px solid ${C.chipEdge}`,
+          color: C.ink5,
+          fontSize: 9.5,
+          fontWeight: 500,
+          padding: "3px 8px",
+          borderRadius: 6,
+          lineHeight: 1,
+          letterSpacing: "0.05em",
+        }}
+      >
+        <span
+          className="rounded-full"
+          style={{ width: 4, height: 4, background: C.ink5 }}
+        />
+        AUTOPLAY OFF
+      </span>
+    );
+  }
+
+  const text = label ?? "AUTOPLAY ON";
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 font-mono"
+      style={{
+        background: quiet ? C.chip : C.amberSoft,
+        border: `1px solid ${quiet ? C.chipEdge : C.amber + "40"}`,
+        color: quiet ? C.ink5 : C.amber,
+        fontSize: 9.5,
+        fontWeight: 600,
+        padding: "3px 8px",
+        borderRadius: 6,
+        lineHeight: 1,
+        letterSpacing: "0.05em",
+      }}
+    >
+      <span
+        className="rounded-full"
+        style={{ width: 4, height: 4, background: quiet ? C.ink5 : C.amber }}
+      />
+      {text}
+    </span>
+  );
+}
+
+function Eyebrow({ children }: { children: ReactNode }) {
+  return (
+    <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-studio-ink-faint">
+      {children}
+    </div>
+  );
+}
+
+function Note({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-studio-rule bg-studio-surface p-4">
+      <div className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-studio-ink-faint">
+        {title}
+      </div>
+      <p className="text-[12.5px] leading-relaxed text-studio-ink">{children}</p>
+    </div>
+  );
+}

--- a/design/studio/src/studio/StudioPages.tsx
+++ b/design/studio/src/studio/StudioPages.tsx
@@ -6,6 +6,12 @@ import type { StudioHudsonRenderContext } from "studio/app-shell";
 import { useStudioRouter } from "studio/router";
 import { DeckHomePage } from "@/studio/DeckHome";
 import { PageHeader } from "@/studio/PageHeader";
+import { AudioInstrumentStudyPage } from "@/studio/AudioInstrumentStudy";
+import { LaneConsoleStudyPage } from "@/studio/LaneConsoleStudy";
+import { MicroThemesKimiStudyPage } from "@/studio/MicroThemesKimiStudy";
+import { MicroThemesMatureStudyPage } from "@/studio/MicroThemesMatureStudy";
+import { MicroThemesOpusStudyPage } from "@/studio/MicroThemesOpusStudy";
+import { PlayerFaceStudyPage } from "@/studio/PlayerFaceStudy";
 import { ThemesStudyPage } from "@/studio/ThemesStudy";
 import {
   HOME_HREF,
@@ -29,6 +35,24 @@ export function renderStudioPage(
   if (pathname === HOME_HREF) return <DeckHomePage />;
   if (page?.href === "/studio/studies/deck-themes") {
     return <ThemesStudyPage page={page} />;
+  }
+  if (page?.href === "/studio/studies/audio-instrument") {
+    return <AudioInstrumentStudyPage page={page} />;
+  }
+  if (page?.href === "/studio/studies/micro-themes-mature") {
+    return <MicroThemesMatureStudyPage page={page} />;
+  }
+  if (page?.href === "/studio/studies/micro-themes-kimi") {
+    return <MicroThemesKimiStudyPage page={page} />;
+  }
+  if (page?.href === "/studio/studies/lane-console") {
+    return <LaneConsoleStudyPage page={page} />;
+  }
+  if (page?.href === "/studio/studies/micro-themes-opus") {
+    return <MicroThemesOpusStudyPage page={page} />;
+  }
+  if (page?.href === "/studio/studies/player-face") {
+    return <PlayerFaceStudyPage page={page} />;
   }
   const body = page ? extras.docs[page.href] : undefined;
   if (page && body !== undefined) {

--- a/design/studio/src/studio/ThemesStudy.tsx
+++ b/design/studio/src/studio/ThemesStudy.tsx
@@ -46,14 +46,14 @@ const SEEDS: Seed[] = [
   {
     name: "flight",
     scheme: "dark",
-    blurb: "Full dark with the SpeakEasy signal teal, plate included.",
+    blurb: "Void graphite chassis; mint only as signal — not a teal wash.",
     swatches: [
-      { token: "page-bg", value: "#05090b" },
-      { token: "panel", value: "#0c161a" },
-      { token: "ink", value: "#e8f0ee" },
+      { token: "page-bg", value: "#06080a" },
+      { token: "panel", value: "#0d1114" },
+      { token: "ink", value: "#f2f5f6" },
       { token: "accent", value: "#74f2ce" },
     ],
-    note: "Replaces the plate tokens too — pad-face, plate-bg, led states.",
+    note: "Chassis stays cool neutral so #74f2ce reads as a lamp.",
   },
 ];
 

--- a/design/studio/src/studio/studioRegistry.ts
+++ b/design/studio/src/studio/studioRegistry.ts
@@ -57,6 +57,84 @@ export const pages: readonly StudioAppPage[] = [
     source: ["docs/design/deck-connect-brief.md"],
   },
   {
+    href: "/studio/studies/audio-instrument",
+    label: "SE-STU · Audio instrument",
+    bucket: "studies",
+    surface: "pad",
+    status: "wip",
+    blurb:
+      "The Micro Deck bottom-right panel — every capture and playback state, driveable. 1U idle, 2U while playing, on the key-bank grid.",
+    source: ["deck/ipad/Sources/DeckAudioInstrument.swift"],
+  },
+  {
+    href: "/studio/studies/lane-console",
+    label: "SE-STU · Lane console",
+    bucket: "studies",
+    surface: "pad",
+    status: "wip",
+    blurb:
+      "One surface: identity + exchange (panel) over player foot (plate). Ring in numeral gutter; figure is scrub — no second rail.",
+    source: [
+      "deck/ipad/Sources/DeckPlayerConsole.swift",
+      "deck/ipad/Sources/NativeDeckView.swift",
+    ],
+  },
+  {
+    href: "/studio/studies/micro-themes-mature",
+    label: "SE-STU · Micro themes · Mature",
+    bucket: "studies",
+    surface: "pad",
+    status: "wip",
+    blurb:
+      "Product-grade full Micro Deck. Quiet surfaces, one accent as signal — Linear/Cursor/Apple maturity, not workshop cosplay.",
+    source: [
+      "design/studio/src/studio/MicroThemesMatureStudy.tsx",
+      "design/studio/src/studio/MicroDeckFullMock.tsx",
+      "deck/ipad/Sources/DeckTheme.swift",
+    ],
+  },
+  {
+    href: "/studio/studies/micro-themes-opus",
+    label: "SE-STU · Micro themes · Opus",
+    bucket: "studies",
+    surface: "pad",
+    status: "wip",
+    blurb:
+      "Exploratory materials (full Micro). Knobs and presets — workshop lab, not ship defaults.",
+    source: [
+      "docs/design/micro-deck-theme-material-brief.md",
+      "design/studio/src/studio/MicroDeckFullMock.tsx",
+      "deck/ipad/Sources/DeckTheme.swift",
+    ],
+  },
+  {
+    href: "/studio/studies/player-face",
+    label: "SE-STU · Player face",
+    bucket: "studies",
+    surface: "pad",
+    status: "wip",
+    blurb:
+      "Turn player — circular play ring, caption-first, one scrub, chip controls. State matrix 2a–2g (empty → finished).",
+    source: [
+      "design/studio/src/studio/PlayerFaceStudy.tsx",
+      "deck/ipad/Sources/DeckPlayerConsole.swift",
+    ],
+  },
+  {
+    href: "/studio/studies/micro-themes-kimi",
+    label: "SE-STU · Micro themes · Kimi",
+    bucket: "studies",
+    surface: "pad",
+    status: "wip",
+    blurb:
+      "Exploratory materials (full Micro). Texture lab — phosphor, glaze, bakelite. Use Mature for ship-grade.",
+    source: [
+      "design/studio/src/studio/MicroThemesKimiStudy.tsx",
+      "design/studio/src/studio/MicroDeckFullMock.tsx",
+      "deck/ipad/Sources/DeckTheme.swift",
+    ],
+  },
+  {
     href: "/studio/studies/deck-themes",
     label: "SE-STU · Seed themes",
     bucket: "studies",


### PR DESCRIPTION
## What changed

- preserve the Micro Deck full mock and theme explorations
- preserve the lane console, player face, and audio instrument studies
- register the studies in the existing studio navigation

## Why

These studies document the design exploration behind the native surface and are kept separate from production code for focused review. The files are committed as found without cleanup or restructuring.

## Validation

- `pnpm --dir design/studio run typecheck`
- `pnpm --dir design/studio run build`
- Result: typecheck and production build passed (with one existing Turbopack tracing warning)
