### PR TITLE
🐛 Stop /docs/ redirecting to itself forever

### DIFF
--- a/landing/scripts/postexport-doc-redirects.mjs
+++ b/landing/scripts/postexport-doc-redirects.mjs
@@ -28,25 +28,32 @@ function redirectHtml(target) {
 `
 }
 
+/** `index` must never get a stub. The stub for slug X is written to
+ *  out/docs/X.html, and out/docs/index.html is the exported /docs/ page itself
+ *  — so stubbing `index` overwrites the real page with a redirect to /docs/,
+ *  which is the page it just replaced. The browser then spins forever.
+ *
+ *  Nothing is lost by skipping it: /docs/index already resolves to
+ *  out/docs/index.html, which is the page a redirect would have sent you to. */
+const isIndex = (name) => name === "index"
+
 async function main() {
   const meta = JSON.parse(await readFile(META_PATH, "utf8"))
-  const slugs = meta.pages.filter((entry) => !entry.startsWith("---"))
+  const slugs = meta.pages.filter((entry) => !entry.startsWith("---") && !isIndex(entry))
 
   for (const slug of slugs) {
-    const canonical = slug === "index" ? "/docs/" : `/docs/${slug}/`
-    await writeFile(join(OUT_DOCS, `${slug}.html`), redirectHtml(canonical), "utf8")
+    await writeFile(join(OUT_DOCS, `${slug}.html`), redirectHtml(`/docs/${slug}/`), "utf8")
   }
 
   // Also stub any exported doc folders not listed in meta (e.g. legacy aliases)
   const entries = await readdir(OUT_DOCS, { withFileTypes: true })
   for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name === "_next") continue
+    if (!entry.isDirectory() || entry.name === "_next" || isIndex(entry.name)) continue
     const htmlPath = join(OUT_DOCS, `${entry.name}.html`)
     try {
       await readFile(htmlPath)
     } catch {
-      const canonical = entry.name === "index" ? "/docs/" : `/docs/${entry.name}/`
-      await writeFile(htmlPath, redirectHtml(canonical), "utf8")
+      await writeFile(htmlPath, redirectHtml(`/docs/${entry.name}/`), "utf8")
     }
   }
 


### PR DESCRIPTION
`https://speakeasy.arach.dev/docs/` spins in a loading loop and never renders.

## Cause

`landing/scripts/postexport-doc-redirects.mjs` writes a redirect stub for each
doc slug to `out/docs/<slug>.html`. `docs/meta.json` lists a page called
`index` — and `out/docs/index.html` **is the exported `/docs/` page**. So the
stub overwrote the real page with a redirect to `/docs/`, which is the page it
had just replaced:

```html
<meta http-equiv="refresh" content="0; url=/docs/">
<script>location.replace("/docs/")</script>
```

The browser follows that forever.

Skipping `index` loses nothing. `/docs/index` already resolves to
`out/docs/index.html`, which is exactly where the redirect would have sent you.
The two can never coexist as separate files, because they *are* the same file.

## Why it survived

It only reproduces through `pnpm run build`, which is
`next build && node scripts/postexport-doc-redirects.mjs`. A plain `next build`
skips the postexport step and produces a perfectly good `/docs/`. CI runs the
full pipeline, so the bug existed only in the deployed artifact.

Long-standing — the script has not changed since `e071c3a` (July 8) and this is
not a regression from recent work.

## Verified on the full pipeline

```
/docs/              -> renders "Documentation", no redirect loop
/docs/quickstart    -> redirects to /docs/quickstart/   (stub still works)
/docs/quickstart/   -> renders "Quickstart"
```

`out/docs/index.html` is back to the real 48KB page; the other 11 stubs are
unchanged.