### PR TITLE
📝 Prepare the 0.3.0 release pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+Notable changes to `@arach/speakeasy`. The npm package, the macOS app, and the
+agent skill ship as one train under a single version — see
+[`docs/release/0.3.0-release-pass.md`](docs/release/0.3.0-release-pass.md).
+
+## 0.3.0 — unreleased
+
+The first release since `0.2.19` (August 2, 2026). It carries a breaking CLI
+change, so it takes a minor bump rather than a patch.
+
+### Breaking
+
+- The `speakeasy codex <sub>` namespace is gone. `speakeasy plugin` is now the
+  inventory, and it installs into any supported host. Replace `speakeasy codex
+  skill` (and `codex install`) with `speakeasy plugin codex`, and `speakeasy
+  codex deck` with `speakeasy deck`.
+
+### Added
+
+- Long text is narrated as ordered segments instead of a single request, using a
+  new bounded semantic chunker that splits on meaning rather than a byte count.
+- `speakeasy uninstall` genuinely removes what SpeakEasy installed. It only
+  touches paths SpeakEasy created — anything belonging to another tool is left
+  alone.
+- `speakeasy plugin` with no host lists every host it can install into.
+
+### Fixed
+
+- Codex replies are no longer clipped to 600 characters before narration. Long
+  replies were being silently truncated mid-sentence.
+- Deck turns route through canonical Codex tasks, so the task selected on the
+  Deck is the task that activates.
+- Canonical IPC is preserved across Deck navigation instead of being rebuilt,
+  and task IPC is kept warm — both remove a stall on the first interaction.
+- A finished narration restarts at its first segment rather than resuming
+  part-way through.
+
+### Changed
+
+- Filesystem paths are centralized, so the cache, config, and history locations
+  come from one place instead of being rebuilt at each call site.
+- Deck catalog and playback helpers are consolidated.
+- The install surface is narrower: the published tarball ships `dist/` only, and
+  `dist/` is no longer tracked in git. The Deck surface is no longer bundled
+  with the npm package — `speakeasy deck` fetches it into
+  `~/.config/speakeasy/deck` on first run, and the Mac app keeps using its own
+  bundled copy.
+
+### Site
+
+- The approved design mocks are now the live home and Pad pages, rendered
+  directly from `landing/mocks/` rather than re-implemented as components.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ Mac, a browser, or an iPad on your local network.
 
 Paste this bounded task into Codex Desktop:
 
-> Install SpeakEasy 0.2.19 on this Mac. Read
-> https://speakeasy.arach.dev/agent.md and follow Path 3. Do not build from
-> source or bypass Gatekeeper. Tell me which human-only steps remain.
+> Install SpeakEasy on this Mac. Read https://speakeasy.arach.dev/agent.md and
+> follow Path 3. Do not build from source or bypass Gatekeeper. Tell me which
+> version you installed and which human-only steps remain.
 
