### PR TITLE
💄 Step 01 is an instruction for your agent, not a command to type

### DIFF
--- a/landing/mocks/pad.html
+++ b/landing/mocks/pad.html
@@ -635,6 +635,23 @@ nav .wrap { display:flex; align-items:center; justify-content:space-between; hei
 .step p { font-size:14.5px; font-weight:300; line-height:1.7; color:var(--muted); margin-top:12px; flex:1; }
 .step .cmd { display:flex; margin:22px 0 0; font-size:13.5px; padding:12px 12px 12px 18px; gap:12px; }
 .step .cmd span:nth-child(2) { flex:1; overflow-x:auto; white-space:nowrap; }
+
+/* An instruction you hand to your agent, not a command you type. It reads as
+   speech, so it is set in the body face rather than mono — the mono blocks on
+   this page are all things a machine parses. */
+.ask { margin-top:22px; border:1px solid var(--hairline2); border-radius:12px; background:var(--panel); overflow:hidden; }
+.ask .head { display:flex; align-items:center; justify-content:space-between; gap:12px;
+  padding:9px 12px 9px 16px; border-bottom:1px solid var(--hairline2); }
+.ask .head .label { font-family:ui-monospace,Menlo,monospace; font-size:9px; letter-spacing:.2em; color:var(--faint); }
+.ask .copy { position:relative; font-size:9px; letter-spacing:.2em; color:var(--muted);
+  border:1px solid var(--hairline2); border-radius:8px; padding:7px 10px; cursor:pointer; background:none;
+  transition:color .16s ease, border-color .16s ease, background-color .16s ease; }
+.ask .copy::before { content:""; position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); width:100%; min-width:44px; height:44px; }
+.ask .copy:hover { color:var(--accent); border-color:color-mix(in srgb, var(--accent) 60%, var(--hairline2)); }
+.ask .copy:active { background:var(--bg2); }
+.ask .body { padding:16px; font-size:14px; font-weight:300; line-height:1.65; color:var(--text); }
+.step .orelse { font-size:12.5px; font-weight:300; line-height:1.6; color:var(--faint); margin-top:14px; }
+.step .orelse code { font-family:ui-monospace,Menlo,monospace; font-size:11.5px; letter-spacing:.02em; color:var(--muted); }
 .step .key { margin-top:22px; align-self:flex-start; }
 .step .foot { font-family:ui-monospace,Menlo,monospace; font-size:9.5px; letter-spacing:.16em; color:var(--faint); margin-top:16px; }
 
@@ -1051,10 +1068,20 @@ footer .wrap > div:last-child { margin-right:-.22em; }
     <div class="twostep">
       <div class="step">
         <span class="n">STEP 01 · ON YOUR MAC</span>
-        <h3>Set up the plugin.</h3>
-        <p>Installs the SpeakEasy skill into Codex and starts the runtime the Pad talks to.
-        Your agent can run this for you.</p>
-        <div class="cmd"><span class="prompt">$</span><span>bunx @arach/speakeasy plugin codex</span><span class="copy" id="copyBtn">COPY</span></div>
+        <h3>Ask your agent to set it up.</h3>
+        <p>You already have Codex open. Give it this and it installs the SpeakEasy skill,
+        starts the runtime the Pad talks to, and tells you what needs your approval.</p>
+        <div class="ask">
+          <div class="head">
+            <span class="label">PASTE INTO CODEX</span>
+            <button class="copy" id="copyBtn" data-copy-target="askText">COPY</button>
+          </div>
+          <p class="body" id="askText">Set up SpeakEasy on this Mac so I can talk to my Codex tasks from an iPad.
+          Read https://speakeasy.arach.dev/agent.md and follow Path 2, then start the Deck and leave it
+          running. Tell me what you installed and which permissions I still need to approve myself.</p>
+        </div>
+        <p class="orelse">Rather do it by hand? <code>bunx @arach/speakeasy plugin codex</code>, then
+        <code>speakeasy deck</code>.</p>
         <p class="foot">MACOS 14+ APPLE SILICON · CODEX DESKTOP</p>
       </div>
       <div class="step">
@@ -1078,7 +1105,6 @@ footer .wrap > div:last-child { margin-right:-.22em; }
     </div>
     <div class="label" style="text-align:right;">
       MODEL SE-1 · <span id="footFinish">PORCELAIN</span><br>
-      DESIGN MOCK — NOT A SHIPPING PAGE<br>
       SPEAKEASY © 2026
     </div>
   </div>
@@ -1148,12 +1174,18 @@ footer .wrap > div:last-child { margin-right:-.22em; }
   }
 
   // Copy the install command.
+  // Copy whatever is actually on screen. The previous version held its own
+  // hardcoded string, which quietly drifted from the visible text — you read one
+  // thing and pasted another.
   var copyBtn = document.getElementById('copyBtn');
   if (copyBtn) {
     copyBtn.addEventListener('click', function () {
+      var source = document.getElementById(copyBtn.dataset.copyTarget);
+      if (!source) return;
+      var text = source.textContent.replace(/\s+/g, ' ').trim();
       var done = function () { copyBtn.textContent = 'COPIED'; setTimeout(function () { copyBtn.textContent = 'COPY'; }, 1600); };
       if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText('speakeasy deck').then(done, done);
+        navigator.clipboard.writeText(text).then(done, done);
       } else { done(); }
     });
   }


### PR DESCRIPTION
Step 01 of the Pad install handed you a shell command with a COPY button. The
whole premise of the page is that you already have Codex open — so the natural
artifact is an instruction you *give* it, not something you paste into a
terminal yourself.

It's now a bounded prompt:

> Set up SpeakEasy on this Mac so I can talk to my Codex tasks from an iPad.
> Read https://speakeasy.arach.dev/agent.md and follow Path 2, then start the
> Deck and leave it running. Tell me what you installed and which permissions I
> still need to approve myself.

It points at `agent.md` rather than restating the steps, so it stays correct as
the runbook changes — the same reason the README prompt no longer names a
version. The raw commands are still on the card for anyone who wants them.

## A real defect fixed along the way

The COPY button held its **own hardcoded string**:

```js
navigator.clipboard.writeText('speakeasy deck')
```

…while the visible command read `bunx @arach/speakeasy plugin codex`. You read
one thing and pasted another. It now copies the element it points at via
`data-copy-target`, so the two cannot drift again.

Worth noting the handler does `.then(done, done)` — "COPIED" appears even when
the write fails — so I verified by stubbing `writeText` and capturing the actual
argument rather than trusting the label:

```json
{ "copied": "Set up SpeakEasy on this Mac so I can talk to…", "matches": true }
```

## Also

Drops `DESIGN MOCK — NOT A SHIPPING PAGE` from the footer. That has been live on
the shipping page since the mock was promoted.