### PR TITLE
📦 Make the iPad app archivable for TestFlight

### DIFF
--- a/deck/ipad/Sources/Info.plist
+++ b/deck/ipad/Sources/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>SpeakEasy Deck</string>
+	<string>SpeakEasy Pad</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,9 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/deck/ipad/project.yml
+++ b/deck/ipad/project.yml
@@ -30,7 +30,17 @@ targets:
     info:
       path: Sources/Info.plist
       properties:
-        CFBundleDisplayName: SpeakEasy Deck
+        CFBundleDisplayName: SpeakEasy Pad
+        # Take the version from the build settings below rather than pinning it
+        # here. Without these two lines xcodegen writes a literal 1.0/1 and
+        # MARKETING_VERSION is silently ignored — the build reports a version
+        # nobody set.
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        # The app speaks to the Mac over HTTPS and transcribes on device. That
+        # is exempt encryption, so declaring it here spares a manual compliance
+        # answer on every TestFlight upload.
+        ITSAppUsesNonExemptEncryption: false
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
         NSBonjourServices:


### PR DESCRIPTION
Three things stood between the iPad app and an App Store build. All three were
found by actually archiving it, not by reading the config.

**The version was a lie.** The generated `Info.plist` pinned
`CFBundleShortVersionString` to a literal `1.0` and `CFBundleVersion` to `1`, so
`MARKETING_VERSION: "0.1.0"` in the build settings was silently ignored. The
first TestFlight build would have shipped as "1.0" — a version nobody chose, and
one that makes the next real version number awkward. Both keys now read through
from the build settings, so the version lives in one place.

**No export-compliance declaration.** Without `ITSAppUsesNonExemptEncryption`,
TestFlight stops and asks a compliance question on *every* upload. The app talks
to the Mac over HTTPS and transcribes on device, so the exemption applies;
declaring it answers the question once. Flagging it as a compliance statement
rather than a config tweak — it's easy to revert if you'd rather answer manually.

**Two names for one product.** `CFBundleDisplayName` said "SpeakEasy Deck" while
the App Store listing is "SpeakEasy Pad".

Edits are in `project.yml` because xcodegen generates `Info.plist` from it —
editing the plist directly would be overwritten on the next `xcodegen generate`.

## Verified

Archived and exported a signed IPA (1.9 MB) with an App Store profile:

```
CFBundleIdentifier             dev.arach.speakeasy.deck
CFBundleDisplayName            SpeakEasy Pad
CFBundleShortVersionString     0.1.0
CFBundleVersion                1
ITSAppUsesNonExemptEncryption  false
MinimumOSVersion               17.0     UIDeviceFamily [1,2]
Authority                      iPhone Distribution: Arach Tchoupani (2U83JFPW66)
```

Also registered on the account, outside this diff: bundle ID
`dev.arach.speakeasy.deck` (`98ZNS8GCS4`) and App Store profile `YZ55C7J8SP`.

Note there are two iOS distribution certs on the account; only `39HDUG95YR` has
its private key in this Mac's keychain. I matched by SHA-1 fingerprint rather
than picking one — the other would have failed at signing.

## Still blocked

No App Store Connect app record exists, and creating one needs an Apple web
session (API keys can't do it). Upload has nowhere to go until then.