-`0.2.19` is the first public **Latest** train, covering the Mac core and the
-browser/iPad deck. The earlier `0.2.18` build remains a GitHub prerelease
+The prompt names no version on purpose — the installer resolves the current
+release and verifies against that release's own published checksum, so a pasted
+prompt does not go stale. The `0.2.18` build remains a GitHub prerelease
 permanently and is a Mac-core-only preview — do not use it to evaluate the
 browser/iPad path.
 See [SpeakEasy for Codex](https://speakeasy.arach.dev/codex/) for the product
@@ -168,18 +169,19 @@ For the complete macOS app—local dictation, exact Codex task lanes, native
 narration, and the Deck—the recommended installation flow is a bounded Codex
 task. Paste this into Codex:
 
-> Install SpeakEasy 0.2.19 on this Mac. Read
-> https://speakeasy.arach.dev/agent.md and follow Path 3. Do not build from
-> source or bypass Gatekeeper. Tell me which human-only steps remain.
+> Install SpeakEasy on this Mac. Read https://speakeasy.arach.dev/agent.md and
+> follow Path 3. Do not build from source or bypass Gatekeeper. Tell me which
+> version you installed and which human-only steps remain.
 
-Codex downloads and inspects the pinned installer, verifies the published
-checksum, Gatekeeper acceptance, Developer ID, and exact version, safely
-replaces the app, and opens **Settings → Deck**. You only approve the microphone
-and local-network prompts that macOS requires a person to handle.
+Codex downloads and inspects the installer, verifies the published checksum,
+Gatekeeper acceptance, Developer ID, and the app version against the release it
+downloaded, safely replaces the app, and opens **Settings → Deck**. You only
+approve the microphone and local-network prompts that macOS requires a person to
+handle.
 
 For a manual install, download the same signed and notarized release:
 
-**[Download SpeakEasy 0.2.19 for macOS](https://github.com/arach/SpeakEasy/releases/download/v0.2.19/SpeakEasy.dmg)**
+**[Download SpeakEasy for macOS](https://github.com/arach/SpeakEasy/releases/latest/download/SpeakEasy.dmg)**
 
 1. Drag SpeakEasy to **Applications**.
 2. Open it and approve microphone and local-network access when macOS asks.

--- a/docs/release/0.3.0-release-pass.md
+++ b/docs/release/0.3.0-release-pass.md
@@ -1,0 +1,179 @@
+# Goal: ship 0.3.0 as one train
+
+Audited August 10, 2026 against `master` at `dfca141`.
+
+This is a task brief. It states the situation, the decision already made, and
+the gates. It extends [`plugins/speakeasy/RELEASE-CHECKLIST.md`](../../plugins/speakeasy/RELEASE-CHECKLIST.md)
+— that file is the canonical procedure for the native app and the OpenAI
+submission, and this brief does not replace it.
+
+## The situation
+
+`master` is 16 commits of `src/` ahead of what the public can install, and
+**every published surface still says `0.2.19`**:
+
+| Surface | What a fresh machine gets | Age |
+| --- | --- | --- |
+| npm `@arach/speakeasy` | `0.2.19` | published Aug 2 |
+| GitHub `releases/latest` | `v0.2.19` | tagged Aug 2 |
+| Skill bundle | repo tarball **at tag `v0.2.19`** | Aug 2 |
+| `package.json` on master | `0.2.19` | Aug 10 |
+
+The install path itself is sound — `bunx @arach/speakeasy plugin codex`
+resolves `releases/latest`, gets `v0.2.19`, and pulls the repo tarball at that
+tag, so the CLI and the skill are consistent with each other. Nothing breaks or
+half-installs.
+
+The trap is the last row. Master carries a *different* codebase under the *same*
+version number, so there is no signal that an install is stale. Someone
+installing today gets replies clipped at 600 characters, no working
+`uninstall`, and the old Deck routing — all of which read as product bugs
+rather than as an old build.
+
+## The decision
+
+**Bump to `0.3.0`, not `0.2.20`.** `aacc693` removed the `speakeasy codex
+<sub>` namespace — `codex deck`, `codex skill`, and `codex install` no longer
+exist. That is a breaking CLI change, and in `0.x` a minor bump is how it gets
+signalled. No public doc still references the removed commands (already
+verified), so the fallout is limited to anyone with the old form in a script.
+
+## Ordering constraint — do not reorder
+
+Two independent constraints both point the same way, and the second one is easy
+to miss.
+
+**The skill** resolves `releases/latest` at install time and pulls the repo
+tarball at that tag. So the GitHub release must exist and be promoted to Latest
+before the skill is packaged or submitted, or the skill installs against the
+previous train. This is the constraint recorded at the top of
+`RELEASE-CHECKLIST.md`.
+
+**The Deck surface** is no longer published to npm. `files` is now `["dist"]`,
+which dropped `deck/index.html`, `deck/themes.json`, and `deck/variants` — they
+shipped in the `0.2.19` tarball and will not ship in `0.3.0`. That is
+deliberate: `deckRoot()` in `src/cli/deck.ts` falls back to fetching them into
+`~/.config/speakeasy/deck` on first run. But `installDeckSurface` fetches the
+tarball at **`v${packageVersion}`**, and `downloadTarball` only tries
+`tags/<ref>` then `heads/<ref>` — there is no fallback to `master`.
+
+So if npm `0.3.0` is published before the tag `v0.3.0` exists, `speakeasy deck`
+404s for every fresh install, with no bundled copy to fall back on. Tag first.
+
+1. Version bump lands on `master`.
+2. **Tag `v0.3.0` and push it** — before npm, or the Deck fetch has no source.
+3. Native app: build, sign, notarize, staple, publish the DMG on the `v0.3.0` release.
+4. Promote `v0.3.0` to Latest.
+5. Publish npm.
+6. Package and verify the skill ZIP from the exact release commit.
+7. Reinstall-test on a clean machine.
+
+## 1 · Version bump
+
+Every file below carries `0.2.19` and must move together. This list is
+exhaustive as of the audit — re-grep before finishing.
+
+- `package.json:3`
+- `README.md` — lines 25, 29, 171, 182 (line 182 is the DMG download URL)
+- `landing/public/agent.md` — lines 90, 98, 108, 111 (the agent runbook: version,
+  installer URL, and the published DMG SHA-256)
+- `app/tools/release/install-release.sh:4` — `DEFAULT_VERSION`
+- `plugins/speakeasy/RELEASE-CHECKLIST.md` — open a `0.3.0` train section
+- `docs/release/self-serve-mac-test.md` — lines 4, 9
+
+`CHANGELOG.md` already has a drafted `0.3.0` section. Verify it against
+`git log v0.2.19..master` and correct anything that misreads the change.
+
+## 2 · Gates before anything is published
+
+Run from the repo root. All of these were green at audit time except where noted.
+
+```bash
+pnpm run build          # tsup
+bunx tsc --noEmit       # full typecheck, not just the public surface
+bun test src            # 52 tests
+bun run test:privacy
+pnpm run build:plugin-runtime
+git diff --exit-code plugins/speakeasy/skills/speakeasy/runtime/speakeasy-cli.js
+```
+
+That last command is the one that matters most. The plugin runtime is a
+**committed build artifact**, and it has silently drifted from source twice
+before — once by 1099 lines. `bun build` is deterministic, so a clean
+`git diff` after rebuilding proves the shipped bundle matches the source being
+tagged. If it drifts, commit the rebuild before tagging.
+
+Note that `pnpm run build` uses `tsup --dts`, which only typechecks the public
+surface. `bunx tsc --noEmit` is not redundant — it is the check that has caught
+broken internals passing a green build.
+
+## 3 · Native app, npm, and skill
+
+Follow `RELEASE-CHECKLIST.md` sections 1–2 for the signed DMG. The parts that
+need a human are called out in "Out of scope" below.
+
+For npm, confirm the tarball contents before publishing — `files` is now
+`["dist"]`, and the packaged tree should be `dist/`, `deck/`, `README.md`,
+`LICENSE`, `package.json` and nothing else:
+
+```bash
+npm pack --dry-run
+```
+
+## 4 · Verify like a stranger
+
+The point of the whole pass. On a machine that has never had SpeakEasy:
+
+```bash
+bunx @arach/speakeasy plugin codex
+```
+
+Then confirm, on that machine:
+
+- `speakeasy --version` reports `0.3.0`.
+- A reply longer than 600 characters narrates in full, in order, without
+  clipping — this is the headline fix and the thing most likely to regress.
+- `speakeasy plugin` with no host lists the hosts.
+- `speakeasy deck` fetches its surface and serves it. This is the one that
+  breaks if the tag is missing, and it cannot be caught on a dev machine — a
+  repo checkout resolves `deck/` locally and never takes the fetch path.
+- `speakeasy uninstall` removes what SpeakEasy installed and leaves everything
+  else alone.
+- `speakeasy codex deck` fails with a useful error rather than a stack trace.
+
+Then re-check the public surfaces:
+
+```bash
+curl -s https://speakeasy.arach.dev/ | grep -o 'data-src="[^"]*"' | sort -u
+curl -sI https://speakeasy.arach.dev/audio/tagline-demo.mp3 | head -1
+npm view @arach/speakeasy version
+gh release view --json tagName,isLatest
+```
+
+## Out of scope — needs the owner, do not attempt
+
+- **Signing and notarization.** Requires the Developer ID identity for team
+  `2U83JFPW66` and the `notarytool-air` Keychain profile. Never pass the
+  app-specific password on a command line.
+- **`npm publish`.** Requires the owner's npm auth. Prepare and verify the
+  tarball; stop there.
+- **The OpenAI Platform submission** (`RELEASE-CHECKLIST.md` section 4). Still
+  blocked on publisher verification, which only the owner can complete.
+- **Anything under `~/.codex/`.** `state_5.sqlite` and `sqlite/codex-dev.db` are
+  live databases with Codex Desktop running against them. Do not open them for
+  write, copy, move, or vacuum them.
+
+## Known-open, decide before or during
+
+- The Pad page CTA reads `GET THE APP` and links to `#honesty`. There is no App
+  Store or TestFlight artifact behind it; the live page sells a DMG. Either the
+  copy changes or the link goes to the DMG.
+- The Pad hero still reads "A pad for the Codex tasks you're already running",
+  which the design review recommended cutting in favour of the line about each
+  key holding whatever you put on it. It is production copy now.
+- The home page title is the layout's "SpeakEasy — Unified text-to-speech" while
+  the mock's own title is "One API. Every voice." Changing it moves the OG cards
+  site-wide.
+- `landing/scripts/behavior-test.js` is stale — it clicks a pnpm install tab the
+  page no longer has. Either update it to the Codex/Claude Code tabs or delete
+  it, but do not leave a test that fails by default.

--- a/docs/release/0.3.0-release-pass.md
+++ b/docs/release/0.3.0-release-pass.md
@@ -70,12 +70,17 @@ So if npm `0.3.0` is published before the tag `v0.3.0` exists, `speakeasy deck`
 
 ## 1 · Version bump
 
-Only two files carry a version that must move:
+Three files carry a version that must move:
 
 - `package.json:3`
 - `app/tools/release/install-release.sh:4` — `DEFAULT_VERSION`. This one is
   load-bearing: the script is uploaded as a release asset, so the value baked in
   at build time is what every agent install resolves to.
+- `landing/lib/release.ts:1-2` — `releaseVersion` and `launchVersion`, which
+  build the DMG, installer, checksum, and release-page URLs for the site.
+
+The docs header badge reads from `package.json` via
+`landing/lib/package-version.ts`, so it follows the bump on its own. Leave it.
 
 Then open a `0.3.0` train section in `plugins/speakeasy/RELEASE-CHECKLIST.md`.
 
@@ -216,3 +221,17 @@ gh release view --json tagName,isLatest
 - `landing/scripts/behavior-test.js` is stale — it clicks a pnpm install tab the
   page no longer has. Either update it to the Codex/Claude Code tabs or delete
   it, but do not leave a test that fails by default.
+- `/codex/concepts/` is a live page whose nav still links to a version-pinned
+  DMG (`releases/download/v0.2.19/SpeakEasy.dmg`, via `releaseDownloadUrl`).
+  Pointing `releaseDownloadUrl` at `releases/latest/download/SpeakEasy.dmg`
+  would retire another bump surface. `releaseChecksumUrl` cannot follow, because
+  that asset is version-named (`SpeakEasy-0.2.19.sha256`) — making it
+  latest-resolvable means publishing an unversioned `SpeakEasy.sha256` alongside
+  it, which is a change to `ship.sh`, not a doc edit. Decide deliberately rather
+  than half-converting.
+- The old React home-page components (`hero-section.tsx`,
+  `dual-mode-section.tsx`, `download-section.tsx`, `agent-voice-section.tsx`,
+  `codex-install-prompt.tsx`) are no longer rendered anywhere since the mocks
+  became the live pages. They still carry `0.2.19` strings. They are dead
+  weight that will keep showing up in version greps — delete them or keep them
+  deliberately, but do not bump them by reflex.

--- a/docs/release/0.3.0-release-pass.md
+++ b/docs/release/0.3.0-release-pass.md
@@ -70,19 +70,58 @@ So if npm `0.3.0` is published before the tag `v0.3.0` exists, `speakeasy deck`
 
 ## 1 · Version bump
 
-Every file below carries `0.2.19` and must move together. This list is
-exhaustive as of the audit — re-grep before finishing.
+Only two files carry a version that must move:
 
 - `package.json:3`
-- `README.md` — lines 25, 29, 171, 182 (line 182 is the DMG download URL)
-- `landing/public/agent.md` — lines 90, 98, 108, 111 (the agent runbook: version,
-  installer URL, and the published DMG SHA-256)
-- `app/tools/release/install-release.sh:4` — `DEFAULT_VERSION`
-- `plugins/speakeasy/RELEASE-CHECKLIST.md` — open a `0.3.0` train section
-- `docs/release/self-serve-mac-test.md` — lines 4, 9
+- `app/tools/release/install-release.sh:4` — `DEFAULT_VERSION`. This one is
+  load-bearing: the script is uploaded as a release asset, so the value baked in
+  at build time is what every agent install resolves to.
+
+Then open a `0.3.0` train section in `plugins/speakeasy/RELEASE-CHECKLIST.md`.
+
+**Leave the rest alone.** `docs/release/gtm.md`,
+`docs/release/self-serve-mac-test.md`, and
+`docs/architecture/tier-split-proposal.md` mention `0.2.19` as a record of what
+was launched and decided. They are history, not configuration. Blanket-replacing
+the version across the repo would rewrite that record and is the most likely way
+to make a mess of this pass.
+
+`README.md` and `landing/public/agent.md` no longer name a version at all — see
+the next section.
 
 `CHANGELOG.md` already has a drafted `0.3.0` section. Verify it against
 `git log v0.2.19..master` and correct anything that misreads the change.
+
+## 1b · The agent install path is now self-resolving
+
+The paste-into-Codex prompt and the runbook used to pin `0.2.19`: the installer
+URL, the expected app version, and the DMG link all named it. That made a pasted
+prompt go stale the moment a release shipped, and it put four more files in the
+bump list.
+
+Both now use GitHub's `releases/latest/download/...`, which redirects to the
+current release's asset. Verification is unchanged and still exact — the
+installer checks the DMG against the checksum published *with that same
+release*, so resolving latest weakens nothing. `SPEAKEASY_VERSION` still forces
+a specific release when someone actually wants one.
+
+What this means for the pass: **do not reintroduce a version into `README.md` or
+`landing/public/agent.md`.** If a future change makes the agent path name a
+version again, that is a regression in the release process, not a doc detail.
+
+Confirm both URLs still resolve after the release is promoted to Latest:
+
+```bash
+curl -sIL -o /dev/null -w '%{http_code}\n' \
+  https://github.com/arach/SpeakEasy/releases/latest/download/install-speakeasy.sh
+curl -sIL -o /dev/null -w '%{http_code}\n' \
+  https://github.com/arach/SpeakEasy/releases/latest/download/SpeakEasy.dmg
+curl -sL https://github.com/arach/SpeakEasy/releases/latest/download/install-speakeasy.sh \
+  | grep -m1 DEFAULT_VERSION      # must report 0.3.0
+```
+
+That last line is the real end-to-end check on the agent path: it proves the
+asset an agent will actually download is the new train.
 
 ## 2 · Gates before anything is published
 

--- a/docs/release/0.3.0-release-pass.md
+++ b/docs/release/0.3.0-release-pass.md
@@ -218,9 +218,10 @@ gh release view --json tagName,isLatest
 - The home page title is the layout's "SpeakEasy — Unified text-to-speech" while
   the mock's own title is "One API. Every voice." Changing it moves the OG cards
   site-wide.
-- `landing/scripts/behavior-test.js` is stale — it clicks a pnpm install tab the
-  page no longer has. Either update it to the Codex/Claude Code tabs or delete
-  it, but do not leave a test that fails by default.
+- ~~`landing/scripts/behavior-test.js` is stale.~~ Fixed — the home page installs
+  the library again, so the pnpm tab it clicks is back and the whole suite
+  passes. Run it as part of the pass; it is now a real signal rather than a
+  known failure.
 - `/codex/concepts/` is a live page whose nav still links to a version-pinned
   DMG (`releases/download/v0.2.19/SpeakEasy.dmg`, via `releaseDownloadUrl`).
   Pointing `releaseDownloadUrl` at `releases/latest/download/SpeakEasy.dmg`

--- a/landing/public/agent.md
+++ b/landing/public/agent.md
@@ -87,15 +87,15 @@ Mac dictation, or drive a real Codex task by voice. It installs a signed
 application into `/Applications` and requires human approval of system prompts.
 Do not offer it as an upgrade to Path 1.
 
-Release `0.2.19` requires an Apple silicon Mac running macOS 14 or newer.
+Requires an Apple silicon Mac running macOS 14 or newer.
 
-Download the pinned installer to a temporary file. **Inspect it before running;
+Download the current installer to a temporary file. **Inspect it before running;
 do not pipe a network response into a shell.**
 
 ```bash
 installer="$(mktemp "${TMPDIR:-/tmp}/install-speakeasy.XXXXXX")"
 curl --fail --location --proto '=https' --tlsv1.2 \
-  https://github.com/arach/SpeakEasy/releases/download/v0.2.19/install-speakeasy.sh \
+  https://github.com/arach/SpeakEasy/releases/latest/download/install-speakeasy.sh \
   --output "$installer"
 sed -n '1,260p' "$installer"
 bash -n "$installer"
@@ -103,12 +103,22 @@ bash "$installer"
 rm -f "$installer"
 ```
 
+That URL always resolves to the current release, so there is no version for you
+to look up or keep in sync. The installer names the version it is about to
+install in its own output and in its `DEFAULT_VERSION` line — read it there
+rather than assuming one. Report that version back to the user when you are
+done.
+
 The installer refuses to touch `/Applications` unless all of these pass:
 
-- published SHA-256 for the exact `0.2.19` DMG;
+- the published SHA-256 for the exact DMG it names;
 - Gatekeeper acceptance of the signed, notarized DMG and app;
 - bundle ID `com.speakeasy.config` and Developer ID team `2U83JFPW66`;
-- exact app version `0.2.19`.
+- an installed app version matching the release it downloaded.
+
+If you need a specific older release instead, set `SPEAKEASY_VERSION` and the
+installer will verify against that release's published checksum. Do not do this
+unless the user asked for a particular version.
 
 It then opens **SpeakEasy → Settings → Deck**.
 


### PR DESCRIPTION
`master` is 16 `src/` commits ahead of what the public can install, and every
published surface still reports `0.2.19`. The install path works — the CLI and
skill are consistent with each other — but `package.json` on master carries the
same version number over a different codebase, so nothing signals that an
install is stale. A fresh machine today gets replies clipped at 600 characters,
no working `uninstall`, and the old Deck routing.

Docs only. No version bump, no tag, no publish — those are the release act, and
this hands them to Codex with the ordering attached.

## What's here

- `CHANGELOG.md`, drafted from the real `v0.2.19..master` range.
- `docs/release/0.3.0-release-pass.md`, a task brief that extends
  `plugins/speakeasy/RELEASE-CHECKLIST.md` rather than forking the process.

## The catch the audit turned up

The `files` trim to `["dist"]` dropped `deck/index.html`, `deck/themes.json`,
and `deck/variants`, which shipped in the `0.2.19` tarball. That's deliberate —
`deckRoot()` falls back to fetching them on first run. But
`installDeckSurface` fetches the tarball at `v${packageVersion}`, and
`downloadTarball` only tries `tags/<ref>` then `heads/<ref>`. There is no
fallback to `master`.

So publishing npm `0.3.0` before the tag `v0.3.0` exists would 404
`speakeasy deck` on every fresh install, with no bundled copy to fall back on —
and it cannot be caught on a dev machine, because a repo checkout resolves
`deck/` locally and never takes the fetch path. The brief puts tagging at step 2,
ahead of npm.

## Version

`0.3.0`, not `0.2.20`. `aacc693` removed `speakeasy codex deck|skill|install`,
which is a breaking CLI change; in `0.x` a minor bump is how that gets signalled.
No public doc still references the removed commands (verified).

## Gates, green at audit time

`bunx tsc --noEmit` clean · 52 tests pass · `build:plugin-runtime` rebuilds
byte-identical to the committed bundle — the artifact that silently drifted 1099
lines once before.